### PR TITLE
feat: Moved "run selected" from code lens to hover provider

### DIFF
--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -65,6 +65,7 @@ export class ExtensionController implements Disposable {
     logger.info(
       'Congratulations, your extension "vscode-deephaven" is now active!'
     );
+    this._outputChannel?.show();
     this._outputChannel?.appendLine('Deephaven extension activated');
   }
 

--- a/src/providers/RunCommandCodeLensProvider.ts
+++ b/src/providers/RunCommandCodeLensProvider.ts
@@ -35,24 +35,6 @@ export class RunCommandCodeLensProvider
       }),
     ];
 
-    const editor = vscode.window.activeTextEditor;
-
-    // Show the run selected lines code lens if there is more than 1 line in the
-    // doc and there is a non-whitespace selection.
-    if (
-      editor &&
-      document.lineCount > 1 &&
-      /\S/.test(editor.document.getText(editor.selection))
-    ) {
-      codeLenses.push(
-        new vscode.CodeLens(editor.selection, {
-          title: `$(${ICON_ID.runSelection}) Run Deephaven Selected Lines`,
-          command: 'vscode-deephaven.runSelection',
-          arguments: [document.uri],
-        })
-      );
-    }
-
     return codeLenses;
   }
 

--- a/src/providers/RunSelectedLinesHoverProvider.ts
+++ b/src/providers/RunSelectedLinesHoverProvider.ts
@@ -22,14 +22,8 @@ export const runSelectedLinesHoverProvider: vscode.HoverProvider = {
       return;
     }
 
-    // Tally total selected lines across all selections
-    const selectedLineCount = editor.selections.reduce(
-      (sum, selection) => sum + 1 + selection.end.line - selection.start.line,
-      0
-    );
-
     const hoverContent = new vscode.MarkdownString(
-      `[$(${ICON_ID.runSelection}) Run Deephaven selected lines (${selectedLineCount})](command:${RUN_SELECTION_COMMAND})`,
+      `[$(${ICON_ID.runSelection}) Run Deephaven selected lines](command:${RUN_SELECTION_COMMAND})`,
       true
     );
 

--- a/src/providers/RunSelectedLinesHoverProvider.ts
+++ b/src/providers/RunSelectedLinesHoverProvider.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { ICON_ID, RUN_SELECTION_COMMAND } from '../common';
+
+/**
+ * Provides hover content for running selected lines in Deephaven.
+ */
+export const runSelectedLinesHoverProvider: vscode.HoverProvider = {
+  provideHover(_document, _position, _token) {
+    const hoverContent = new vscode.MarkdownString(
+      `[$(${ICON_ID.runSelection}) Run Deephaven selected lines](command:${RUN_SELECTION_COMMAND})`,
+      true
+    );
+
+    hoverContent.isTrusted = {
+      enabledCommands: [RUN_SELECTION_COMMAND],
+    };
+
+    const editor = vscode.window.activeTextEditor;
+    if (editor == null) {
+      return;
+    }
+
+    return new vscode.Hover(hoverContent);
+  },
+};

--- a/src/providers/RunSelectedLinesHoverProvider.ts
+++ b/src/providers/RunSelectedLinesHoverProvider.ts
@@ -1,24 +1,41 @@
 import * as vscode from 'vscode';
 import { ICON_ID, RUN_SELECTION_COMMAND } from '../common';
