### PR TITLE
fix: Re-published as 0.1.4 to fix linux install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-deephaven",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-deephaven",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "ws": "^8.18.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-deephaven",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "displayName": "Deephaven in VS Code",
   "description": "",
   "publisher": "deephaven",
@@ -94,11 +94,13 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "tsc -p ./",
+    "clean": "rm -rf out",
+    "compile": "npm run clean && tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "package": "vsce package -o releases/ && vsce package -o releases/vscode-deephaven-latest.vsix",
+    "publish:pre": "vsce publish --pre-release",
     "test": "node ./out/test/runTest.js"
   },
   "devDependencies": {


### PR DESCRIPTION
I've re-deployed to fix the casing of `Logger.js`. I also added a `clean` script to ensure `out` folder is clean on build / deploy.

fixes #53