### PR TITLE
fix: Disconnect client explicitly

### DIFF
--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -4,3 +4,7 @@ export type ConnectionAndSession<TConnection, TSession> = {
   cn: TConnection;
   session: TSession;
 };
+
+export interface Disposable {
+  dispose(): Promise<void>;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,20 +44,23 @@ export function activate(context: vscode.ExtensionContext) {
     outputChannel
   );
 
-  dhcServiceRegistry.addEventListener('disconnect', () => {
+  dhcServiceRegistry.addEventListener('disconnect', serverUrl => {
+    vscode.window.showInformationMessage(
+      `Disconnected from Deephaven server: ${serverUrl}`
+    );
     clearConnection();
   });
 
   /*
    * Clear connection data
    */
-  function clearConnection() {
+  async function clearConnection() {
     selectedConnectionUrl = null;
     selectedDhService = null;
     const { text, tooltip } = createConnectTextAndTooltip('disconnected');
     connectStatusBarItem.text = text;
     connectStatusBarItem.tooltip = tooltip;
-    dhcServiceRegistry.clearCache();
+    await dhcServiceRegistry.clearCache();
   }
 
   /**
@@ -85,6 +88,7 @@ export function activate(context: vscode.ExtensionContext) {
   const connectStatusBarItem = createConnectStatusBarItem();
 
   context.subscriptions.push(
+    dhcServiceRegistry,
     outputChannel,
     runCodeCmd,
     runSelectionCmd,

--- a/src/services/DhServiceRegistry.ts
+++ b/src/services/DhServiceRegistry.ts
@@ -25,8 +25,9 @@ export class DhServiceRegistry<T extends DhcService> extends CacheService<
           outputChannel
         );
 
-        dhService.addEventListener('disconnect', () => {
-          this.dispatchEvent('disconnect');
+        // Propagate service events as registry events.
+        dhService.addEventListener('disconnect', event => {
+          this.dispatchEvent('disconnect', event);
         });
 
         return dhService;

--- a/src/services/EventDispatcher.ts
+++ b/src/services/EventDispatcher.ts
@@ -34,6 +34,8 @@ export class EventDispatcher<TEventName extends string> {
    * @param event The event to dispatch to all listeners
    */
   dispatchEvent = <TEvent>(eventName: TEventName, event?: TEvent): void => {
-    this.listeners.get(eventName)?.forEach(listener => listener(event));
+    this.listeners.get(eventName)?.forEach(listener => {
+      listener(event);
+    });
   };
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,5 +1,6 @@
 export * from './downloadUtils';
 export * from './ExtendedMap';
+export * from './isDisposable';
 export * from './panelUtils';
 export * from './polyfillUtils';
 export * from './uiUtils';

--- a/src/util/isDisposable.ts
+++ b/src/util/isDisposable.ts
@@ -1,0 +1,17 @@
+import { Disposable } from '../common';
+
+/**
+ * Typeguard to determine if given object has a `disposable` method.
+ * @param maybeDisposable The object to check.
+ * @returns `true` if the object has a `dispose` method, `false` otherwise.
+ */
+export function isDisposable(
+  maybeDisposable: unknown
+): maybeDisposable is Disposable {
+  return (
+    maybeDisposable != null &&
+    typeof maybeDisposable === 'object' &&
+    'dispose' in maybeDisposable &&
+    typeof maybeDisposable.dispose === 'function'
+  );
+}


### PR DESCRIPTION
Client wasn't actually getting disconnected when user clicked disconnect button. I have introduced proper disposal logic to dispose all DH services as part of clearing caches.

### Testing
#### Test 1
- Start DH server
- Connect to server from vscode
- Disconnect via the status bar item
- Should see "Disconnected from Deephaven server: ..." toast message
- Kill server. 
- Should **not** see a new "Disconnected from Deephaven server..." toast message

#### Test 2
- Start DH server
- Connect to server from vscode
- Kill server
- Should see "Disconnected from Deephaven server..." toast message

resolves #22