+import { expandSelectionToFullLines } from '../util';
 
 /**
  * Provides hover content for running selected lines in Deephaven.
  */
 export const runSelectedLinesHoverProvider: vscode.HoverProvider = {
-  provideHover(_document, _position, _token) {
+  provideHover(_document, position, _token) {
+    const editor = vscode.window.activeTextEditor;
+
+    if (editor == null) {
+      return;
+    }
+
+    // Determine of hover is over a selected line
+    const isOverSelection = editor.selections.some(selection =>
+      expandSelectionToFullLines(editor.document)(selection).contains(position)
+    );
+
+    if (!isOverSelection) {
+      return;
+    }
+
+    // Tally total selected lines across all selections
+    const selectedLineCount = editor.selections.reduce(
+      (sum, selection) => sum + 1 + selection.end.line - selection.start.line,
+      0
+    );
+
     const hoverContent = new vscode.MarkdownString(
-      `[$(${ICON_ID.runSelection}) Run Deephaven selected lines](command:${RUN_SELECTION_COMMAND})`,
+      `[$(${ICON_ID.runSelection}) Run Deephaven selected lines (${selectedLineCount})](command:${RUN_SELECTION_COMMAND})`,
       true
     );
 
     hoverContent.isTrusted = {
       enabledCommands: [RUN_SELECTION_COMMAND],
     };
-
-    const editor = vscode.window.activeTextEditor;
-    if (editor == null) {
-      return;
-    }
 
     return new vscode.Hover(hoverContent);
   },

--- a/src/providers/RunSelectedLinesHoverProvider.ts
+++ b/src/providers/RunSelectedLinesHoverProvider.ts
@@ -13,7 +13,7 @@ export const runSelectedLinesHoverProvider: vscode.HoverProvider = {
       return;
     }
 
-    // Determine of hover is over a selected line
+    // Determine if hover is over a selected line
     const isOverSelection = editor.selections.some(selection =>
       expandSelectionToFullLines(editor.document)(selection).contains(position)
     );

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,5 @@
 export * from './RunCommandCodeLensProvider';
+export * from './RunSelectedLinesHoverProvider';
 export * from './ServerConnectionTreeProvider';
 export * from './ServerTreeProvider';
 export * from './TreeDataProviderBase';

--- a/src/services/DhService.ts
+++ b/src/services/DhService.ts
@@ -10,6 +10,7 @@ import type {
 import {
   ExtendedMap,
   formatTimestamp,
+  getCombinedSelectedLinesText,
   isAggregateError,
   Logger,
   NoConsoleTypesError,
@@ -247,17 +248,11 @@ export abstract class DhService<TDH = unknown, TClient = unknown>
       return;
     }
 
-    const selectionRange =
-      selectionOnly && editor.selection
-        ? new vscode.Range(
-            editor.selection.start.line,
-            0,
-            editor.selection.end.line,
-            editor.document.lineAt(editor.selection.end.line).text.length
-          )
-        : undefined;
+    const text = selectionOnly
+      ? getCombinedSelectedLinesText(editor)
+      : editor.document.getText();
 
-    const text = editor.document.getText(selectionRange);
+    // const text = editor.document.getText(selectionRange);
 
     logger.info('Sending text to dh:', text);
 

--- a/src/services/DhService.ts
+++ b/src/services/DhService.ts
@@ -252,8 +252,6 @@ export abstract class DhService<TDH = unknown, TClient = unknown>
       ? getCombinedSelectedLinesText(editor)
       : editor.document.getText();
 
-    // const text = editor.document.getText(selectionRange);
-
     logger.info('Sending text to dh:', text);
 
     let result: CommandResultBase;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -8,6 +8,7 @@ export * from './Logger';
 export * from './OutputChannelWithHistory';
 export * from './panelUtils';
 export * from './polyfillUtils';
+export * from './selectionUtils';
 export * from './serverUtils';
 export * from './Toaster';
 export * from './uiUtils';

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+
+/**
+ * Combine content of all selected lines (including multi-cursor selections).
+ * Any line that is partially selected will be included in its entirety.
+ * @param editor
+ */
+export function getCombinedSelectedLinesText(
+  editor: vscode.TextEditor
+): string {
+  return sortSelections(editor.selections)
+    .map(expandSelectionToFullLines(editor.document))
+    .map(selection => editor.document.getText(selection))
+    .join('\n');
+}
+
+/**
+ * Create a function that can expand selection to include the full lines of any
+ * lines that are included in the selection.
+ * @param document
+ * @returns
+ */
+export function expandSelectionToFullLines(document: vscode.TextDocument) {
+  /**
+   * Expand a given selection to include the full lines of any lines that are included
+   * in the selection.
+   * @param selection
+   */
+  return (selection: vscode.Selection): vscode.Selection => {
+    return new vscode.Selection(
+      selection.start.line,
+      0,
+      selection.end.line,
+      document.lineAt(selection.end.line).text.length
+    );
+  };
+}
+
+/**
+ * Sort selections in document order. Useful for converting `TextEditor.selections`
+ * which are ordered based on multi-cursor creation order.
+ * @param selections
+ */
+export function sortSelections(
+  selections: readonly vscode.Selection[]
+): vscode.Selection[] {
+  return [...selections].sort(
+    (s1, s2) =>
+      s1.start.line - s2.start.line || s1.start.character - s2.start.character
+  );
+}


### PR DESCRIPTION
**Moved "run selected" from code lens to hover provider**

- "Run Deephaven selected lines" command should appear when hovering over a selection.
- Code should no longer shift when the cmd appears
- In cases where the language service includes additional hover info, the command will be at the bottom of the hover popover
- Clicking the play button should run the selection

**Running selection now supports multi-cursor selection**
- All selections are expanded to include full lines
- Multi cursor selections will be concatenated with `\n`

resolves #109