### PR TITLE
feat: Surface python error in Problems tab and Editor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,9 @@ export function activate(context: vscode.ExtensionContext) {
   let selectedDhService: DhcService | null = null;
   let connectionOptions = createConnectionOptions();
 
+  const diagnosticsCollection =
+    vscode.languages.createDiagnosticCollection('python');
+
   const outputChannel = vscode.window.createOutputChannel('Deephaven', 'log');
   const debugOutputChannel = new OutputChannelWithHistory(
     context,
@@ -54,9 +57,15 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions
   );
 
+  // Clear diagnostics on save
+  vscode.workspace.onDidSaveTextDocument(doc => {
+    diagnosticsCollection.set(doc.uri, []);
+  });
+
   const dhcServiceRegistry = new DhServiceRegistry(
     DhcService,
     new ExtendedMap<string, vscode.WebviewPanel>(),
+    diagnosticsCollection,
     outputChannel,
     toaster
   );

--- a/src/services/DhService.ts
+++ b/src/services/DhService.ts
@@ -2,7 +2,13 @@ import * as vscode from 'vscode';
 import type { dh as DhcType } from '../dh/dhc-types';
 import { hasErrorCode } from '../util/typeUtils';
 import { ConnectionAndSession, Disposable } from '../common';
-import { ExtendedMap, formatTimestamp, Logger, Toaster } from '../util';
+import {
+  ExtendedMap,
+  formatTimestamp,
+  Logger,
+  parseServerError,
+  Toaster,
+} from '../util';
 import { EventDispatcher } from './EventDispatcher';
 
 const logger = new Logger('DhService');
@@ -35,6 +41,7 @@ export abstract class DhService<TDH, TClient>
   constructor(
     serverUrl: string,
     panelRegistry: ExtendedMap<string, vscode.WebviewPanel>,
+    diagnosticsCollection: vscode.DiagnosticCollection,
     outputChannel: vscode.OutputChannel,
     toaster: Toaster
   ) {
@@ -42,6 +49,7 @@ export abstract class DhService<TDH, TClient>
 
     this.serverUrl = serverUrl;
     this.panelRegistry = panelRegistry;
+    this.diagnosticsCollection = diagnosticsCollection;
     this.outputChannel = outputChannel;
     this.toaster = toaster;
   }
@@ -49,9 +57,10 @@ export abstract class DhService<TDH, TClient>
   public readonly serverUrl: string;
   protected readonly subscriptions: (() => void)[] = [];
 
-  protected outputChannel: vscode.OutputChannel;
-  protected toaster: Toaster;
-  private panelRegistry: ExtendedMap<string, vscode.WebviewPanel>;
+  protected readonly outputChannel: vscode.OutputChannel;
+  protected readonly toaster: Toaster;
+  private readonly panelRegistry: ExtendedMap<string, vscode.WebviewPanel>;
+  private readonly diagnosticsCollection: vscode.DiagnosticCollection;
   private cachedCreateClient: Promise<TClient> | null = null;
   private cachedCreateSession: Promise<ConnectionAndSession<
     DhcType.IdeConnection,
@@ -199,9 +208,8 @@ export abstract class DhService<TDH, TClient>
       return;
     }
 
-    // this.outputChannel.appendLine(
-    //   `Sending${selectionOnly ? ' selected' : ''} code to: ${this.serverUrl}`
-    // );
+    // Clear previous diagnostics when cmd starts running
+    this.diagnosticsCollection.set(editor.document.uri, []);
 
     if (this.session == null) {
       await this.initDh();
@@ -250,6 +258,28 @@ export abstract class DhService<TDH, TClient>
       this.outputChannel.show(true);
       this.outputChannel.appendLine(error);
       this.toaster.error('An error occurred when running a command');
+
+      const { line, value } = parseServerError(error);
+
+      if (line != null) {
+        // If selectionOnly is true, the line number in the error will be
+        // relative to the selection
+        const offsetLine = selectionOnly
+          ? line + editor.selection.start.line - 1
+          : line - 1;
+
+        const lineLength = editor.document.lineAt(offsetLine).text.length;
+
+        // Diagnostic representing the line of code that produced the server error
+        const diagnostic: vscode.Diagnostic = {
+          message: value == null ? error : `${value}\n${error}`,
+          severity: vscode.DiagnosticSeverity.Error,
+          range: new vscode.Range(offsetLine, 0, offsetLine, lineLength),
+          source: 'deephaven',
+        };
+
+        this.diagnosticsCollection.set(editor.document.uri, [diagnostic]);
+      }
 
       return;
     }

