### PR TITLE
feat: Logger util

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "@typescript-eslint/semi": "warn",
     "curly": "warn",
     "eqeqeq": ["warn", "always", { "null": "ignore" }],
+    "no-console": "warn",
     "no-throw-literal": "warn",
     "semi": "off"
   },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
       {
         "command": "vscode-deephaven.selectConnection",
         "title": "Deephaven: Select Connection"
+      },
+      {
+        "command": "vscode-deephaven.downloadLogs",
+        "title": "Deephaven: Download Logs"
       }
     ],
     "menus": {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,7 @@ export const CONFIG_KEY = 'vscode-deephaven';
 export const CONFIG_CORE_SERVERS = 'core-servers';
 
 // export const DHFS_SCHEME = 'dhfs';
+export const DOWNLOAD_LOGS_CMD = `${CONFIG_KEY}.downloadLogs`;
 export const RUN_CODE_COMMAND = `${CONFIG_KEY}.runCode`;
 export const RUN_SELECTION_COMMAND = `${CONFIG_KEY}.runSelection`;
 export const SELECT_CONNECTION_COMMAND = `${CONFIG_KEY}.selectConnection`;
@@ -9,3 +10,5 @@ export const SELECT_CONNECTION_COMMAND = `${CONFIG_KEY}.selectConnection`;
 export const STATUS_BAR_DISCONNECTED_TEXT = 'Deephaven: Disconnected';
 export const STATUS_BAR_DISCONNECT_TEXT = 'Deephaven: Disconnect';
 export const STATUS_BAR_CONNECTING_TEXT = 'Deephaven: Connecting...';
+
+export const DOWNLOAD_LOGS_TEXT = 'Download Logs';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   dhcServiceRegistry.addEventListener('disconnect', serverUrl => {
-    toaster.showInfoMessage(`Disconnected from Deephaven server: ${serverUrl}`);
+    toaster.info(`Disconnected from Deephaven server: ${serverUrl}`);
     clearConnection();
   });
 
@@ -125,7 +125,7 @@ export function activate(context: vscode.ExtensionContext) {
     const uri = await debugOutputChannel.downloadHistoryToFile();
 
     if (uri != null) {
-      toaster.showInfoMessage(`Downloaded logs to ${uri.fsPath}`);
+      toaster.info(`Downloaded logs to ${uri.fsPath}`);
       vscode.window.showTextDocument(uri);
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,10 +23,6 @@ import { OutputChannelWithHistory } from './util/OutputChannelWithHistory';
 const logger = new Logger('extension');
 
 export function activate(context: vscode.ExtensionContext) {
-  logger.info(
-    'Congratulations, your extension "vscode-deephaven" is now active!'
-  );
-
   let selectedConnectionUrl: string | null = null;
   let selectedDhService: DhcService | null = null;
   let connectionOptions = createConnectionOptions();
@@ -41,6 +37,10 @@ export function activate(context: vscode.ExtensionContext) {
   // Configure log handlers
   Logger.addConsoleHandler();
   Logger.addOutputChannelHandler(debugOutputChannel);
+
+  logger.info(
+    'Congratulations, your extension "vscode-deephaven" is now active!'
+  );
 
   outputChannel.appendLine('Deephaven extension activated');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import {
   createConnectionOptions,
   createConnectionQuickPick,
   getTempDir,
+  Logger,
 } from './util';
 import { DhcService } from './services';
 import { DhServiceRegistry } from './services';
@@ -16,8 +17,10 @@ import {
   SELECT_CONNECTION_COMMAND,
 } from './common';
 
+const logger = new Logger('extension');
+
 export function activate(context: vscode.ExtensionContext) {
-  console.log(
+  logger.info(
     'Congratulations, your extension "vscode-deephaven" is now active!'
   );
 
@@ -26,6 +29,15 @@ export function activate(context: vscode.ExtensionContext) {
   let connectionOptions = createConnectionOptions();
 
   const outputChannel = vscode.window.createOutputChannel('Deephaven', 'log');
+  const debugOutputChannel = vscode.window.createOutputChannel(
+    'Deephaven Debug',
+    'log'
+  );
+
+  // Configure log handlers
+  Logger.addConsoleHandler();
+  Logger.addOutputChannelHandler(debugOutputChannel);
+
   outputChannel.appendLine('Deephaven extension activated');
 
   // Update connection options when configuration changes

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,6 +126,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (uri != null) {
       toaster.showInfoMessage(`Downloaded logs to ${uri.fsPath}`);
+      vscode.window.showTextDocument(uri);
     }
   }
 

--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -1,6 +1,8 @@
 import { Disposable } from '../common';
-import { isDisposable } from '../util';
+import { isDisposable, Logger } from '../util';
 import { EventDispatcher } from './EventDispatcher';
+
+const logger = new Logger('CacheService');
 
 export class CacheService<T, TEventName extends string>
   extends EventDispatcher<TEventName>
@@ -27,7 +29,7 @@ export class CacheService<T, TEventName extends string>
     const normalizeKey = this.normalizeKey(key);
 
     if (!this.cachedPromises.has(normalizeKey)) {
-      console.log(`${this.label}: caching key: ${normalizeKey}`);
+      logger.info(`${this.label}: caching key: ${normalizeKey}`);
       // Note that we cache the promise itself, not the result of the promise.
       // This helps ensure the loader is only called the first time `get` is
       // called.
@@ -49,7 +51,7 @@ export class CacheService<T, TEventName extends string>
         }
       });
     } catch (err) {
-      console.error('An error occurred while disposing cached values:', err);
+      logger.error('An error occurred while disposing cached values:', err);
     }
 
     this.cachedPromises.clear();

--- a/src/services/DhService.ts
+++ b/src/services/DhService.ts
@@ -127,7 +127,7 @@ export abstract class DhService<TDH, TClient>
       this.outputChannel.appendLine(
         `Failed to initialize Deephaven API${err == null ? '.' : `: ${err}`}`
       );
-      this.toaster.showErrorMessage('Failed to initialize Deephaven API');
+      this.toaster.error('Failed to initialize Deephaven API');
       return false;
     }
 
@@ -177,15 +177,13 @@ export abstract class DhService<TDH, TClient>
     if (this.cn == null || this.session == null) {
       this.clearCaches();
 
-      this.toaster.showErrorMessage(
+      this.toaster.error(
         `Failed to create Deephaven session: ${this.serverUrl}`
       );
 
       return false;
     } else {
-      this.toaster.showInfoMessage(
-        `Created Deephaven session: ${this.serverUrl}`
-      );
+      this.toaster.info(`Created Deephaven session: ${this.serverUrl}`);
 
       return true;
     }
@@ -240,7 +238,7 @@ export abstract class DhService<TDH, TClient>
       // clear the caches on connection disconnect
       if (hasErrorCode(err, 16)) {
         this.clearCaches();
-        this.toaster.showErrorMessage(
+        this.toaster.error(
           'Session is no longer invalid. Please re-run the command to reconnect.'
         );
         return;
@@ -251,7 +249,7 @@ export abstract class DhService<TDH, TClient>
       logger.error(error);
       this.outputChannel.show(true);
       this.outputChannel.appendLine(error);
-      this.toaster.showErrorMessage('An error occurred when running a command');
+      this.toaster.error('An error occurred when running a command');
 
       return;
     }

--- a/src/services/DhService.ts
+++ b/src/services/DhService.ts
@@ -2,8 +2,10 @@ import * as vscode from 'vscode';
 import type { dh as DhcType } from '../dh/dhc-types';
 import { hasErrorCode } from '../util/typeUtils';
 import { ConnectionAndSession, Disposable } from '../common';
-import { ExtendedMap, formatTimestamp } from '../util';
+import { ExtendedMap, formatTimestamp, Logger } from '../util';
 import { EventDispatcher } from './EventDispatcher';
+
+const logger = new Logger('DhService');
 
 /* eslint-disable @typescript-eslint/naming-convention */
 const icons = {
@@ -118,7 +120,7 @@ export abstract class DhService<TDH, TClient>
       );
     } catch (err) {
       this.clearCaches();
-      console.error(err);
+      logger.error(err);
       this.outputChannel.appendLine(
         `Failed to initialize Deephaven API${err == null ? '.' : `: ${err}`}`
       );
@@ -192,7 +194,7 @@ export abstract class DhService<TDH, TClient>
   ): Promise<void> {
     if (editor.document.languageId !== 'python') {
       // This should not actually happen
-      console.log(`languageId '${editor.document.languageId}' not supported.`);
+      logger.info(`languageId '${editor.document.languageId}' not supported.`);
       return;
     }
 
@@ -220,7 +222,7 @@ export abstract class DhService<TDH, TClient>
 
     const text = editor.document.getText(selectionRange);
 
-    console.log('Sending text to dh:', text);
+    logger.info('Sending text to dh:', text);
 
     let result: CommandResultBase;
     let error: string | null = null;
@@ -243,7 +245,7 @@ export abstract class DhService<TDH, TClient>
     }
 
     if (error) {
-      console.error(error);
+      logger.error(error);
       this.outputChannel.show(true);
       this.outputChannel.appendLine(error);
       vscode.window.showErrorMessage(

--- a/src/services/DhServiceRegistry.ts
+++ b/src/services/DhServiceRegistry.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { CacheService } from './CacheService';
 import { DhcService, DhcServiceConstructor } from './DhcService';
-import { ensureHasTrailingSlash, ExtendedMap } from '../util';
+import { ensureHasTrailingSlash, ExtendedMap, Toaster } from '../util';
 
 export class DhServiceRegistry<T extends DhcService> extends CacheService<
   T,
@@ -10,7 +10,8 @@ export class DhServiceRegistry<T extends DhcService> extends CacheService<
   constructor(
     serviceFactory: DhcServiceConstructor<T>,
     panelRegistry: ExtendedMap<string, vscode.WebviewPanel>,
-    outputChannel: vscode.OutputChannel
+    outputChannel: vscode.OutputChannel,
+    toaster: Toaster
   ) {
     super(
       serviceFactory.name,
@@ -22,7 +23,8 @@ export class DhServiceRegistry<T extends DhcService> extends CacheService<
         const dhService = new serviceFactory(
           serverUrl,
           panelRegistry,
-          outputChannel
+          outputChannel,
+          toaster
         );
 
         // Propagate service events as registry events.

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -8,8 +8,10 @@ import {
   initDhcApi,
   initDhcSession,
 } from '../dh/dhc';
-import { ExtendedMap, getPanelHtml } from '../util';
+import { ExtendedMap, getPanelHtml, Logger } from '../util';
 import { ConnectionAndSession } from '../common';
+
+const logger = new Logger('DhcService');
 
 export type DhcServiceConstructor<T extends DhcService> = new (
   serverUrl: string,
@@ -30,7 +32,7 @@ export class DhcService extends DhService<typeof DhcType, DhcType.CoreClient> {
     try {
       return new dh.CoreClient(this.serverUrl);
     } catch (err) {
-      console.error(err);
+      logger.error(err);
       throw err;
     }
   }
@@ -68,7 +70,7 @@ export class DhcService extends DhService<typeof DhcType, DhcType.CoreClient> {
         this.psk = token;
       }
     } catch (err) {
-      console.error(err);
+      logger.error(err);
     }
 
     return connectionAndSession;

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -8,7 +8,7 @@ import {
   initDhcApi,
   initDhcSession,
 } from '../dh/dhc';
-import { ExtendedMap, getPanelHtml, Logger } from '../util';
+import { ExtendedMap, getPanelHtml, Logger, Toaster } from '../util';
 import { ConnectionAndSession } from '../common';
 
 const logger = new Logger('DhcService');
@@ -16,7 +16,8 @@ const logger = new Logger('DhcService');
 export type DhcServiceConstructor<T extends DhcService> = new (
   serverUrl: string,
   panelRegistry: ExtendedMap<string, vscode.WebviewPanel>,
-  outputChannel: vscode.OutputChannel
+  outputChannel: vscode.OutputChannel,
+  toaster: Toaster
 ) => T;
 
 export class DhcService extends DhService<typeof DhcType, DhcType.CoreClient> {

--- a/src/services/PanelFocusManager.ts
+++ b/src/services/PanelFocusManager.ts
@@ -1,4 +1,7 @@
 import * as vscode from 'vscode';
+import { Logger } from '../util';
+
+const logger = new Logger('PanelFocusManager');
 
 /*
  * Panels steal focus when they finish loading which causes the run
@@ -26,7 +29,7 @@ export class PanelFocusManager {
   >();
 
   initialize(panel: vscode.WebviewPanel): void {
-    console.log('Initializing panel:', panel.title, 2);
+    logger.info('Initializing panel:', panel.title, 2);
 
     // Only count the last panel initialized
     this.panelsPendingInitialFocus = new WeakMap();
@@ -59,7 +62,7 @@ export class PanelFocusManager {
 
       const pendingChangeCount = this.panelsPendingInitialFocus.get(panel) ?? 0;
 
-      console.log('Panel view state changed:', {
+      logger.info('Panel view state changed:', {
         panelTitle: panel.title,
         activeEditorViewColumn,
         activeTabGroupViewColumn,

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -28,11 +28,11 @@ export class Logger {
   static addConsoleHandler = () => {
     Logger.handlers.add({
       /* eslint-disable no-console */
-      error: (label, ...args) => console.error(`[${label}] ERROR:`, ...args),
-      warn: (label, ...args) => console.warn(`[${label}] WARN:`, ...args),
-      info: (label, ...args) => console.info(`[${label}] INFO:`, ...args),
-      debug: (label, ...args) => console.debug(`[${label}] DEBUG:`, ...args),
-      debug2: (label, ...args) => console.debug(`[${label}] DEBUG2:`, ...args),
+      error: console.error.bind(console),
+      warn: console.warn.bind(console),
+      info: console.info.bind(console),
+      debug: console.debug.bind(console),
+      debug2: console.debug.bind(console),
       /* eslint-enable no-console */
     });
   };
@@ -56,7 +56,7 @@ export class Logger {
     });
   };
 
-  constructor(private label: string) {}
+  constructor(private readonly label: string) {}
 
   /**
    * Handle log args for a given level

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -44,15 +44,15 @@ export class Logger {
   static addOutputChannelHandler = (outputChannel: vscode.OutputChannel) => {
     Logger.handlers.add({
       error: (label, ...args) =>
-        outputChannel.appendLine(`[${label}] ERROR: ${args.join(', ')}`),
+        outputChannel.appendLine(`${label} ERROR: ${args.join(', ')}`),
       warn: (label, ...args) =>
-        outputChannel.appendLine(`[${label}] WARN: ${args.join(', ')}`),
+        outputChannel.appendLine(`${label} WARN: ${args.join(', ')}`),
       info: (label, ...args) =>
-        outputChannel.appendLine(`[${label}] INFO: ${args.join(', ')}`),
+        outputChannel.appendLine(`${label} INFO: ${args.join(', ')}`),
       debug: (label, ...args) =>
-        outputChannel.appendLine(`[${label}] DEBUG: ${args.join(', ')}`),
+        outputChannel.appendLine(`${label} DEBUG: ${args.join(', ')}`),
       debug2: (label, ...args) =>
-        outputChannel.appendLine(`[${label}] DEBUG2: ${args.join(', ')}`),
+        outputChannel.appendLine(`${label} DEBUG2: ${args.join(', ')}`),
     });
   };
 
@@ -64,7 +64,9 @@ export class Logger {
    * @param args The arguments to log
    */
   private handle = (level: LogLevel, ...args: unknown[]) => {
-    Logger.handlers.forEach(handler => handler[level](this.label, ...args));
+    Logger.handlers.forEach(handler =>
+      handler[level](`[${this.label}]`, ...args)
+    );
   };
 
   debug = (...args: unknown[]): void => {

--- a/src/util/Logger.ts
+++ b/src/util/Logger.ts
@@ -1,0 +1,89 @@
+import * as vscode from 'vscode';
+
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug' | 'debug2';
+
+export type LogLevelHandler = (label: string, ...args: unknown[]) => void;
+
+export type LogHandler = Record<LogLevel, LogLevelHandler>;
+
+/**
+ * Simple logger delegate that can be used to log messages to a set of handlers.
+ * Messages will include a label for scoping log messages.
+ *
+ * Handlers can be statically registered via:
+ *
+ *   Logger.handlers.add(handler);
+ *
+ * Then modules can create labeled loggers and use them to log messages:
+ *
+ *   const logger = new Logger('MyModule');
+ *   logger.info('Hello, world!');
+ */
+export class Logger {
+  static handlers: Set<LogHandler> = new Set();
+
+  /**
+   * Register log handler that logs to console.
+   */
+  static addConsoleHandler = () => {
+    Logger.handlers.add({
+      /* eslint-disable no-console */
+      error: (label, ...args) => console.error(`[${label}] ERROR:`, ...args),
+      warn: (label, ...args) => console.warn(`[${label}] WARN:`, ...args),
+      info: (label, ...args) => console.info(`[${label}] INFO:`, ...args),
+      debug: (label, ...args) => console.debug(`[${label}] DEBUG:`, ...args),
+      debug2: (label, ...args) => console.debug(`[${label}] DEBUG2:`, ...args),
+      /* eslint-enable no-console */
+    });
+  };
+
+  /**
+   * Register a log handler that logs to a `vscode.OutputChannel`.
+   * @param outputChannel
+   */
+  static addOutputChannelHandler = (outputChannel: vscode.OutputChannel) => {
+    Logger.handlers.add({
+      error: (label, ...args) =>
+        outputChannel.appendLine(`[${label}] ERROR: ${args.join(', ')}`),
+      warn: (label, ...args) =>
+        outputChannel.appendLine(`[${label}] WARN: ${args.join(', ')}`),
+      info: (label, ...args) =>
+        outputChannel.appendLine(`[${label}] INFO: ${args.join(', ')}`),
+      debug: (label, ...args) =>
+        outputChannel.appendLine(`[${label}] DEBUG: ${args.join(', ')}`),
+      debug2: (label, ...args) =>
+        outputChannel.appendLine(`[${label}] DEBUG2: ${args.join(', ')}`),
+    });
+  };
+
+  constructor(private label: string) {}
+
+  /**
+   * Handle log args for a given level
+   * @param level The level to handle
+   * @param args The arguments to log
+   */
+  private handle = (level: LogLevel, ...args: unknown[]) => {
+    Logger.handlers.forEach(handler => handler[level](this.label, ...args));
+  };
+
+  debug = (...args: unknown[]): void => {
+    this.handle('debug', ...args);
+  };
+
+  debug2 = (...args: unknown[]): void => {
+    this.handle('debug2', ...args);
+  };
+
+  info = (...args: unknown[]): void => {
+    this.handle('info', ...args);
+  };
+
+  warn = (...args: unknown[]): void => {
+    this.handle('warn', ...args);
+  };
+
+  error = (...args: unknown[]): void => {
+    this.handle('error', ...args);
+  };
+}

--- a/src/util/OutputChannelWithHistory.ts
+++ b/src/util/OutputChannelWithHistory.ts
@@ -11,7 +11,7 @@ export class OutputChannelWithHistory implements vscode.OutputChannel {
   ) {
     this.name = outputChannel.name;
 
-    // Have to bind this explicilty since function overloads prevent using
+    // Have to bind this explicitly since function overloads prevent using
     // lexical binding via arrow function.
     this.show = this.show.bind(this);
   }

--- a/src/util/OutputChannelWithHistory.ts
+++ b/src/util/OutputChannelWithHistory.ts
@@ -1,0 +1,129 @@
+import * as vscode from 'vscode';
+import * as fs from 'node:fs/promises';
+
+/**
+ * Output channel wrapper that keeps a history of all appended lines.
+ */
+export class OutputChannelWithHistory implements vscode.OutputChannel {
+  constructor(
+    readonly context: vscode.ExtensionContext,
+    readonly outputChannel: vscode.OutputChannel
+  ) {
+    this.name = outputChannel.name;
+
+    // Have to bind this explicilty since function overloads prevent using
+    // lexical binding via arrow function.
+    this.show = this.show.bind(this);
+  }
+
+  private history: string[] = [];
+  readonly name: string;
+
+  /**
+   * Append the given value to the channel. Also appends to the history.
+   *
+   * @param value A string, falsy values will not be printed.
+   */
+  append = (value: string): void => {
+    this.history.push(value);
+    return this.outputChannel.append(value);
+  };
+
+  /**
+   * Append the given value and a line feed character
+   * to the channel. Also appends to the history.
+   *
+   * @param value A string, falsy values will be printed.
+   */
+  appendLine = (value: string) => {
+    this.history.push(value);
+    this.outputChannel.appendLine(value);
+  };
+
+  /**
+   * Clear the history.
+   */
+  clearHistory = () => {
+    this.history = [];
+  };
+
+  downloadHistoryToFile = async (): Promise<vscode.Uri | null> => {
+    const response = await vscode.window.showSaveDialog({
+      defaultUri: vscode.Uri.file(
+        `deephaven-vscode_${new Date()
+          .toISOString()
+          .substring(0, 19)
+          .replace(/[:]/g, '')
+          .replace('T', '_')}.log`
+      ),
+      filters: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        Logs: ['log'],
+      },
+    });
+
+    if (response?.fsPath == null) {
+      return null;
+    }
+
+    await fs.writeFile(response.fsPath, this.history.join('\n'));
+
+    return response;
+  };
+
+  /**
+   * Dispose and free associated resources.
+   */
+  dispose = (): void => {
+    this.clearHistory();
+    this.outputChannel.dispose();
+  };
+
+  /**
+   * Removes all output from the channel. Also clears the history.
+   */
+  clear = (): void => {
+    this.clearHistory();
+    this.outputChannel.clear();
+  };
+
+  /**
+   * Hide this channel from the UI.
+   */
+  hide = (): void => {
+    return this.outputChannel.hide();
+  };
+
+  /**
+   * Replaces all output from the channel with the given value. Also replaces
+   * the history.
+   *
+   * @param value A string, falsy values will not be printed.
+   */
+  replace = (value: string): void => {
+    this.history = [value];
+    this.outputChannel.replace(value);
+  };
+
+  /**
+   * Reveal this channel in the UI.
+   *
+   * @param preserveFocus When `true` the channel will not take focus.
+   */
+  show(preserveFocus?: boolean): void;
+  /**
+   * Reveal this channel in the UI.
+   *
+   * @deprecated Use the overload with just one parameter (`show(preserveFocus?: boolean): void`).
+   *
+   * @param column This argument is **deprecated** and will be ignored.
+   * @param preserveFocus When `true` the channel will not take focus.
+   */
+  show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
+  show(column?: unknown, preserveFocus?: unknown): void {
+    return this.outputChannel.show(
+      column as Parameters<vscode.OutputChannel['show']>[0],
+      preserveFocus as Parameters<vscode.OutputChannel['show']>[1]
+    );
+  }
+}

--- a/src/util/Toaster.ts
+++ b/src/util/Toaster.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { DOWNLOAD_LOGS_CMD, DOWNLOAD_LOGS_TEXT } from '../common';
+
+/**
+ * Show toast messages to user.
+ */
+export class Toaster {
+  constructor() {}
+
+  showErrorMessage = async (message: string) => {
+    const response = await vscode.window.showErrorMessage(
+      message,
+      DOWNLOAD_LOGS_TEXT
+    );
+
+    // If user clicks "Download Logs" button
+    if (response === DOWNLOAD_LOGS_TEXT) {
+      await vscode.commands.executeCommand(DOWNLOAD_LOGS_CMD);
+    }
+  };
+
+  showInfoMessage = async (message: string) => {
+    await vscode.window.showInformationMessage(message);
+  };
+}

--- a/src/util/Toaster.ts
+++ b/src/util/Toaster.ts
@@ -7,7 +7,7 @@ import { DOWNLOAD_LOGS_CMD, DOWNLOAD_LOGS_TEXT } from '../common';
 export class Toaster {
   constructor() {}
 
-  showErrorMessage = async (message: string) => {
+  error = async (message: string) => {
     const response = await vscode.window.showErrorMessage(
       message,
       DOWNLOAD_LOGS_TEXT
@@ -19,7 +19,7 @@ export class Toaster {
     }
   };
 
-  showInfoMessage = async (message: string) => {
+  info = async (message: string) => {
     await vscode.window.showInformationMessage(message);
   };
 }

--- a/src/util/downloadUtils.ts
+++ b/src/util/downloadUtils.ts
@@ -2,6 +2,9 @@ import * as fs from 'node:fs';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import * as path from 'node:path';
+import { Logger } from './Logger';
+
+const logger = new Logger('downloadUtils');
 
 export function getTempDir(recreate = false) {
   const tempDir = path.join(__dirname, 'tmp');
@@ -60,12 +63,12 @@ export async function downloadFromURL(
         });
       })
       .on('timeout', () => {
-        console.error('Failed download of url:', url);
+        logger.error('Failed download of url:', url);
         reject();
       })
       .on('error', e => {
         if (retries > 0) {
-          console.error('Retrying url:', url);
+          logger.error('Retrying url:', url);
           setTimeout(
             () =>
               downloadFromURL(url, retries - 1, retryDelay).then(
@@ -75,10 +78,10 @@ export async function downloadFromURL(
             retryDelay
           );
         } else {
-          console.error(
+          logger.error(
             `Hit retry limit. Stopping attempted include from ${url} with error`
           );
-          console.error(e);
+          logger.error(e);
           reject();
         }
       });

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,7 @@
 export * from './downloadUtils';
 export * from './ExtendedMap';
 export * from './isDisposable';
+export * from './Logger';
 export * from './panelUtils';
 export * from './polyfillUtils';
 export * from './uiUtils';

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -4,5 +4,6 @@ export * from './isDisposable';
 export * from './Logger';
 export * from './panelUtils';
 export * from './polyfillUtils';
+export * from './Toaster';
 export * from './uiUtils';
 export * from './urlUtils';


### PR DESCRIPTION
- Util that can be used by any module to log scoped messages. Handlers can be registered globally.
- Registered additional "Deephaven Debug" output channel to capture Logger logs (I considered just logging to the existing panel, but I didn't want to clutter it with things more diagnostics in nature).
- Added a "Download Logs" button to error toasts. Also added to cmd palette

Testing
- Produce an error
- Should now see a "Download Logs" button on the error toast
- Clicking should prompt to save and open the file in vscode after save
- This should show the same content as the "Deephaven Debug" output panel

resolves #33