--- a/src/services/DhServiceRegistry.ts
+++ b/src/services/DhServiceRegistry.ts
@@ -10,6 +10,7 @@ export class DhServiceRegistry<T extends DhcService> extends CacheService<
   constructor(
     serviceFactory: DhcServiceConstructor<T>,
     panelRegistry: ExtendedMap<string, vscode.WebviewPanel>,
+    diagnosticsCollection: vscode.DiagnosticCollection,
     outputChannel: vscode.OutputChannel,
     toaster: Toaster
   ) {
@@ -23,6 +24,7 @@ export class DhServiceRegistry<T extends DhcService> extends CacheService<
         const dhService = new serviceFactory(
           serverUrl,
           panelRegistry,
+          diagnosticsCollection,
           outputChannel,
           toaster
         );

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -16,6 +16,7 @@ const logger = new Logger('DhcService');
 export type DhcServiceConstructor<T extends DhcService> = new (
   serverUrl: string,
   panelRegistry: ExtendedMap<string, vscode.WebviewPanel>,
+  diagnosticsCollection: vscode.DiagnosticCollection,
   outputChannel: vscode.OutputChannel,
   toaster: Toaster
 ) => T;

--- a/src/util/errorUtils.ts
+++ b/src/util/errorUtils.ts
@@ -1,0 +1,46 @@
+import { Logger } from './Logger';
+
+const logger = new Logger('errorUtils');
+
+export interface ParsedError {
+  [key: string]: string | number | undefined;
+  type?: string;
+  value?: string;
+  line?: number;
+  namespace?: string;
+  file?: string;
+  traceback?: string;
+}
+
+/**
+ * Parse a server error string into a key-value object.
+ * @param error
+ */
+export function parseServerError(error: string): ParsedError {
+  const errorDetails: ParsedError = {};
+  const lines = error.split('\n');
+
+  if (lines[0] !== 'java.lang.RuntimeException: Error in Python interpreter:') {
+    logger.debug('Unrecognized error type:', error);
+    return errorDetails;
+  }
+
+  while (lines.length) {
+    const line = lines.shift()!;
+
+    const [key, value] = line.split(':');
+
+    if (key && value) {
+      // Once we hit the Traceback, accumulate remaining lines
+      if (key === 'Traceback (most recent call last)') {
+        errorDetails.traceback = [value, ...lines].join('\n');
+        break;
+      }
+
+      errorDetails[key.toLowerCase()] =
+        key === 'Line' ? Number(value.trim()) : value.trim();
+    }
+  }
+
+  return errorDetails;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,5 @@
 export * from './downloadUtils';
+export * from './errorUtils';
 export * from './ExtendedMap';
 export * from './isDisposable';
 export * from './Logger';


### PR DESCRIPTION
Python server errors are now surfaced via the Problems tab and red squiggles in the editor.

<img width="1296" alt="image" src="https://github.com/user-attachments/assets/3ba3acb9-2d61-4a10-b112-0591b1a30589">

## Testing

- Introduce a typo in a script (e.g. `printx('some text')`)
- Run the whole file
- Should see an error in the Problems tab + red squiggles on the offending line
- Save. Errors should disappear
- Select the line and "Run Deephaven Selected Lines"
- Error should show again on correct line + Problems tab
- Save. Errors should disappear

UPDATE: found out the running script isn't always the top-level error, so added handling for that. Example to test:
```python
import sys; print(sys.version)

from deephaven import empty_table, time_table
from deephaven.plot import Figure

t1 = empty_table(10).update(["X = i", "Y = 10 * i"])
t2 = time_table("PT1s").update(["X = i%10", "Y = 10 * i"])

t3 = t1.natural_join(t2.last_by("X"), on="X", joins="YY=Y")

p1 = Figure().plot_xy("Plot 1", t1, x="X", y="Y").show()
p2 = Figure().plot_xy(t2, "X", "Y").show()

# p1 = Figure().plot_xy("Plot 1", t1, x="X", y="Y").show()
# p2 = Figure().plot_xy("Plot 2", t2, x="X", y="Y").show()


print("DH Rules")
print("DH Sucks")
```

resolves #39