### PR TITLE
feat: Pip Server Management

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,11 @@
         "icon": "$(plug)"
       },
       {
+        "command": "vscode-deephaven.createNewTextDoc",
+        "title": "New File",
+        "icon": "$(new-file)"
+      },
+      {
         "command": "vscode-deephaven.disconnectEditor",
         "title": "Deephaven: Disconnect Editor",
         "icon": "$(debug-disconnect)"
@@ -234,6 +239,11 @@
           "group": "inline"
         },
         {
+          "command": "vscode-deephaven.createNewTextDoc",
+          "when": "view == vscode-deephaven.serverConnectionTree && viewItem == isConnection",
+          "group": "inline@1"
+        },
+        {
           "command": "vscode-deephaven.disconnectEditor",
           "when": "view == vscode-deephaven.serverConnectionTree && viewItem != isConnection",
           "group": "inline"
@@ -241,7 +251,7 @@
         {
           "command": "vscode-deephaven.disconnectFromServer",
           "when": "view == vscode-deephaven.serverConnectionTree && viewItem == isConnection",
-          "group": "inline"
+          "group": "inline@2"
         },
         {
           "command": "vscode-deephaven.openInBrowser",

--- a/package.json
+++ b/package.json
@@ -140,6 +140,16 @@
         "command": "vscode-deephaven.refreshServerConnectionTree",
         "title": "Deephaven: Refresh Server Connection Tree",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "vscode-deephaven.startServer",
+        "title": "Deephaven: Start Server",
+        "icon": "$(debug-start)"
+      },
+      {
+        "command": "vscode-deephaven.stopServer",
+        "title": "Deephaven: Stop Server",
+        "icon": "$(debug-stop)"
       }
     ],
     "menus": {
@@ -212,6 +222,11 @@
           "when": "view == vscode-deephaven.serverTree"
         },
         {
+          "command": "vscode-deephaven.startServer",
+          "group": "navigation",
+          "when": "view == vscode-deephaven.serverTree"
+        },
+        {
           "command": "vscode-deephaven.refreshServerConnectionTree",
           "group": "navigation",
           "when": "view == vscode-deephaven.serverConnectionTree"
@@ -220,7 +235,7 @@
       "view/item/context": [
         {
           "command": "vscode-deephaven.connectToServer",
-          "when": "view == vscode-deephaven.serverTree && viewItem == isServerRunningDisconnected",
+          "when": "view == vscode-deephaven.serverTree && (viewItem == isManagedServerDisconnected || viewItem == isServerRunningDisconnected)",
           "group": "inline"
         },
         {
@@ -235,7 +250,12 @@
         },
         {
           "command": "vscode-deephaven.openInBrowser",
-          "when": "view == vscode-deephaven.serverTree && (viewItem == isServerRunningConnected || viewItem == isServerRunningDisconnected)",
+          "when": "view == vscode-deephaven.serverTree && (viewItem == isManagedServerConnected || viewItem == isServerRunningConnected || viewItem == isServerRunningDisconnected || viewItem == isManagedServerDisconnected)",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-deephaven.stopServer",
+          "when": "view == vscode-deephaven.serverTree && (viewItem == isManagedServerConnected || viewItem == isManagedServerConnecting || viewItem == isManagedServerDisconnected)",
           "group": "inline"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
         {
           "command": "vscode-deephaven.startServer",
           "group": "navigation",
-          "when": "view == vscode-deephaven.serverTree"
+          "when": "view == vscode-deephaven.serverTree && deephaven.canManageServers"
         },
         {
           "command": "vscode-deephaven.refreshServerConnectionTree",

--- a/package.json
+++ b/package.json
@@ -169,11 +169,11 @@
         },
         {
           "command": "vscode-deephaven.runCode",
-          "when": "true"
+          "when": "editorLangId == python || editorLangId == groovy"
         },
         {
           "command": "vscode-deephaven.runSelection",
-          "when": "true"
+          "when": "editorLangId == python || editorLangId == groovy"
         },
         {
           "command": "vscode-deephaven.connectToServer",

--- a/package.json
+++ b/package.json
@@ -222,11 +222,6 @@
           "when": "view == vscode-deephaven.serverTree"
         },
         {
-          "command": "vscode-deephaven.startServer",
-          "group": "navigation",
-          "when": "view == vscode-deephaven.serverTree && deephaven.canManageServers"
-        },
-        {
           "command": "vscode-deephaven.refreshServerConnectionTree",
           "group": "navigation",
           "when": "view == vscode-deephaven.serverConnectionTree"
@@ -251,6 +246,11 @@
         {
           "command": "vscode-deephaven.openInBrowser",
           "when": "view == vscode-deephaven.serverTree && (viewItem == isManagedServerConnected || viewItem == isServerRunningConnected || viewItem == isServerRunningDisconnected || viewItem == isManagedServerDisconnected)",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-deephaven.startServer",
+          "when": "view == vscode-deephaven.serverTree && viewItem == canStartServer",
           "group": "inline"
         },
         {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -6,6 +6,11 @@
  */
 import { vi } from 'vitest';
 
+export enum QuickPickItemKind {
+  Separator = -1,
+  Default = 0,
+}
+
 export const ThemeColor = vi
   .fn()
   .mockName('ThemeColor')
@@ -22,17 +27,8 @@ export const ThemeIcon = vi
   }));
 
 export enum TreeItemCollapsibleState {
-  /**
-   * Determines an item can be neither collapsed nor expanded. Implies it has no children.
-   */
   None = 0,
-  /**
-   * Determines an item is collapsed
-   */
   Collapsed = 1,
-  /**
-   * Determines an item is expanded
-   */
   Expanded = 2,
 }
 

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /**
  * Mock `vscode` module. Note that `vi.mock('vscode')` has to be explicitly
  * called in any test module needing to use this mock. It will not be loaded
@@ -5,6 +6,39 @@
  */
 import { vi } from 'vitest';
 
+export const ThemeColor = vi
+  .fn()
+  .mockName('ThemeColor')
+  .mockImplementation((id: string) => ({
+    id,
+  }));
+
+export const ThemeIcon = vi
+  .fn()
+  .mockName('ThemeIcon')
+  .mockImplementation((id: string, color?: typeof ThemeColor) => ({
+    id,
+    color,
+  }));
+
+export enum TreeItemCollapsibleState {
+  /**
+   * Determines an item can be neither collapsed nor expanded. Implies it has no children.
+   */
+  None = 0,
+  /**
+   * Determines an item is collapsed
+   */
+  Collapsed = 1,
+  /**
+   * Determines an item is expanded
+   */
+  Expanded = 2,
+}
+
 export const workspace = {
-  getConfiguration: vi.fn().mockReturnValue(new Map()),
+  getConfiguration: vi
+    .fn()
+    .mockName('getConfiguration')
+    .mockReturnValue(new Map()),
 };

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -10,3 +10,5 @@ export const REFRESH_SERVER_CONNECTION_TREE_CMD = `${EXTENSION_ID}.refreshServer
 export const RUN_CODE_COMMAND = `${EXTENSION_ID}.runCode`;
 export const RUN_SELECTION_COMMAND = `${EXTENSION_ID}.runSelection`;
 export const SELECT_CONNECTION_COMMAND = `${EXTENSION_ID}.selectConnection`;
+export const START_SERVER_CMD = `${EXTENSION_ID}.startServer`;
+export const STOP_SERVER_CMD = `${EXTENSION_ID}.stopServer`;

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -1,6 +1,7 @@
 import { EXTENSION_ID } from './constants';
 
 export const CONNECT_TO_SERVER_CMD = `${EXTENSION_ID}.connectToServer`;
+export const CREATE_NEW_TEXT_DOC_CMD = `${EXTENSION_ID}.createNewTextDoc`;
 export const DISCONNECT_EDITOR_CMD = `${EXTENSION_ID}.disconnectEditor`;
 export const DISCONNECT_FROM_SERVER_CMD = `${EXTENSION_ID}.disconnectFromServer`;
 export const DOWNLOAD_LOGS_CMD = `${EXTENSION_ID}.downloadLogs`;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -76,6 +76,4 @@ export const SERVER_TREE_ITEM_CONTEXT = {
   isServerStopped: 'isServerStopped',
 } as const;
 
-export const PIP_SERVER_STATUS_DIRECTORY = 'pip-server-status';
-
 export type ServerTreeItemContextValue = keyof typeof SERVER_TREE_ITEM_CONTEXT;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -20,7 +20,7 @@ export const PYTHON_ENV_WAIT = 1500 as const;
 
 export const SERVER_STATUS_CHECK_TIMEOUT = 3000;
 export const PIP_SERVER_STATUS_CHECK_INTERVAL = 3000;
-export const PIP_SERVER_STATUS_CHECK_TIMEOUT = 15000;
+export const PIP_SERVER_STATUS_CHECK_TIMEOUT = 30000;
 
 export const STATUS_BAR_DISCONNECTED_TEXT = 'Deephaven: Disconnected';
 export const STATUS_BAR_DISCONNECT_TEXT = 'Deephaven: Disconnect';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -55,6 +55,10 @@ export const CONNECTION_TREE_ITEM_CONTEXT = {
   isUri: 'isUri',
 } as const;
 
+export const GLOBAL_CONTEXT = {
+  canManageServers: 'deephaven.canManageServers',
+};
+
 export const SERVER_TREE_ITEM_CONTEXT = {
   isManagedServerConnected: 'isManagedServerConnected',
   isManagedServerConnecting: 'isManagedServerConnecting',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -61,4 +61,7 @@ export const SERVER_TREE_ITEM_CONTEXT = {
   isServerStopped: 'isServerStopped',
 } as const;
 
+export const PIP_SERVER_STATUS_DIRECTORY = 'pip-server-status';
+export const PIP_SERVER_STATUS_FILE = 'pip-server-ready.txt';
+
 export type ServerTreeItemContextValue = keyof typeof SERVER_TREE_ITEM_CONTEXT;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -56,12 +56,14 @@ export const CONNECTION_TREE_ITEM_CONTEXT = {
 } as const;
 
 export const SERVER_TREE_ITEM_CONTEXT = {
+  isManagedServerConnected: 'isManagedServerConnected',
+  isManagedServerConnecting: 'isManagedServerConnecting',
+  isManagedServerDisconnected: 'isManagedServerDisconnected',
   isServerRunningConnected: 'isServerRunningConnected',
   isServerRunningDisconnected: 'isServerRunningDisconnected',
   isServerStopped: 'isServerStopped',
 } as const;
 
 export const PIP_SERVER_STATUS_DIRECTORY = 'pip-server-status';
-export const PIP_SERVER_STATUS_FILE = 'pip-server-ready.txt';
 
 export type ServerTreeItemContextValue = keyof typeof SERVER_TREE_ITEM_CONTEXT;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import type { ConsoleType } from '../types';
+import type { ConsoleType, Port } from '../types';
 
 export const EXTENSION_ID = 'vscode-deephaven' as const;
 
@@ -12,7 +12,13 @@ export const CONFIG_KEY = {
 export const DEFAULT_CONSOLE_TYPE = 'python' as const;
 // export const DHFS_SCHEME = 'dhfs';
 
+export const DEFAULT_PIP_PORT_RANGE: ReadonlySet<Port> = new Set([
+  10001, 10002, 10003, 10004,
+] as Port[]);
+
 export const SERVER_STATUS_CHECK_TIMEOUT = 3000;
+export const PIP_SERVER_STATUS_CHECK_INTERVAL = 3000;
+export const PIP_SERVER_STATUS_CHECK_TIMEOUT = 15000;
 
 export const STATUS_BAR_DISCONNECTED_TEXT = 'Deephaven: Disconnected';
 export const STATUS_BAR_DISCONNECT_TEXT = 'Deephaven: Disconnect';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -30,6 +30,11 @@ export const SERVER_LANGUAGE_SET = new Set([
   'groovy',
 ]) as ReadonlySet<ConsoleType>;
 
+export const PIP_SERVER_SUPPORTED_PLATFORMS = new Set<NodeJS.Platform>([
+  'darwin',
+  'linux',
+]);
+
 export const TMP_DIR_ROOT = path.join(__dirname, '..', 'tmp');
 
 export const VIEW_ID = {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -16,6 +16,8 @@ export const DEFAULT_PIP_PORT_RANGE: ReadonlySet<Port> = new Set([
   10001, 10002, 10003, 10004,
 ] as Port[]);
 
+export const PYTHON_ENV_WAIT = 1500 as const;
+
 export const SERVER_STATUS_CHECK_TIMEOUT = 3000;
 export const PIP_SERVER_STATUS_CHECK_INTERVAL = 3000;
 export const PIP_SERVER_STATUS_CHECK_TIMEOUT = 15000;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -60,11 +60,8 @@ export const CONNECTION_TREE_ITEM_CONTEXT = {
   isUri: 'isUri',
 } as const;
 
-export const GLOBAL_CONTEXT = {
-  canManageServers: 'deephaven.canManageServers',
-};
-
 export const SERVER_TREE_ITEM_CONTEXT = {
+  canStartServer: 'canStartServer',
   isManagedServerConnected: 'isManagedServerConnected',
   isManagedServerConnecting: 'isManagedServerConnecting',
   isManagedServerDisconnected: 'isManagedServerDisconnected',

--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -78,6 +78,17 @@ export class ConnectionController implements Disposable {
       undefined,
       this._context.subscriptions
     );
+
+    this._serverManager.onDidServerStatusChange(
+      server => {
+        // Auto connect to servers managed by extension when they start
+        if (server.isManaged && server.isRunning) {
+          this._serverManager.connectToServer(server.url);
+        }
+      },
+      undefined,
+      this._context.subscriptions
+    );
   };
 
   /**

--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -257,10 +257,11 @@ export class ConnectionController implements Disposable {
       hasConnections: false,
     });
 
-    const connections: IDhService[] = await getConnectionsForConsoleType(
-      this._serverManager.getConnections(),
-      editor.document.languageId as ConsoleType
-    );
+    const connectionsForConsoleType: IDhService[] =
+      await getConnectionsForConsoleType(
+        this._serverManager.getConnections(),
+        editor.document.languageId as ConsoleType
+      );
 
     const editorActiveConnectionUrl = this._serverManager.getUriConnection(
       editor.document.uri
@@ -272,7 +273,7 @@ export class ConnectionController implements Disposable {
       selectedCnResult = await createConnectionQuickPick(
         createConnectionQuickPickOptions(
           runningServersWithoutConnections,
-          connections,
+          connectionsForConsoleType,
           editor.document.languageId,
           editorActiveConnectionUrl
         )

--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import type {
   ConsoleType,
   Disposable,
-  IConfigService,
   IDhService,
   IServerManager,
   IToastService,

--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -11,6 +11,7 @@ import {
   assertDefined,
   createConnectionOption,
   createConnectionQuickPick,
+  createConnectionQuickPickOptions,
   createConnectStatusBarItem,
   getConnectionsForConsoleType,
   getEditorForUri,
@@ -269,10 +270,12 @@ export class ConnectionController implements Disposable {
 
     try {
       selectedCnResult = await createConnectionQuickPick(
-        runningServersWithoutConnections,
-        connections,
-        editor.document.languageId,
-        editorActiveConnectionUrl
+        createConnectionQuickPickOptions(
+          runningServersWithoutConnections,
+          connections,
+          editor.document.languageId,
+          editorActiveConnectionUrl
+        )
       );
 
       if (selectedCnResult == null) {

--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -26,13 +26,11 @@ const logger = new Logger('ConnectionController');
 export class ConnectionController implements Disposable {
   constructor(
     context: vscode.ExtensionContext,
-    configService: IConfigService,
     serverManager: IServerManager,
     outputChannel: vscode.OutputChannel,
     toastService: IToastService
   ) {
     this._context = context;
-    this._config = configService;
     this._serverManager = serverManager;
     this._outputChannel = outputChannel;
     this._toaster = toastService;
@@ -42,7 +40,6 @@ export class ConnectionController implements Disposable {
   }
 
   private readonly _context: vscode.ExtensionContext;
-  private readonly _config: IConfigService;
   private readonly _serverManager: IServerManager;
   private readonly _outputChannel: vscode.OutputChannel;
   private readonly _toaster: IToastService;

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import {
   CONNECT_TO_SERVER_CMD,
+  CREATE_NEW_TEXT_DOC_CMD,
   DISCONNECT_EDITOR_CMD,
   DISCONNECT_FROM_SERVER_CMD,
   DOWNLOAD_LOGS_CMD,
@@ -264,6 +265,9 @@ export class ExtensionController implements Disposable {
     /** Create server connection */
     this.registerCommand(CONNECT_TO_SERVER_CMD, this.onConnectToServer);
 
+    /** Create new document */
+    this.registerCommand(CREATE_NEW_TEXT_DOC_CMD, this.onCreateNewDocument);
+
     /** Disconnect editor */
     this.registerCommand(DISCONNECT_EDITOR_CMD, this.onDisconnectEditor);
 
@@ -395,6 +399,24 @@ export class ExtensionController implements Disposable {
    */
   onConnectToServer = async (serverState: ServerState): Promise<void> => {
     this._serverManager?.connectToServer(serverState.url);
+  };
+
+  /**
+   * Create a new text document based on the given connection capabilities.
+   * @param dhService
+   */
+  onCreateNewDocument = async (dhService: IDhService): Promise<void> => {
+    const language = (await dhService.supportsConsoleType('python'))
+      ? 'python'
+      : 'groovy';
+
+    const doc = await vscode.workspace.openTextDocument({
+      language,
+    });
+
+    const editor = await vscode.window.showTextDocument(doc);
+
+    this._serverManager?.setEditorConnection(editor, dhService);
   };
 
   /**

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -296,12 +296,12 @@ export class ExtensionController implements Disposable {
     );
 
     /** Refresh server tree */
-    this.registerCommand(REFRESH_SERVER_TREE_CMD, this.onRefreshServerTree);
+    this.registerCommand(REFRESH_SERVER_TREE_CMD, this.onRefreshServerTrees);
 
     /** Refresh server connection tree */
     this.registerCommand(
       REFRESH_SERVER_CONNECTION_TREE_CMD,
-      this.onRefreshServerConnectionTree
+      this.onRefreshServerTrees
     );
 
     /** Start a server */
@@ -456,14 +456,11 @@ export class ExtensionController implements Disposable {
     );
   };
 
-  onRefreshServerTree = async (): Promise<void> => {
+  onRefreshServerTrees = async (): Promise<void> => {
+    await this._pipServerController?.syncManagedServers();
     await this._serverManager?.updateStatus();
-    this._pipServerController?.syncManagedServers();
-    this._serverTreeProvider?.refresh();
-  };
 
-  onRefreshServerConnectionTree = async (): Promise<void> => {
-    await this._serverManager?.updateStatus();
+    this._serverConnectionTreeProvider?.refresh();
     this._serverConnectionTreeProvider?.refresh();
   };
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -70,6 +70,7 @@ export class ExtensionController implements Disposable {
     logger.info(
       'Congratulations, your extension "vscode-deephaven" is now active!'
     );
+
     this._outputChannel?.show();
     this._outputChannel?.appendLine('Deephaven extension activated');
   }

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -144,6 +144,7 @@ export class ExtensionController implements Disposable {
     assertDefined(this._toaster, 'toaster');
 
     this._pipServerController = new PipServerController(
+      this._context,
       this._serverManager!,
       [10001, 10002, 10003, 10004],
       this._outputChannel,
@@ -435,6 +436,7 @@ export class ExtensionController implements Disposable {
 
   onRefreshServerTree = async (): Promise<void> => {
     await this._serverManager?.updateStatus();
+    this._pipServerController?.syncManagedServers();
     this._serverTreeProvider?.refresh();
   };
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -502,7 +502,7 @@ export class ExtensionController implements Disposable {
    * Start a server.
    */
   onStartServer = (): void => {
-    this._pipServerController?.startServer();
+    void this._pipServerController?.startServer();
   };
 
   /**

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -226,11 +226,15 @@ export class ExtensionController implements Disposable {
       this._dhcServiceFactory
     );
 
-    this._serverManager.onDidDisconnect(serverUrl => {
-      this._outputChannel?.appendLine(
-        `Disconnected from server: '${serverUrl}'.`
-      );
-    });
+    this._serverManager.onDidDisconnect(
+      serverUrl => {
+        this._outputChannel?.appendLine(
+          `Disconnected from server: '${serverUrl}'.`
+        );
+      },
+      undefined,
+      this._context.subscriptions
+    );
 
     vscode.workspace.onDidChangeConfiguration(
       async () => {

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -501,16 +501,16 @@ export class ExtensionController implements Disposable {
   /**
    * Start a server.
    */
-  onStartServer = (): void => {
-    void this._pipServerController?.startServer();
+  onStartServer = async (): Promise<void> => {
+    await this._pipServerController?.startServer();
   };
 
   /**
    * Stop a server.
    * @param value
    */
-  onStopServer = (value: ServerState): void => {
-    this._pipServerController?.stopServer(value.url);
+  onStopServer = async (value: ServerState): Promise<void> => {
+    await this._pipServerController?.stopServer(value.url);
   };
 
   /**

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -233,9 +233,9 @@ export class ExtensionController implements Disposable {
     });
 
     vscode.workspace.onDidChangeConfiguration(
-      () => {
-        this._serverManager?.loadServerConfig();
-        this._pipServerController?.syncManagedServers();
+      async () => {
+        await this._serverManager?.loadServerConfig();
+        await this.onRefreshServerStatus();
       },
       undefined,
       this._context.subscriptions
@@ -299,12 +299,12 @@ export class ExtensionController implements Disposable {
     );
 
     /** Refresh server tree */
-    this.registerCommand(REFRESH_SERVER_TREE_CMD, this.onRefreshServerTrees);
+    this.registerCommand(REFRESH_SERVER_TREE_CMD, this.onRefreshServerStatus);
 
     /** Refresh server connection tree */
     this.registerCommand(
       REFRESH_SERVER_CONNECTION_TREE_CMD,
-      this.onRefreshServerTrees
+      this.onRefreshServerStatus
     );
 
     /** Start a server */
@@ -459,12 +459,9 @@ export class ExtensionController implements Disposable {
     );
   };
 
-  onRefreshServerTrees = async (): Promise<void> => {
+  onRefreshServerStatus = async (): Promise<void> => {
     await this._pipServerController?.syncManagedServers();
     await this._serverManager?.updateStatus();
-
-    this._serverTreeProvider?.refresh();
-    this._serverConnectionTreeProvider?.refresh();
   };
 
   /**

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import {
   CONNECT_TO_SERVER_CMD,
   CREATE_NEW_TEXT_DOC_CMD,
+  DEFAULT_PIP_PORT_RANGE,
   DISCONNECT_EDITOR_CMD,
   DISCONNECT_FROM_SERVER_CMD,
   DOWNLOAD_LOGS_CMD,
@@ -148,7 +149,7 @@ export class ExtensionController implements Disposable {
     this._pipServerController = new PipServerController(
       this._context,
       this._serverManager!,
-      [10001, 10002, 10003, 10004],
+      DEFAULT_PIP_PORT_RANGE,
       this._outputChannel,
       this._toaster
     );

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -144,11 +144,12 @@ export class ExtensionController implements Disposable {
    */
   initializePipServerController = (): void => {
     assertDefined(this._outputChannel, 'outputChannel');
+    assertDefined(this._serverManager, 'serverManager');
     assertDefined(this._toaster, 'toaster');
 
     this._pipServerController = new PipServerController(
       this._context,
-      this._serverManager!,
+      this._serverManager,
       DEFAULT_PIP_PORT_RANGE,
       this._outputChannel,
       this._toaster

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -463,7 +463,7 @@ export class ExtensionController implements Disposable {
     await this._pipServerController?.syncManagedServers();
     await this._serverManager?.updateStatus();
 
-    this._serverConnectionTreeProvider?.refresh();
+    this._serverTreeProvider?.refresh();
     this._serverConnectionTreeProvider?.refresh();
   };
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -468,20 +468,10 @@ export class ExtensionController implements Disposable {
    * Run all code in editor for given uri.
    * @param uri
    */
-  onRunCode = async (uri: vscode.Uri): Promise<void> => {
-    assertDefined(this._connectionController, 'connectionController');
-
-    const editor = await getEditorForUri(uri);
-    const dhService =
-      await this._connectionController.getOrCreateConnection(uri);
-    await dhService?.runEditorCode(editor);
-  };
-
-  /**
-   * Run selected code in editor for given uri.
-   * @param uri
-   */
-  onRunSelectedCode = async (uri?: vscode.Uri): Promise<void> => {
+  onRunCode = async (
+    uri?: vscode.Uri,
+    selectionOnly?: boolean
+  ): Promise<void> => {
     assertDefined(this._connectionController, 'connectionController');
 
     if (uri == null) {
@@ -495,7 +485,15 @@ export class ExtensionController implements Disposable {
     const editor = await getEditorForUri(uri);
     const dhService =
       await this._connectionController.getOrCreateConnection(uri);
-    await dhService?.runEditorCode(editor, true);
+    await dhService?.runEditorCode(editor, selectionOnly);
+  };
+
+  /**
+   * Run selected code in editor for given uri.
+   * @param uri
+   */
+  onRunSelectedCode = async (uri?: vscode.Uri): Promise<void> => {
+    this.onRunCode(uri, true);
   };
 
   /**

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -485,9 +485,7 @@ export class ExtensionController implements Disposable {
       uri = vscode.window.activeTextEditor?.document.uri;
     }
 
-    if (uri == null) {
-      return;
-    }
+    assertDefined(uri, 'uri');
 
     const editor = await getEditorForUri(uri);
     const dhService =

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -128,7 +128,6 @@ export class ExtensionController implements Disposable {
 
     this._connectionController = new ConnectionController(
       this._context,
-      this._config,
       this._serverManager,
       this._outputChannel,
       this._toaster

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -471,9 +471,12 @@ export class ExtensionController implements Disposable {
   /**
    * Run all code in editor for given uri.
    * @param uri
+   * @param arg
+   * @param selectionOnly
    */
   onRunCode = async (
     uri?: vscode.Uri,
+    _arg?: { groupId: number },
     selectionOnly?: boolean
   ): Promise<void> => {
     assertDefined(this._connectionController, 'connectionController');
@@ -489,15 +492,19 @@ export class ExtensionController implements Disposable {
     const editor = await getEditorForUri(uri);
     const dhService =
       await this._connectionController.getOrCreateConnection(uri);
-    await dhService?.runEditorCode(editor, selectionOnly);
+    await dhService?.runEditorCode(editor, selectionOnly === true);
   };
 
   /**
    * Run selected code in editor for given uri.
    * @param uri
+   * @param arg
    */
-  onRunSelectedCode = async (uri?: vscode.Uri): Promise<void> => {
-    this.onRunCode(uri, true);
+  onRunSelectedCode = async (
+    uri?: vscode.Uri,
+    arg?: { groupId: number }
+  ): Promise<void> => {
+    this.onRunCode(uri, arg, true);
   };
 
   /**

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -5,9 +5,10 @@ import {
   PIP_SERVER_STATUS_CHECK_INTERVAL,
   PIP_SERVER_STATUS_CHECK_TIMEOUT,
   PIP_SERVER_SUPPORTED_PLATFORMS,
+  PYTHON_ENV_WAIT,
 } from '../common';
 import { isDhcServerRunning } from '../dh/dhc';
-import { pollUntilTrue } from '../util/promiseUtils';
+import { pollUntilTrue, waitFor } from '../util/promiseUtils';
 
 const logger = new Logger('PipServerController');
 
@@ -68,7 +69,7 @@ export class PipServerController implements Disposable {
         });
 
         // Give python extension time to setup .venv if configured
-        await waitFor(1500);
+        await waitFor(PYTHON_ENV_WAIT);
 
         // Attempt to import deephaven_server to see if it's installed and exit
         // with code 2 if it fails.
@@ -148,7 +149,7 @@ export class PipServerController implements Disposable {
     this.syncManagedServers();
 
     // Give python extension time to setup .venv if configured
-    await waitFor(1000);
+    await waitFor(PYTHON_ENV_WAIT);
 
     terminal.sendText(`python -c 'import deephaven_server;' || exit 2`);
 
@@ -209,8 +210,4 @@ export class PipServerController implements Disposable {
   dispose = async (): Promise<void> => {
     this.disposeServers(this._serverUrlTerminalMap.keys());
   };
-}
-
-function waitFor(waitMs: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, waitMs));
 }

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -126,11 +126,11 @@ export class PipServerController implements Disposable {
 
     try {
       await promise;
+      logger.debug(`Pip server started: '${serverUrl}'`);
     } catch (err) {
       logger.error(err);
+      this.disposeServers([port]);
     }
-
-    logger.debug(`Pip server started: '${serverUrl}'`);
 
     this._pollers.delete(port);
     void this._serverManager.updateStatus([serverUrl]);

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -44,6 +44,7 @@ export class PipServerController implements Disposable {
   private readonly _serverManager: IServerManager;
   private readonly _toaster: IToastService;
   private _checkPipInstallPromise: Promise<boolean> | null = null;
+  private _isPipServerInstalled = false;
 
   /**
    * Start a terminal and attempt an import of `deephaven_server` to check if
@@ -149,12 +150,14 @@ export class PipServerController implements Disposable {
   };
 
   syncManagedServers = async (): Promise<void> => {
-    const canManageServers = await this.checkPipInstall();
+    if (!this._isPipServerInstalled) {
+      this._isPipServerInstalled = await this.checkPipInstall();
+    }
 
     this._serverManager.canStartServer =
-      canManageServers && this.getAvailablePorts().length > 0;
+      this._isPipServerInstalled && this.getAvailablePorts().length > 0;
 
-    if (!canManageServers) {
+    if (!this._isPipServerInstalled) {
       this._serverManager.syncManagedServers([]);
       return;
     }

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -165,12 +165,12 @@ export class PipServerController implements Disposable {
     await this.pollUntilServerStarts(port);
   };
 
-  stopServer = (url: URL): void => {
+  stopServer = async (url: URL): Promise<void> => {
     this._serverManager.disconnectFromServer(url);
 
     const port = parsePort(url.port);
 
-    this.disposeServers([port]);
+    await this.disposeServers([port]);
   };
 
   syncManagedServers = async (): Promise<void> => {

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -129,7 +129,7 @@ export class PipServerController implements Disposable {
       logger.debug(`Pip server started: '${serverUrl}'`);
     } catch (err) {
       logger.error(err);
-      this.disposeServers([port]);
+      void this.disposeServers([port]);
     }
 
     this._pollers.delete(port);

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -43,7 +43,6 @@ export class PipServerController implements Disposable {
   private readonly _serverUrlTerminalMap: Map<Port, vscode.Terminal>;
   private readonly _serverManager: IServerManager;
   private readonly _toaster: IToastService;
-  private readonly _failedServerStarts: Set<vscode.Terminal> = new Set();
   private _checkPipInstallPromise: Promise<boolean> | null = null;
 
   /**
@@ -173,11 +172,6 @@ export class PipServerController implements Disposable {
       terminal.dispose();
     }
     this._serverUrlTerminalMap.clear();
-
-    for (const terminal of this._failedServerStarts) {
-      terminal.dispose();
-    }
-    this._failedServerStarts.clear();
 
     await this.syncManagedServers();
   };

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -1,0 +1,149 @@
+import * as vscode from 'vscode';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getTempDir } from '../util';
+import type { Disposable, IServerManager } from '../types';
+import { PIP_SERVER_STATUS_DIRECTORY, PIP_SERVER_STATUS_FILE } from '../common';
+import { PollingService } from '../services';
+
+type Port = number;
+
+export class PipServerController implements Disposable {
+  constructor(serverManager: IServerManager, portRange: number[]) {
+    this._poller = new PollingService();
+    this._portRange = new Set(portRange);
+    this._serverTerminalMap = new Map();
+    this._serverManager = serverManager;
+
+    this._poller.start(this.syncManagedServers, 10000);
+  }
+
+  private _isEnvironmentReadyPromise: Promise<boolean> | null = null;
+  private _isEnvironmentReadyCheckTerminal: vscode.Terminal | null = null;
+
+  private readonly _poller: PollingService;
+  private readonly _portRange: Set<Port>;
+  private readonly _serverTerminalMap: Map<Port, vscode.Terminal>;
+  private readonly _serverManager: IServerManager;
+
+  /**
+   * Attempt to run `deephaven` command in a new terminal and create a tmp file
+   * if successful. Then check for the existence of the tmp file to determine
+   * if the environment is ready.
+   */
+  private _checkIsEnvironmentReady = (): Promise<boolean> => {
+    return new Promise(async resolve => {
+      const cwd = getTempDir(false, PIP_SERVER_STATUS_DIRECTORY);
+      const statusFileName = PIP_SERVER_STATUS_FILE;
+      const statusFilePath = path.join(cwd, statusFileName);
+
+      if (this._isEnvironmentReadyCheckTerminal == null) {
+        this._isEnvironmentReadyCheckTerminal = vscode.window.createTerminal({
+          name: 'Deephaven: Check Pip Environment',
+          cwd,
+          isTransient: true,
+        });
+      }
+
+      try {
+        fs.unlinkSync(statusFilePath);
+      } catch {}
+
+      // Give python extension time to setup .venv if configured
+      await waitFor(1000);
+
+      this._isEnvironmentReadyCheckTerminal.sendText(
+        `deephaven && echo ready > ${statusFileName}`
+      );
+
+      // Wait for status check to run
+      await waitFor(2000);
+
+      const isReady = fs.existsSync(statusFilePath);
+
+      resolve(isReady);
+    });
+  };
+
+  getAvailablePorts = (): Port[] => {
+    return [...this._portRange]
+      .filter(port => !this._serverTerminalMap.has(port))
+      .sort();
+  };
+
+  isEnvironmentReady = async (): Promise<boolean> => {
+    if (this._isEnvironmentReadyPromise == null) {
+      this._isEnvironmentReadyPromise = this._checkIsEnvironmentReady();
+
+      this._isEnvironmentReadyPromise.then(() => {
+        this._isEnvironmentReadyPromise = null;
+      });
+    }
+
+    return this._isEnvironmentReadyPromise;
+  };
+
+  startServer = async (): Promise<void> => {
+    const [port] = this.getAvailablePorts();
+
+    if (port == null) {
+      throw new Error('No available ports');
+    }
+
+    const terminal = vscode.window.createTerminal({
+      name: `Deephaven Server (${port})`,
+      env: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        PYTHONPATH: './',
+      },
+      isTransient: true,
+    });
+
+    this._serverTerminalMap.set(port, terminal);
+
+    // Give python extension time to setup .venv if configured
+    await waitFor(1000);
+
+    terminal.sendText(
+      [
+        'deephaven server',
+        '--jvm-args "-DAuthHandlers=io.deephaven.auth.AnonymousAuthenticationHandler -Dprocess.info.system-info.enabled=false"',
+        `--port ${port}`,
+        '--no-browser',
+      ].join(' ')
+    );
+  };
+
+  stopServer = (url: URL): void => {
+    this._serverManager.disconnectFromServer(url);
+
+    const port = Number(url.port);
+
+    const terminal = this._serverTerminalMap.get(port);
+
+    if (terminal == null) {
+      return;
+    }
+
+    terminal.dispose();
+    this._serverTerminalMap.delete(port);
+  };
+
+  syncManagedServers = async (): Promise<void> => {
+    if (!(await this.isEnvironmentReady())) {
+      return;
+    }
+
+    const ports = this.getAvailablePorts();
+
+    this._serverManager.addManagedServers(
+      ports.map(port => new URL(`http://localhost:${port}`))
+    );
+  };
+
+  dispose = async (): Promise<void> => {};
+}
+
+function waitFor(waitMs: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, waitMs));
+}

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,3 +1,4 @@
 export * from './ConnectionController';
 export * from './ExtensionController';
+export * from './PipServerController';
 export * from './ServerConnectionTreeDragAndDropController';

--- a/src/providers/ServerTreeProvider.ts
+++ b/src/providers/ServerTreeProvider.ts
@@ -50,6 +50,10 @@ export class ServerTreeProvider extends TreeDataProviderBase<ServerNode> {
         label: element,
         iconPath: new vscode.ThemeIcon(ICON_ID.server),
         collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+        contextValue:
+          element === 'Managed' && this.serverManager.canStartServer
+            ? SERVER_TREE_ITEM_CONTEXT.canStartServer
+            : undefined,
       };
     }
 
@@ -95,14 +99,10 @@ export class ServerTreeProvider extends TreeDataProviderBase<ServerNode> {
     const managedServers = [];
     const runningServers = [];
     const stoppedServers = [];
-    let hasManaged = false;
 
     for (const server of servers) {
       if (server.isManaged) {
-        hasManaged = true;
-        // if (server.isRunning) {
         managedServers.push(server);
-        // }
       } else if (server.isRunning) {
         runningServers.push(server);
       } else {
@@ -114,7 +114,9 @@ export class ServerTreeProvider extends TreeDataProviderBase<ServerNode> {
     if (elementOrRoot == null) {
       // Only show groups that contain server child nodes
       return [
-        hasManaged ? ('Managed' as const) : undefined,
+        this.serverManager.canStartServer || managedServers.length > 0
+          ? ('Managed' as const)
+          : undefined,
         runningServers.length === 0 ? undefined : ('Running' as const),
         stoppedServers.length === 0 ? undefined : ('Stopped' as const),
       ].filter(child => child != null);

--- a/src/providers/ServerTreeProvider.ts
+++ b/src/providers/ServerTreeProvider.ts
@@ -6,7 +6,7 @@ import {
 } from '../common';
 import { TreeDataProviderBase } from './TreeDataProviderBase';
 import type { ServerGroupState, ServerNode } from '../types/treeViewTypes';
-import { getServerDescription } from '../util';
+import { getServerDescription, getServerIconPath } from '../util';
 
 function isServerGroupState(node: ServerNode): node is ServerGroupState {
   return typeof node === 'string';
@@ -77,13 +77,7 @@ export class ServerTreeProvider extends TreeDataProviderBase<ServerNode> {
       tooltip: canConnect ? `Click to connect to ${urlStr}` : urlStr,
       contextValue: element.type === 'DHC' ? contextValue : undefined,
       iconPath: new vscode.ThemeIcon(
-        isRunning
-          ? isConnected
-            ? ICON_ID.serverConnected
-            : ICON_ID.serverRunning
-          : isManaged
-            ? ICON_ID.connecting
-            : ICON_ID.serverStopped
+        getServerIconPath({ isConnected, isManaged, isRunning })
       ),
       command: canConnect
         ? {

--- a/src/providers/ServerTreeProvider.ts
+++ b/src/providers/ServerTreeProvider.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
-import { ICON_ID, SERVER_TREE_ITEM_CONTEXT } from '../common';
 import { TreeDataProviderBase } from './TreeDataProviderBase';
 import type { ServerGroupState, ServerNode } from '../types/treeViewTypes';
 import {
-  getServerContextValue,
-  getServerDescription,
-  getServerIconPath,
+  assertNever,
+  getServerGroupTreeItem,
+  getServerTreeItem,
+  groupServers,
 } from '../util';
 
 function isServerGroupState(node: ServerNode): node is ServerGroupState {
@@ -20,90 +20,59 @@ export class ServerTreeProvider extends TreeDataProviderBase<ServerNode> {
     element: ServerNode
   ): vscode.TreeItem | Thenable<vscode.TreeItem> {
     if (isServerGroupState(element)) {
-      return {
-        label: element,
-        iconPath: new vscode.ThemeIcon(ICON_ID.server),
-        collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
-        contextValue:
-          element === 'Managed' && this.serverManager.canStartServer
-            ? SERVER_TREE_ITEM_CONTEXT.canStartServer
-            : undefined,
-      };
+      return getServerGroupTreeItem(element, this.serverManager.canStartServer);
     }
 
     const isConnected = this.serverManager.hasConnection(element.url);
     const isManaged = element.isManaged ?? false;
     const isRunning = element.isRunning ?? false;
-    const contextValue = getServerContextValue({
+
+    return getServerTreeItem({
+      server: element,
       isConnected,
       isManaged,
       isRunning,
     });
-    const canConnect =
-      contextValue === SERVER_TREE_ITEM_CONTEXT.isManagedServerDisconnected ||
-      contextValue === SERVER_TREE_ITEM_CONTEXT.isServerRunningDisconnected;
-    const urlStr = element.url.toString();
-    const description = getServerDescription(
-      isConnected ? 1 : 0,
-      isManaged,
-      element.label
-    );
-
-    return {
-      label: new URL(urlStr).host,
-      description,
-      tooltip: canConnect ? `Click to connect to ${urlStr}` : urlStr,
-      contextValue: element.type === 'DHC' ? contextValue : undefined,
-      iconPath: new vscode.ThemeIcon(
-        getServerIconPath({ isConnected, isManaged, isRunning })
-      ),
-      command: canConnect
-        ? {
-            title: 'Open in Browser',
-            command: 'vscode-deephaven.connectToServer',
-            arguments: [element],
-          }
-        : undefined,
-    };
   }
 
   getChildren(elementOrRoot?: ServerNode): vscode.ProviderResult<ServerNode[]> {
-    const servers = this.serverManager.getServers();
-
-    const managedServers = [];
-    const runningServers = [];
-    const stoppedServers = [];
-
-    for (const server of servers) {
-      if (server.isManaged) {
-        managedServers.push(server);
-      } else if (server.isRunning) {
-        runningServers.push(server);
-      } else {
-        stoppedServers.push(server);
-      }
-    }
+    const { managed, running, stopped } = groupServers(
+      this.serverManager.getServers()
+    );
 
     // Root node
     if (elementOrRoot == null) {
-      // Only show groups that contain server child nodes
-      return [
-        this.serverManager.canStartServer || managedServers.length > 0
-          ? ('Managed' as const)
-          : undefined,
-        runningServers.length === 0 ? undefined : ('Running' as const),
-        stoppedServers.length === 0 ? undefined : ('Stopped' as const),
-      ].filter(child => child != null);
+      const children: ServerGroupState[] = [];
+
+      if (managed.length > 0 || this.serverManager.canStartServer) {
+        children.push('Managed');
+      }
+
+      if (running.length > 0) {
+        children.push('Running');
+      }
+
+      if (stopped.length > 0) {
+        children.push('Stopped');
+      }
+
+      return children;
     }
 
     if (isServerGroupState(elementOrRoot)) {
-      return {
-        /* eslint-disable @typescript-eslint/naming-convention */
-        Managed: managedServers,
-        Running: runningServers,
-        Stopped: stoppedServers,
-        /* eslint-enable @typescript-eslint/naming-convention */
-      }[elementOrRoot];
+      switch (elementOrRoot) {
+        case 'Managed':
+          return managed;
+
+        case 'Running':
+          return running;
+
+        case 'Stopped':
+          return stopped;
+
+        default:
+          assertNever(elementOrRoot, 'elementOrRoot');
+      }
     }
   }
 }

--- a/src/providers/ServerTreeProvider.ts
+++ b/src/providers/ServerTreeProvider.ts
@@ -1,41 +1,15 @@
 import * as vscode from 'vscode';
-import {
-  ICON_ID,
-  SERVER_TREE_ITEM_CONTEXT,
-  type ServerTreeItemContextValue,
-} from '../common';
+import { ICON_ID, SERVER_TREE_ITEM_CONTEXT } from '../common';
 import { TreeDataProviderBase } from './TreeDataProviderBase';
 import type { ServerGroupState, ServerNode } from '../types/treeViewTypes';
-import { getServerDescription, getServerIconPath } from '../util';
+import {
+  getServerContextValue,
+  getServerDescription,
+  getServerIconPath,
+} from '../util';
 
 function isServerGroupState(node: ServerNode): node is ServerGroupState {
   return typeof node === 'string';
-}
-
-function getServerContextValue({
-  isConnected,
-  isManaged,
-  isRunning,
-}: {
-  isConnected: boolean;
-  isManaged: boolean;
-  isRunning: boolean;
-}): ServerTreeItemContextValue {
-  if (isManaged) {
-    return isConnected
-      ? SERVER_TREE_ITEM_CONTEXT.isManagedServerConnected
-      : isRunning
-        ? SERVER_TREE_ITEM_CONTEXT.isManagedServerDisconnected
-        : SERVER_TREE_ITEM_CONTEXT.isManagedServerConnecting;
-  }
-
-  if (isRunning) {
-    return isConnected
-      ? SERVER_TREE_ITEM_CONTEXT.isServerRunningConnected
-      : SERVER_TREE_ITEM_CONTEXT.isServerRunningDisconnected;
-  }
-
-  return SERVER_TREE_ITEM_CONTEXT.isServerStopped;
 }
 
 /**

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -16,6 +16,10 @@ const logger = new Logger('DhcService');
 export class DhcService extends DhService<typeof DhcType, DhcType.CoreClient> {
   private psk?: string;
 
+  setPsk(psk: string): void {
+    this.psk = psk;
+  }
+
   protected async initApi(): Promise<typeof DhcType> {
     return initDhcApi(this.serverUrl);
   }
@@ -44,18 +48,18 @@ export class DhcService extends DhService<typeof DhcType, DhcType.CoreClient> {
         type: dh.CoreClient.LOGIN_TYPE_ANONYMOUS,
       });
     } else if (authConfig.has(AUTH_HANDLER_TYPE_PSK)) {
-      const token = await vscode.window.showInputBox({
-        placeHolder: 'Pre-Shared Key',
-        prompt: 'Enter your Deephaven pre-shared key',
-        password: true,
-      });
+      if (this.psk == null) {
+        this.psk = await vscode.window.showInputBox({
+          placeHolder: 'Pre-Shared Key',
+          prompt: 'Enter your Deephaven pre-shared key',
+          password: true,
+        });
+      }
 
       const connectionAndSession = await initDhcSession(client, {
         type: 'io.deephaven.authentication.psk.PskAuthenticationHandler',
-        token,
+        token: this.psk,
       });
-
-      this.psk = token;
 
       return connectionAndSession;
     }

--- a/src/services/DhcServiceFactory.ts
+++ b/src/services/DhcServiceFactory.ts
@@ -14,13 +14,19 @@ export class DhcServiceFactory implements IDhServiceFactory {
     private toaster: IToastService
   ) {}
 
-  create = (serverUrl: URL): DhcService => {
-    return new DhcService(
+  create = (serverUrl: URL, psk?: string): DhcService => {
+    const dhService = new DhcService(
       serverUrl,
       this.panelRegistry,
       this.diagnosticsCollection,
       this.outputChannel,
       this.toaster
     );
+
+    if (psk != null) {
+      dhService.setPsk(psk);
+    }
+
+    return dhService;
   };
 }

--- a/src/services/SerializedKeyMap.spec.ts
+++ b/src/services/SerializedKeyMap.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SerializedKeyMap } from './SerializedKeyMap';
+
+describe('SerializedKeyMap', () => {
+  const deserializeKey = (key: string): Object => JSON.parse(key);
+  const serializeKey = (key: Object): string => JSON.stringify(key);
+
+  class JsonKeyMap extends SerializedKeyMap<Object, string> {
+    deserializeKey = deserializeKey;
+    serializeKey = serializeKey;
+  }
+
+  const keyA = () => ({ a: 1 }) as const;
+  const keyB = () => ({ b: 2 }) as const;
+
+  it('should key data by value equality', () => {
+    const instance = new JsonKeyMap();
+
+    expect(instance.has(keyA())).toBe(false);
+
+    instance.set(keyA(), 'value-a');
+
+    expect(instance.has(keyA())).toBe(true);
+    expect(instance.get(keyA())).toBe('value-a');
+
+    instance.delete(keyA());
+    expect(instance.has(keyA())).toBe(false);
+  });
+
+  describe('entries', () => {
+    it('should provide value equality entries', () => {
+      const instance = new JsonKeyMap();
+
+      const a = keyA();
+      const b = keyB();
+
+      instance.set(a, 'value-a');
+      instance.set(b, 'value-b');
+
+      const entries = [...instance.entries()];
+
+      expect(entries[0][0]).not.toBe(a);
+      expect(entries[1][0]).not.toBe(b);
+      expect(entries).toEqual([
+        [a, 'value-a'],
+        [b, 'value-b'],
+      ]);
+    });
+  });
+
+  describe('keys', () => {
+    it('should provide value equality keys', () => {
+      const instance = new JsonKeyMap();
+
+      const a = keyA();
+      const b = keyB();
+
+      instance.set(a, 'value-a');
+      instance.set(b, 'value-b');
+
+      const keys = [...instance.keys()];
+      expect(keys[0]).not.toBe(a);
+      expect(keys[1]).not.toBe(b);
+      expect(keys).toEqual([a, b]);
+    });
+  });
+
+  describe('forEach', () => {
+    it.each([undefined, {}])(
+      'should pass value equality keys to callback: %o',
+      thisArg => {
+        const instance = new JsonKeyMap();
+
+        instance.set(keyA(), 'value-a');
+        instance.set(keyB(), 'value-b');
+
+        const callbackFn = vi.fn();
+
+        instance.forEach(callbackFn, thisArg);
+
+        expect(callbackFn).toHaveBeenCalledTimes(2);
+
+        expect(callbackFn).toHaveBeenCalledWith('value-a', keyA(), thisArg);
+        expect(callbackFn).toHaveBeenCalledWith('value-b', keyB(), thisArg);
+      }
+    );
+  });
+
+  describe('values', () => {
+    it('should provide values', () => {
+      const instance = new JsonKeyMap();
+
+      instance.set(keyA(), 'value-a');
+      instance.set(keyB(), 'value-b');
+
+      const values = [...instance.values()];
+
+      expect(values).toEqual(['value-a', 'value-b']);
+    });
+  });
+});

--- a/src/services/SerializedKeyMap.ts
+++ b/src/services/SerializedKeyMap.ts
@@ -42,6 +42,21 @@ export abstract class SerializedKeyMap<TKey, TValue> {
     return this._map.delete(this.serializeKey(key));
   }
 
+  forEach(
+    callback: (value: TValue, key: TKey, map: Map<TKey, TValue>) => void,
+    thisArg?: any
+  ): void {
+    this._map.forEach((value, key) => {
+      callback(value, this.deserializeKey(key), thisArg);
+    }, thisArg);
+  }
+
+  *entries(): IterableIterator<[TKey, TValue]> {
+    for (const [key, value] of this._map.entries()) {
+      yield [this.deserializeKey(key), value];
+    }
+  }
+
   *keys(): IterableIterator<TKey> {
     for (const key of this._map.keys()) {
       yield this.deserializeKey(key);

--- a/src/services/SerializedKeyMap.ts
+++ b/src/services/SerializedKeyMap.ts
@@ -1,0 +1,54 @@
+/**
+ * Base class for Maps that need to store their keys as serialized string values
+ * internally for equality checks. Externally, the keys are deserialized back to
+ * their original type. Note that the implementation of `deserializeKey` will
+ * determine whether keys with the same serialized value maintain reference
+ * equality (in most cases they will not).
+ *
+ * // New reference on every call
+ * e.g. deserializeKey = (key: string) => new URL(key)
+ */
+export abstract class SerializedKeyMap<TKey, TValue> {
+  constructor();
+  constructor(entries: readonly (readonly [TKey, TValue])[] | null);
+  constructor(entries?: readonly (readonly [TKey, TValue])[] | null) {
+    this._map = new Map(
+      entries?.map(([key, value]) => [this.serializeKey(key), value])
+    );
+  }
+
+  private readonly _map: Map<string, TValue>;
+
+  /** Serialize from a key to a string. */
+  protected abstract serializeKey(key: TKey): string;
+
+  /** Deserialize from a string to a key. */
+  protected abstract deserializeKey(key: string): TKey;
+
+  get(key: TKey): TValue | undefined {
+    return this._map.get(this.serializeKey(key));
+  }
+
+  set(key: TKey, value: TValue): this {
+    this._map.set(this.serializeKey(key), value);
+    return this;
+  }
+
+  has(key: TKey): boolean {
+    return this._map.has(this.serializeKey(key));
+  }
+
+  delete(key: TKey): boolean {
+    return this._map.delete(this.serializeKey(key));
+  }
+
+  *keys(): IterableIterator<TKey> {
+    for (const key of this._map.keys()) {
+      yield this.deserializeKey(key);
+    }
+  }
+
+  *values(): IterableIterator<TValue> {
+    yield* this._map.values();
+  }
+}

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -26,7 +26,8 @@ export class ServerManager implements IServerManager {
     this._serverMap = new URLMap();
     this._connectionMap = new URLMap();
     this._uriConnectionsMap = new Map();
-    this._poller = new PollingService();
+
+    this.canStartServer = false;
 
     this.loadServerConfig();
 
@@ -56,6 +57,8 @@ export class ServerManager implements IServerManager {
   readonly onDidUpdate = this._onDidUpdate.event;
 
   private _hasEverUpdatedStatus = false;
+
+  canStartServer: boolean;
 
   loadServerConfig = (): void => {
     const initialDhcServerState = getInitialServerStates(

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -274,10 +274,21 @@ export class ServerManager implements IServerManager {
     this._onDidUpdate.fire();
   };
 
-  updateStatus = async (): Promise<void> => {
+  /**
+   * Update server statuses. Optionally filter servers to update by a list of urls.
+   * @param filterBy Optional list of urls to filter servers by.
+   */
+  updateStatus = async (filterBy?: URL[]): Promise<void> => {
     logger.debug('Updating server statuses.');
 
-    const promises = this.getServers().map(async server => {
+    let servers = this.getServers();
+
+    if (filterBy != null) {
+      const filterSet = new Set(filterBy.map(String));
+      servers = servers.filter(server => filterSet.has(server.url.toString()));
+    }
+
+    const promises = servers.map(async server => {
       const isRunning = await (server.type === 'DHC'
         ? isDhcServerRunning(server.url)
         : isDheServerRunning(server.url));

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -35,7 +35,7 @@ export class ServerManager implements IServerManager {
   }
 
   private readonly _configService: IConfigService;
-  private readonly _connectionMap: Map<URL, IDhService>;
+  private readonly _connectionMap: URLMap<IDhService>;
   private readonly _dhcServiceFactory: IDhServiceFactory;
   private readonly _uriConnectionsMap: Map<vscode.Uri, IDhService>;
   private _serverMap: URLMap<ServerState>;

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -27,6 +27,10 @@ export class ServerManager implements IServerManager {
   private readonly _onDidDisconnect = new vscode.EventEmitter<URL>();
   readonly onDidDisconnect = this._onDidDisconnect.event;
 
+  private readonly _onDidServerStatusChange =
+    new vscode.EventEmitter<ServerState>();
+  readonly onDidServerStatusChange = this._onDidServerStatusChange.event;
+
   private readonly _onDidRegisterEditor = new vscode.EventEmitter<vscode.Uri>();
   readonly onDidRegisterEditor = this._onDidRegisterEditor.event;
 

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { randomUUID } from 'node:crypto';
 import { UnsupportedConsoleTypeError } from '../common';
 import { isDhcServerRunning } from '../dh/dhc';
 import { isDheServerRunning } from '../dh/dhe';
@@ -101,7 +102,10 @@ export class ServerManager implements IServerManager {
       return null;
     }
 
-    const connection = this._dhcServiceFactory.create(serverUrl);
+    const connection = this._dhcServiceFactory.create(
+      serverUrl,
+      serverState.isManaged ? serverState.psk : undefined
+    );
 
     this._connectionMap.set(serverUrl, connection);
     this._onDidUpdate.fire();
@@ -170,6 +174,15 @@ export class ServerManager implements IServerManager {
    */
   hasEverUpdatedStatus = (): boolean => {
     return this._hasEverUpdatedStatus;
+  };
+
+  /**
+   * Get the server state for the given URL.
+   * @param serverUrl The URL of the server to get.
+   * @returns The server state, or `undefined` if no server with the given URL exists.
+   */
+  getServer = (serverUrl: URL): ServerState | undefined => {
+    return this._serverMap.get(serverUrl);
   };
 
   getServers = ({
@@ -266,6 +279,7 @@ export class ServerManager implements IServerManager {
       this._serverMap.set(server.url, {
         ...server,
         isManaged: true,
+        psk: randomUUID(),
       });
     }
 

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -30,9 +30,7 @@ export class ServerManager implements IServerManager {
 
     this.canStartServer = false;
 
-    this.loadServerConfig();
-
-    this.loadServerConfig();
+    void this.loadServerConfig();
   }
 
   private readonly _configService: IConfigService;
@@ -61,7 +59,7 @@ export class ServerManager implements IServerManager {
 
   canStartServer: boolean;
 
-  loadServerConfig = (): void => {
+  loadServerConfig = async (): Promise<void> => {
     const initialDhcServerState = getInitialServerStates(
       'DHC',
       this._configService.getCoreServers()
@@ -87,7 +85,7 @@ export class ServerManager implements IServerManager {
       }
     }
 
-    this.updateStatus();
+    await this.updateStatus();
   };
 
   connectToServer = async (serverUrl: URL): Promise<IDhService | null> => {

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -78,6 +78,16 @@ export class ServerManager implements IServerManager {
     this.updateStatus();
   };
 
+  addManagedServers = (urls: URL[]): void => {
+    for (const server of getInitialServerStates('DHC', urls)) {
+      if (!this._serverMap.has(server.url)) {
+        this._serverMap.set(server.url, { ...server, isManaged: true });
+      }
+    }
+
+    this._onDidUpdate.fire();
+  };
+
   connectToServer = async (serverUrl: URL): Promise<IDhService | null> => {
     if (this.hasConnection(serverUrl)) {
       logger.info('Already connected to server:', serverUrl);

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -291,14 +291,14 @@ export class ServerManager implements IServerManager {
         ? isDhcServerRunning(server.url)
         : isDheServerRunning(server.url));
 
-      const newServerState = {
-        ...server,
-        isRunning,
-      };
+      if ((server.isRunning ?? false) !== isRunning) {
+        const newServerState = {
+          ...server,
+          isRunning,
+        };
 
-      this._serverMap.set(server.url, newServerState);
+        this._serverMap.set(server.url, newServerState);
 
-      if ((server.isRunning ?? false) !== newServerState.isRunning) {
         // If server goes from running to stopped, get rid of any active
         // connections to it.
         if (!newServerState.isRunning) {

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types';
 import { getInitialServerStates, Logger } from '../util';
 import { URLMap } from './URLMap';
+import { URIMap } from './URIMap';
 
 const logger = new Logger('ServerManager');
 
@@ -25,7 +26,7 @@ export class ServerManager implements IServerManager {
 
     this._serverMap = new URLMap();
     this._connectionMap = new URLMap();
-    this._uriConnectionsMap = new Map();
+    this._uriConnectionsMap = new URIMap();
 
     this.canStartServer = false;
 
@@ -37,7 +38,7 @@ export class ServerManager implements IServerManager {
   private readonly _configService: IConfigService;
   private readonly _connectionMap: URLMap<IDhService>;
   private readonly _dhcServiceFactory: IDhServiceFactory;
-  private readonly _uriConnectionsMap: Map<vscode.Uri, IDhService>;
+  private readonly _uriConnectionsMap: URIMap<IDhService>;
   private _serverMap: URLMap<ServerState>;
 
   private readonly _onDidConnect = new vscode.EventEmitter<URL>();

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -301,7 +301,7 @@ export class ServerManager implements IServerManager {
       if ((server.isRunning ?? false) !== newServerState.isRunning) {
         // If server goes from running to stopped, get rid of any active
         // connections to it.
-        if (!isRunning) {
+        if (!newServerState.isRunning) {
           void this.disconnectFromServer(server.url);
         }
 

--- a/src/services/URIMap.ts
+++ b/src/services/URIMap.ts
@@ -1,0 +1,17 @@
+import * as vscode from 'vscode';
+import { SerializedKeyMap } from './SerializedKeyMap';
+
+/**
+ * Map that uses `vscode.Uri`s as keys. Internally serializes keys to strings
+ * for value equality. Since keys are deserialized back to uris, they will not
+ * maintain reference equalty with original keys.
+ */
+export class URIMap<T> extends SerializedKeyMap<vscode.Uri, T> {
+  deserializeKey(uriString: string): vscode.Uri {
+    return vscode.Uri.parse(uriString);
+  }
+
+  serializeKey(uri: vscode.Uri): string {
+    return uri.toString();
+  }
+}

--- a/src/services/URLMap.ts
+++ b/src/services/URLMap.ts
@@ -1,0 +1,16 @@
+import { SerializedKeyMap } from './SerializedKeyMap';
+
+/**
+ * Map that uses URLs as keys. Internally serializes keys to strings for value
+ * equality. Since keys are deserialized back to URLs, they will not maintain
+ * reference equalty with original keys.
+ */
+export class URLMap<T> extends SerializedKeyMap<URL, T> {
+  deserializeKey(urlString: string): URL {
+    return new URL(urlString);
+  }
+
+  serializeKey(url: URL): string {
+    return url.toString();
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,4 +3,6 @@ export * from './DhService';
 export * from './DhcService';
 export * from './DhcServiceFactory';
 export * from './PollingService';
+export * from './SerializedKeyMap';
 export * from './ServerManager';
+export * from './URLMap';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,4 +5,5 @@ export * from './DhcServiceFactory';
 export * from './PollingService';
 export * from './SerializedKeyMap';
 export * from './ServerManager';
+export * from './URIMap';
 export * from './URLMap';

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -6,6 +6,8 @@ export type Brand<T extends string, TBase = string> = TBase & {
   readonly [__brand]: T;
 };
 
+export type Port = Brand<'Port', number>;
+
 export type ConnectionType = 'DHC';
 
 export type ConnectionAndSession<TConnection, TSession> = {

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -37,6 +37,11 @@ export interface EnterpriseConnectionConfig {
   url: URL;
 }
 
+export type ServerConnectionConfig =
+  | CoreConnectionConfig
+  | EnterpriseConnectionConfig
+  | URL;
+
 export interface Disposable {
   dispose(): Promise<void>;
 }

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -55,10 +55,18 @@ export type UnsubscribeEventListener = () => void;
 
 export type ServerType = 'DHC' | 'DHE';
 
-export interface ServerState {
+export interface UnmanagedServerState {
+  isManaged?: false;
+}
+
+export interface ManagedServerState {
+  isManaged: true;
+  psk: string;
+}
+
+export type ServerState = {
   type: ServerType;
   url: URL;
   label?: string;
-  isManaged?: boolean;
   isRunning?: boolean;
-}
+} & (UnmanagedServerState | ManagedServerState);

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -42,6 +42,10 @@ export type ServerConnectionConfig =
   | EnterpriseConnectionConfig
   | URL;
 
+export interface ServerConnection {
+  readonly serverUrl: URL;
+}
+
 export interface Disposable {
   dispose(): Promise<void>;
 }

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -41,6 +41,7 @@ export interface ServerState {
   type: ServerType;
   url: URL;
   label?: string;
+  isManaged?: boolean;
   isRunning?: boolean;
 }
 

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -58,13 +58,3 @@ export interface ServerState {
   isManaged?: boolean;
   isRunning?: boolean;
 }
-
-export type SeparatorPickItem = {
-  label: string;
-  kind: vscode.QuickPickItemKind.Separator;
-};
-
-export type ConnectionPickItem<TType, TData> = vscode.QuickPickItem & {
-  type: TType;
-  data: TData;
-};

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -1,5 +1,11 @@
 import * as vscode from 'vscode';
 
+// Branded type helpers
+declare const __brand: unique symbol;
+export type Brand<T extends string, TBase = string> = TBase & {
+  readonly [__brand]: T;
+};
+
 export type ConnectionType = 'DHC';
 
 export type ConnectionAndSession<TConnection, TSession> = {
@@ -21,7 +27,8 @@ export interface CoreConnectionConfig {
   url: URL;
 }
 
-export type EnterpriseConnectionConfigStored = string;
+export type EnterpriseConnectionConfigStored =
+  Brand<'EnterpriseConnectionConfigStored'>;
 
 export interface EnterpriseConnectionConfig {
   label?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export type * from './commonTypes';
 export type * from './serviceTypes';
 export type * from './treeViewTypes';
+export type * from './uiTypes';

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -65,7 +65,6 @@ export type IDhServiceFactory = IFactory<IDhService, [serverUrl: URL]>;
 export interface IServerManager extends Disposable {
   canStartServer: boolean;
 
-  addManagedServers: (urls: URL[]) => void;
   connectToServer: (serverUrl: URL) => Promise<IDhService | null>;
   disconnectEditor: (uri: vscode.Uri) => void;
   disconnectFromServer: (serverUrl: URL) => Promise<void>;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -88,6 +88,7 @@ export interface IServerManager extends Disposable {
   }) => ServerState[];
   getUriConnection: (uri: vscode.Uri) => IDhService | null;
   hasEverUpdatedStatus: () => boolean;
+  syncManagedServers: (urls: URL[]) => void;
   updateStatus: () => Promise<void>;
 
   onDidConnect: vscode.Event<URL>;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -90,7 +90,7 @@ export interface IServerManager extends Disposable {
   getUriConnection: (uri: vscode.Uri) => IDhService | null;
   hasEverUpdatedStatus: () => boolean;
   syncManagedServers: (urls: URL[]) => void;
-  updateStatus: () => Promise<void>;
+  updateStatus: (filterBy?: URL[]) => Promise<void>;
 
   onDidConnect: vscode.Event<URL>;
   onDidDisconnect: vscode.Event<URL>;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -5,6 +5,7 @@ import type {
   Disposable,
   EnterpriseConnectionConfig,
   EventListenerT,
+  ServerConnection,
   ServerState,
   UnsubscribeEventListener,
 } from '../types/commonTypes';
@@ -22,10 +23,10 @@ export interface IConfigService {
  */
 export interface IDhService<TDH = unknown, TClient = unknown>
   extends Disposable,
-    IEventDispatcher<'disconnect'> {
+    IEventDispatcher<'disconnect'>,
+    ServerConnection {
   readonly isInitialized: boolean;
   readonly isConnected: boolean;
-  readonly serverUrl: URL;
 
   initDh: () => Promise<boolean>;
 

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -68,7 +68,7 @@ export interface IServerManager extends Disposable {
   connectToServer: (serverUrl: URL) => Promise<IDhService | null>;
   disconnectEditor: (uri: vscode.Uri) => void;
   disconnectFromServer: (serverUrl: URL) => Promise<void>;
-  loadServerConfig: () => void;
+  loadServerConfig: () => Promise<void>;
 
   hasConnection: (serverUrl: URL) => boolean;
   hasConnectionUris: (connection: IDhService) => boolean;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -58,7 +58,10 @@ export interface IFactory<T, TArgs extends unknown[] = []> {
 /**
  * Factory for creating IDhService instances.
  */
-export type IDhServiceFactory = IFactory<IDhService, [serverUrl: URL]>;
+export type IDhServiceFactory = IFactory<
+  IDhService,
+  [serverUrl: URL, psk?: string]
+>;
 
 /**
  * Server manager interface.
@@ -84,6 +87,7 @@ export interface IServerManager extends Disposable {
     dhService: IDhService
   ) => Promise<void>;
 
+  getServer: (serverUrl: URL) => ServerState | undefined;
   getServers: (filter?: {
     isRunning?: boolean;
     hasConnections?: boolean;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -63,6 +63,8 @@ export type IDhServiceFactory = IFactory<IDhService, [serverUrl: URL]>;
  * Server manager interface.
  */
 export interface IServerManager extends Disposable {
+  canStartServer: boolean;
+
   addManagedServers: (urls: URL[]) => void;
   connectToServer: (serverUrl: URL) => Promise<IDhService | null>;
   disconnectEditor: (uri: vscode.Uri) => void;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -63,6 +63,7 @@ export type IDhServiceFactory = IFactory<IDhService, [serverUrl: URL]>;
  * Server manager interface.
  */
 export interface IServerManager extends Disposable {
+  addManagedServers: (urls: URL[]) => void;
   connectToServer: (serverUrl: URL) => Promise<IDhService | null>;
   disconnectEditor: (uri: vscode.Uri) => void;
   disconnectFromServer: (serverUrl: URL) => Promise<void>;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -94,6 +94,7 @@ export interface IServerManager extends Disposable {
   onDidConnect: vscode.Event<URL>;
   onDidDisconnect: vscode.Event<URL>;
   onDidRegisterEditor: vscode.Event<vscode.Uri>;
+  onDidServerStatusChange: vscode.Event<ServerState>;
   onDidUpdate: vscode.Event<void>;
 }
 

--- a/src/types/treeViewTypes.d.ts
+++ b/src/types/treeViewTypes.d.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import type { IDhService } from './serviceTypes';
 import type { ServerState } from './commonTypes';
 
-export type ServerGroupState = 'Running' | 'Stopped';
+export type ServerGroupState = 'Managed' | 'Running' | 'Stopped';
 export type ServerNode = ServerGroupState | ServerState;
 export interface ServerTreeView extends vscode.TreeView<ServerNode> {}
 

--- a/src/types/uiTypes.d.ts
+++ b/src/types/uiTypes.d.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-import type { ServerState } from './commonTypes';
-import type { IDhService } from './serviceTypes';
+import type { ServerConnection, ServerState } from './commonTypes';
 
 export type SeparatorPickItem = {
   label: string;
@@ -12,7 +11,7 @@ export type ConnectionPickItem<TType, TData> = vscode.QuickPickItem & {
   data: TData;
 };
 
-export type ConnectionPickOption =
+export type ConnectionPickOption<TConnection extends ServerConnection> =
   | SeparatorPickItem
   | ConnectionPickItem<'server', ServerState>
-  | ConnectionPickItem<'connection', IDhService>;
+  | ConnectionPickItem<'connection', TConnection>;

--- a/src/types/uiTypes.d.ts
+++ b/src/types/uiTypes.d.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode';
+import type { ServerState } from './commonTypes';
+import type { IDhService } from './serviceTypes';
+
+export type SeparatorPickItem = {
+  label: string;
+  kind: vscode.QuickPickItemKind.Separator;
+};
+
+export type ConnectionPickItem<TType, TData> = vscode.QuickPickItem & {
+  type: TType;
+  data: TData;
+};
+
+export type ConnectionPickOption =
+  | SeparatorPickItem
+  | ConnectionPickItem<'server', ServerState>
+  | ConnectionPickItem<'connection', IDhService>;

--- a/src/util/__snapshots__/serverUtils.spec.ts.snap
+++ b/src/util/__snapshots__/serverUtils.spec.ts.snap
@@ -88,21 +88,21 @@ exports[`getServerGroupTreeItem > should return server group tree item: group=Ru
 }
 `;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=false, isRunning=false 1`] = `"circle-slash"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=false, isManaged=false, isRunning=false 1`] = `"circle-slash"`;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=false, isRunning=true 1`] = `"circle-large-outline"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=false, isManaged=false, isRunning=true 1`] = `"circle-large-outline"`;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=true, isRunning=false 1`] = `"sync~spin"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=false, isManaged=true, isRunning=false 1`] = `"sync~spin"`;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=true, isRunning=true 1`] = `"circle-large-outline"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=false, isManaged=true, isRunning=true 1`] = `"circle-large-outline"`;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=false, isRunning=false 1`] = `"circle-slash"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=true, isManaged=false, isRunning=false 1`] = `"circle-slash"`;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=false, isRunning=true 1`] = `"circle-large-filled"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=true, isManaged=false, isRunning=true 1`] = `"circle-large-filled"`;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=true, isRunning=false 1`] = `"sync~spin"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=true, isManaged=true, isRunning=false 1`] = `"sync~spin"`;
 
-exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=true, isRunning=true 1`] = `"circle-large-filled"`;
+exports[`getServerIconID > should return icon id based on server state: isConnected=true, isManaged=true, isRunning=true 1`] = `"circle-large-filled"`;
 
 exports[`getServerTreeItem > should return DHC server tree item: isConnected=false, isManaged=false, isRunning=false 1`] = `
 {
@@ -240,24 +240,28 @@ exports[`groupServers > should group servers by state 1`] = `
     {
       "isManaged": true,
       "isRunning": true,
+      "psk": "mock.psk",
       "type": "DHC",
       "url": "http://localhost:10000/",
     },
     {
       "isManaged": true,
       "isRunning": true,
+      "psk": "mock.psk",
       "type": "DHC",
       "url": "http://localhost:10001/",
     },
     {
       "isManaged": true,
       "isRunning": false,
+      "psk": "mock.psk",
       "type": "DHC",
       "url": "http://localhost:10002/",
     },
     {
       "isManaged": true,
       "isRunning": false,
+      "psk": "mock.psk",
       "type": "DHC",
       "url": "http://localhost:10003/",
     },
@@ -266,12 +270,14 @@ exports[`groupServers > should group servers by state 1`] = `
     {
       "isManaged": false,
       "isRunning": true,
+      "psk": undefined,
       "type": "DHC",
       "url": "http://localhost:10004/",
     },
     {
       "isManaged": false,
       "isRunning": true,
+      "psk": undefined,
       "type": "DHC",
       "url": "http://localhost:10005/",
     },
@@ -280,12 +286,14 @@ exports[`groupServers > should group servers by state 1`] = `
     {
       "isManaged": false,
       "isRunning": false,
+      "psk": undefined,
       "type": "DHC",
       "url": "http://localhost:10006/",
     },
     {
       "isManaged": false,
       "isRunning": false,
+      "psk": undefined,
       "type": "DHC",
       "url": "http://localhost:10007/",
     },

--- a/src/util/__snapshots__/serverUtils.spec.ts.snap
+++ b/src/util/__snapshots__/serverUtils.spec.ts.snap
@@ -233,3 +233,62 @@ exports[`getServerTreeItem > should return DHC server tree item: isConnected=tru
   "tooltip": "http://localhost:10000/",
 }
 `;
+
+exports[`groupServers > should group servers by state 1`] = `
+{
+  "managed": [
+    {
+      "isManaged": true,
+      "isRunning": true,
+      "type": "DHC",
+      "url": "http://localhost:10000/",
+    },
+    {
+      "isManaged": true,
+      "isRunning": true,
+      "type": "DHC",
+      "url": "http://localhost:10001/",
+    },
+    {
+      "isManaged": true,
+      "isRunning": false,
+      "type": "DHC",
+      "url": "http://localhost:10002/",
+    },
+    {
+      "isManaged": true,
+      "isRunning": false,
+      "type": "DHC",
+      "url": "http://localhost:10003/",
+    },
+  ],
+  "running": [
+    {
+      "isManaged": false,
+      "isRunning": true,
+      "type": "DHC",
+      "url": "http://localhost:10004/",
+    },
+    {
+      "isManaged": false,
+      "isRunning": true,
+      "type": "DHC",
+      "url": "http://localhost:10005/",
+    },
+  ],
+  "stopped": [
+    {
+      "isManaged": false,
+      "isRunning": false,
+      "type": "DHC",
+      "url": "http://localhost:10006/",
+    },
+    {
+      "isManaged": false,
+      "isRunning": false,
+      "type": "DHC",
+      "url": "http://localhost:10007/",
+    },
+  ],
+}
+`;

--- a/src/util/__snapshots__/serverUtils.spec.ts.snap
+++ b/src/util/__snapshots__/serverUtils.spec.ts.snap
@@ -1,5 +1,109 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=false, isManaged=false, isRunning=false 1`] = `"isServerStopped"`;
+
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=false, isManaged=false, isRunning=true 1`] = `"isServerRunningDisconnected"`;
+
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=false, isManaged=true, isRunning=false 1`] = `"isManagedServerConnecting"`;
+
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=false, isManaged=true, isRunning=true 1`] = `"isManagedServerDisconnected"`;
+
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=true, isManaged=false, isRunning=false 1`] = `"isServerStopped"`;
+
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=true, isManaged=false, isRunning=true 1`] = `"isServerRunningConnected"`;
+
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=true, isManaged=true, isRunning=false 1`] = `"isManagedServerConnected"`;
+
+exports[`getServerContextValue > should return contextValue based on server state: isConnected=true, isManaged=true, isRunning=true 1`] = `"isManagedServerConnected"`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=0, isManaged=false, label=some label 1`] = `"some label"`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=0, isManaged=false, label=undefined 1`] = `""`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=0, isManaged=true, label=some label 1`] = `"pip some label"`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=0, isManaged=true, label=undefined 1`] = `"pip"`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=1, isManaged=false, label=some label 1`] = `"some label (1)"`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=1, isManaged=false, label=undefined 1`] = `"(1)"`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=1, isManaged=true, label=some label 1`] = `"pip some label (1)"`;
+
+exports[`getServerDescription > should return server description based on parameters: connectionCount=1, isManaged=true, label=undefined 1`] = `"pip (1)"`;
+
+exports[`getServerGroupContextValue > should return context value when servers can be managed: group=Managed, canStartServer=false 1`] = `undefined`;
+
+exports[`getServerGroupContextValue > should return context value when servers can be managed: group=Managed, canStartServer=true 1`] = `"canStartServer"`;
+
+exports[`getServerGroupContextValue > should return context value when servers can be managed: group=Running, canStartServer=false 1`] = `undefined`;
+
+exports[`getServerGroupContextValue > should return context value when servers can be managed: group=Running, canStartServer=true 1`] = `undefined`;
+
+exports[`getServerGroupTreeItem > should return server group tree item: group=Managed, canStartServer=false 1`] = `
+{
+  "collapsibleState": 2,
+  "contextValue": undefined,
+  "iconPath": {
+    "color": undefined,
+    "id": "server",
+  },
+  "label": "Managed",
+}
+`;
+
+exports[`getServerGroupTreeItem > should return server group tree item: group=Managed, canStartServer=true 1`] = `
+{
+  "collapsibleState": 2,
+  "contextValue": "canStartServer",
+  "iconPath": {
+    "color": undefined,
+    "id": "server",
+  },
+  "label": "Managed",
+}
+`;
+
+exports[`getServerGroupTreeItem > should return server group tree item: group=Running, canStartServer=false 1`] = `
+{
+  "collapsibleState": 2,
+  "contextValue": undefined,
+  "iconPath": {
+    "color": undefined,
+    "id": "server",
+  },
+  "label": "Running",
+}
+`;
+
+exports[`getServerGroupTreeItem > should return server group tree item: group=Running, canStartServer=true 1`] = `
+{
+  "collapsibleState": 2,
+  "contextValue": undefined,
+  "iconPath": {
+    "color": undefined,
+    "id": "server",
+  },
+  "label": "Running",
+}
+`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=false, isRunning=false 1`] = `"circle-slash"`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=false, isRunning=true 1`] = `"circle-large-outline"`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=true, isRunning=false 1`] = `"sync~spin"`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=false, isManaged=true, isRunning=true 1`] = `"circle-large-outline"`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=false, isRunning=false 1`] = `"circle-slash"`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=false, isRunning=true 1`] = `"circle-large-filled"`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=true, isRunning=false 1`] = `"sync~spin"`;
+
+exports[`getServerIconPath > should return icon path based on server state: isConnected=true, isManaged=true, isRunning=true 1`] = `"circle-large-filled"`;
+
 exports[`getServerTreeItem > should return DHC server tree item: isConnected=false, isManaged=false, isRunning=false 1`] = `
 {
   "command": undefined,

--- a/src/util/__snapshots__/serverUtils.spec.ts.snap
+++ b/src/util/__snapshots__/serverUtils.spec.ts.snap
@@ -1,0 +1,131 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=false, isManaged=false, isRunning=false 1`] = `
+{
+  "command": undefined,
+  "contextValue": "isServerStopped",
+  "description": "",
+  "iconPath": {
+    "color": undefined,
+    "id": "circle-slash",
+  },
+  "label": "localhost:10000",
+  "tooltip": "http://localhost:10000/",
+}
+`;
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=false, isManaged=false, isRunning=true 1`] = `
+{
+  "command": {
+    "arguments": [
+      {
+        "type": "DHC",
+        "url": "http://localhost:10000/",
+      },
+    ],
+    "command": "vscode-deephaven.connectToServer",
+    "title": "Connect to server",
+  },
+  "contextValue": "isServerRunningDisconnected",
+  "description": "",
+  "iconPath": {
+    "color": undefined,
+    "id": "circle-large-outline",
+  },
+  "label": "localhost:10000",
+  "tooltip": "Click to connect to http://localhost:10000/",
+}
+`;
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=false, isManaged=true, isRunning=false 1`] = `
+{
+  "command": undefined,
+  "contextValue": "isManagedServerConnecting",
+  "description": "pip",
+  "iconPath": {
+    "color": undefined,
+    "id": "sync~spin",
+  },
+  "label": "localhost:10000",
+  "tooltip": "http://localhost:10000/",
+}
+`;
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=false, isManaged=true, isRunning=true 1`] = `
+{
+  "command": {
+    "arguments": [
+      {
+        "type": "DHC",
+        "url": "http://localhost:10000/",
+      },
+    ],
+    "command": "vscode-deephaven.connectToServer",
+    "title": "Connect to server",
+  },
+  "contextValue": "isManagedServerDisconnected",
+  "description": "pip",
+  "iconPath": {
+    "color": undefined,
+    "id": "circle-large-outline",
+  },
+  "label": "localhost:10000",
+  "tooltip": "Click to connect to http://localhost:10000/",
+}
+`;
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=true, isManaged=false, isRunning=false 1`] = `
+{
+  "command": undefined,
+  "contextValue": "isServerStopped",
+  "description": "(1)",
+  "iconPath": {
+    "color": undefined,
+    "id": "circle-slash",
+  },
+  "label": "localhost:10000",
+  "tooltip": "http://localhost:10000/",
+}
+`;
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=true, isManaged=false, isRunning=true 1`] = `
+{
+  "command": undefined,
+  "contextValue": "isServerRunningConnected",
+  "description": "(1)",
+  "iconPath": {
+    "color": undefined,
+    "id": "circle-large-filled",
+  },
+  "label": "localhost:10000",
+  "tooltip": "http://localhost:10000/",
+}
+`;
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=true, isManaged=true, isRunning=false 1`] = `
+{
+  "command": undefined,
+  "contextValue": "isManagedServerConnected",
+  "description": "pip (1)",
+  "iconPath": {
+    "color": undefined,
+    "id": "sync~spin",
+  },
+  "label": "localhost:10000",
+  "tooltip": "http://localhost:10000/",
+}
+`;
+
+exports[`getServerTreeItem > should return DHC server tree item: isConnected=true, isManaged=true, isRunning=true 1`] = `
+{
+  "command": undefined,
+  "contextValue": "isManagedServerConnected",
+  "description": "pip (1)",
+  "iconPath": {
+    "color": undefined,
+    "id": "circle-large-filled",
+  },
+  "label": "localhost:10000",
+  "tooltip": "http://localhost:10000/",
+}
+`;

--- a/src/util/__snapshots__/uiUtils.spec.ts.snap
+++ b/src/util/__snapshots__/uiUtils.spec.ts.snap
@@ -21,3 +21,129 @@ exports[`createConnectionOption > should return connection option: 'DHC', { labe
   "url": "http://localhost:10000/",
 }
 `;
+
+exports[`createConnectionQuickPickOptions > should return quick pick options 1`] = `
+[
+  {
+    "kind": -1,
+    "label": "Active Connections",
+  },
+  {
+    "data": {
+      "serverUrl": "http://localhost:10000/",
+    },
+    "description": "python",
+    "iconPath": {
+      "color": undefined,
+      "id": "vm-connect",
+    },
+    "label": "http://localhost:10000/",
+    "type": "connection",
+  },
+  {
+    "data": {
+      "serverUrl": "http://localhost:10002/",
+    },
+    "description": "python",
+    "iconPath": {
+      "color": undefined,
+      "id": "vm-connect",
+    },
+    "label": "http://localhost:10002/",
+    "type": "connection",
+  },
+  {
+    "kind": -1,
+    "label": "Connect to Server",
+  },
+  {
+    "data": {
+      "type": "DHC",
+      "url": "http://localhost:10001/",
+    },
+    "description": undefined,
+    "iconPath": {
+      "color": undefined,
+      "id": "server",
+    },
+    "label": "http://localhost:10001/",
+    "type": "server",
+  },
+  {
+    "data": {
+      "type": "DHC",
+      "url": "http://localhost:10003/",
+    },
+    "description": undefined,
+    "iconPath": {
+      "color": undefined,
+      "id": "server",
+    },
+    "label": "http://localhost:10003/",
+    "type": "server",
+  },
+]
+`;
+
+exports[`createConnectionQuickPickOptions > should return quick pick options 2`] = `
+[
+  {
+    "kind": -1,
+    "label": "Active Connections",
+  },
+  {
+    "data": {
+      "serverUrl": "http://localhost:10000/",
+    },
+    "description": "python (current)",
+    "iconPath": {
+      "color": undefined,
+      "id": "vm-connect",
+    },
+    "label": "http://localhost:10000/",
+    "type": "connection",
+  },
+  {
+    "data": {
+      "serverUrl": "http://localhost:10002/",
+    },
+    "description": "python",
+    "iconPath": {
+      "color": undefined,
+      "id": "vm-connect",
+    },
+    "label": "http://localhost:10002/",
+    "type": "connection",
+  },
+  {
+    "kind": -1,
+    "label": "Connect to Server",
+  },
+  {
+    "data": {
+      "type": "DHC",
+      "url": "http://localhost:10001/",
+    },
+    "description": undefined,
+    "iconPath": {
+      "color": undefined,
+      "id": "server",
+    },
+    "label": "http://localhost:10001/",
+    "type": "server",
+  },
+  {
+    "data": {
+      "type": "DHC",
+      "url": "http://localhost:10003/",
+    },
+    "description": undefined,
+    "iconPath": {
+      "color": undefined,
+      "id": "server",
+    },
+    "label": "http://localhost:10003/",
+    "type": "server",
+  },
+]
+`;

--- a/src/util/__snapshots__/uiUtils.spec.ts.snap
+++ b/src/util/__snapshots__/uiUtils.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`createConnectionOption > should return connection option: 'DHC', { labe
 }
 `;
 
-exports[`createConnectionQuickPickOptions > should return quick pick options 1`] = `
+exports[`createConnectionQuickPickOptions > should return quick pick options: editorActiveConnectionUrl=Active A 1`] = `
 [
   {
     "kind": -1,
@@ -32,7 +32,7 @@ exports[`createConnectionQuickPickOptions > should return quick pick options 1`]
     "data": {
       "serverUrl": "http://localhost:10000/",
     },
-    "description": "python",
+    "description": "python (current)",
     "iconPath": {
       "color": undefined,
       "id": "vm-connect",
@@ -85,7 +85,7 @@ exports[`createConnectionQuickPickOptions > should return quick pick options 1`]
 ]
 `;
 
-exports[`createConnectionQuickPickOptions > should return quick pick options 2`] = `
+exports[`createConnectionQuickPickOptions > should return quick pick options: editorActiveConnectionUrl=No active 1`] = `
 [
   {
     "kind": -1,
@@ -95,7 +95,7 @@ exports[`createConnectionQuickPickOptions > should return quick pick options 2`]
     "data": {
       "serverUrl": "http://localhost:10000/",
     },
-    "description": "python (current)",
+    "description": "python",
     "iconPath": {
       "color": undefined,
       "id": "vm-connect",

--- a/src/util/assertUtil.ts
+++ b/src/util/assertUtil.ts
@@ -11,3 +11,14 @@ export function assertDefined<T>(
     throw new Error(`'${name}' is required`);
   }
 }
+
+/**
+ * Assertion for a value that should never be reached. Useful for exhaustive switch
+ * checks.
+ * @param shouldBeNever The value that should never be reached.
+ * @param name The name of the value to include in the error message if the assertion fails.
+ */
+export function assertNever(shouldBeNever: never, name?: string): never {
+  const label = name == null ? 'value' : `'${name}'`;
+  throw new Error(`Unexpected ${label}: ${shouldBeNever}`);
+}

--- a/src/util/promiseUtils.spec.ts
+++ b/src/util/promiseUtils.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, it, expect, vi, afterAll } from 'vitest';
+import { pollUntilTrue, waitFor, withResolvers } from './promiseUtils';
+
+// See __mocks__/vscode.ts for the mock implementation
+vi.mock('vscode');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+const resolved = vi.fn().mockName('resolved');
+const rejected = vi.fn().mockName('rejected');
+
+describe('waitFor', () => {
+  it('should return a Promise that resolves after a given timeout', async () => {
+    waitFor(100).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toHaveBeenCalled();
+  });
+});
+
+describe('withResolvers', () => {
+  it('should return a promise that resolves when resolve function is called', async () => {
+    const { promise, resolve } = withResolvers<string>();
+
+    promise.then(resolved);
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(resolved).not.toHaveBeenCalled();
+
+    resolve('value');
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(resolved).toHaveBeenCalledWith('value');
+  });
+
+  it('should return a promise that rejects when reject function is called', async () => {
+    const { promise, reject } = withResolvers<string>();
+
+    promise.catch(rejected);
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(rejected).not.toHaveBeenCalled();
+
+    reject('Some Error');
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(rejected).toHaveBeenCalledWith('Some Error');
+  });
+});
+
+describe('pollUntilTrue', () => {
+  const poll = vi.fn<() => Promise<boolean>>().mockName('poll');
+
+  it('should resolve when poll function returns true', async () => {
+    const intervalMs = 100;
+    poll.mockResolvedValue(false);
+
+    const { promise } = pollUntilTrue(poll, intervalMs);
+    promise.then(resolved);
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(intervalMs);
+    expect(poll).toHaveBeenCalledTimes(2);
+    expect(resolved).not.toHaveBeenCalled();
+
+    poll.mockResolvedValue(true);
+
+    await vi.advanceTimersByTimeAsync(intervalMs);
+    expect(poll).toHaveBeenCalledTimes(3);
+    expect(resolved).toHaveBeenCalledWith(true);
+
+    await vi.advanceTimersByTimeAsync(intervalMs);
+    expect(poll).toHaveBeenCalledTimes(3);
+    expect(resolved).toHaveBeenCalledOnce();
+  });
+
+  it('should cancel polling if timeout exceeded', async () => {
+    const intervalMs = 100;
+    const timeoutMs = 1000;
+
+    poll.mockResolvedValue(false);
+
+    const { promise } = pollUntilTrue(poll, intervalMs, timeoutMs);
+    promise.then(resolved).catch(rejected);
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(timeoutMs);
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).toHaveBeenCalledWith(new Error('Polling cancelled'));
+  });
+
+  it('should cancel polling if cancel explicitly called', async () => {
+    const intervalMs = 100;
+
+    poll.mockResolvedValue(false);
+
+    const { promise, cancel } = pollUntilTrue(poll, intervalMs);
+    promise.then(resolved).catch(rejected);
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).not.toHaveBeenCalled();
+
+    cancel();
+
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(resolved).not.toHaveBeenCalled();
+    expect(rejected).toHaveBeenCalledWith(new Error('Polling cancelled'));
+  });
+});

--- a/src/util/promiseUtils.spec.ts
+++ b/src/util/promiseUtils.spec.ts
@@ -68,20 +68,24 @@ describe('pollUntilTrue', () => {
     const { promise } = pollUntilTrue(poll, intervalMs);
     promise.then(resolved);
 
+    // Initial polling call that is scheduled via setTimeout(..., 0)
     await vi.advanceTimersToNextTimerAsync();
     expect(poll).toHaveBeenCalledTimes(1);
     expect(resolved).not.toHaveBeenCalled();
 
+    // 2nd poll (after first intervalMs)
     await vi.advanceTimersByTimeAsync(intervalMs);
     expect(poll).toHaveBeenCalledTimes(2);
     expect(resolved).not.toHaveBeenCalled();
 
     poll.mockResolvedValue(true);
 
+    // 3rd poll
     await vi.advanceTimersByTimeAsync(intervalMs);
     expect(poll).toHaveBeenCalledTimes(3);
     expect(resolved).toHaveBeenCalledWith(true);
 
+    // Advance intervalMs. No more polling expected since resolved
     await vi.advanceTimersByTimeAsync(intervalMs);
     expect(poll).toHaveBeenCalledTimes(3);
     expect(resolved).toHaveBeenCalledOnce();

--- a/src/util/promiseUtils.ts
+++ b/src/util/promiseUtils.ts
@@ -12,6 +12,14 @@ export interface PromiseWithCancel<T> {
 }
 
 /**
+ * Return a Promise that resolves after a given number of milliseconds.
+ * @param waitMs
+ */
+export function waitFor(waitMs: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, waitMs));
+}
+
+/**
  * Polyfill for `Promise.withResolvers`. Should be able to replace once we
  * upgrade to Node 22.
  * @returns

--- a/src/util/promiseUtils.ts
+++ b/src/util/promiseUtils.ts
@@ -1,0 +1,93 @@
+import { PollingService } from '../services';
+
+export interface PromiseWithResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+}
+
+export interface PromiseWithCancel<T> {
+  promise: Promise<T>;
+  cancel: () => void;
+}
+
+/**
+ * Polyfill for `Promise.withResolvers`. Should be able to replace once we
+ * upgrade to Node 22.
+ * @returns
+ */
+export function withResolvers<T>(): PromiseWithResolvers<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: any) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+}
+
+/**
+ * Call the given poll function at an interval.
+ * - If the poll result resolves to true, stop polling and resolve the promise.
+ * - If the poll function throws, stop polling and reject the promise.
+ * @param poll
+ * @param intervalMs
+ * @param timeoutMs
+ * @returns Promise that resolves when the poll function returns true + a `reject`
+ * function that can be used to cancel the polling.
+ */
+export function pollUntilTrue(
+  poll: () => Promise<boolean>,
+  intervalMs: number,
+  timeoutMs?: number
+): PromiseWithCancel<true> {
+  const { promise, resolve, reject } = withResolvers<true>();
+
+  let timeout: NodeJS.Timeout;
+  const poller = new PollingService();
+
+  /** Stop polling and resolve / reject promise */
+  function resolveOrReject(trueOrError: true | Error): void {
+    poller.stop();
+    clearTimeout(timeout);
+
+    if (trueOrError === true) {
+      resolve(trueOrError);
+    } else {
+      reject(trueOrError);
+    }
+  }
+
+  /** Cancel polling */
+  const cancel = (): void => {
+    resolveOrReject(new Error('Polling cancelled'));
+  };
+
+  if (timeoutMs != null) {
+    timeout = setTimeout(() => {
+      cancel();
+    }, timeoutMs);
+  }
+
+  poller.start(async () => {
+    try {
+      const isTrue = await poll();
+      if (isTrue) {
+        resolveOrReject(true);
+      }
+    } catch (err) {
+      resolveOrReject(err instanceof Error ? err : new Error(String(err)));
+    }
+  }, intervalMs);
+
+  return {
+    promise,
+    cancel,
+  };
+}

--- a/src/util/serverUtils.spec.ts
+++ b/src/util/serverUtils.spec.ts
@@ -9,6 +9,7 @@ import {
   getServerIconPath,
   getServerTreeItem,
   groupServers,
+  parsePort,
 } from './serverUtils';
 import type { Port, ServerConnectionConfig, ServerState } from '../types';
 
@@ -196,5 +197,22 @@ describe('groupServers', () => {
     const actual = groupServers(servers);
 
     expect(actual).toMatchSnapshot();
+  });
+});
+
+describe('parsePort', () => {
+  it('should parse port from string', () => {
+    const given = '10000';
+    const expected = 10000 as Port;
+
+    const actual = parsePort(given);
+
+    expect(actual).toBe(expected);
+  });
+
+  it('should throw error when port is not a number', () => {
+    const given = 'abc';
+
+    expect(() => parsePort(given)).toThrowError(new Error('Invalid port: abc'));
   });
 });

--- a/src/util/serverUtils.spec.ts
+++ b/src/util/serverUtils.spec.ts
@@ -1,4 +1,3 @@
-import * as vscode from 'vscode';
 import { describe, it, expect, vi } from 'vitest';
 import {
   getInitialServerStates,
@@ -10,7 +9,6 @@ import {
   getServerIconPath,
   getServerTreeItem,
 } from './serverUtils';
-import { ICON_ID, SERVER_TREE_ITEM_CONTEXT } from '../common';
 import type { Port, ServerConnectionConfig, ServerState } from '../types';
 
 // See __mocks__/vscode.ts for the mock implementation
@@ -55,58 +53,57 @@ describe('getPipServerUrl', () => {
 
 describe('getServerContextValue', () => {
   it.each([
-    [true, true, true, SERVER_TREE_ITEM_CONTEXT.isManagedServerConnected],
-    [true, true, false, SERVER_TREE_ITEM_CONTEXT.isManagedServerConnected],
-    [true, false, true, SERVER_TREE_ITEM_CONTEXT.isServerRunningConnected],
-    [true, false, false, SERVER_TREE_ITEM_CONTEXT.isServerStopped],
-    [false, true, true, SERVER_TREE_ITEM_CONTEXT.isManagedServerDisconnected],
-    [false, true, false, SERVER_TREE_ITEM_CONTEXT.isManagedServerConnecting],
-    [false, false, true, SERVER_TREE_ITEM_CONTEXT.isServerRunningDisconnected],
-    [false, false, false, SERVER_TREE_ITEM_CONTEXT.isServerStopped],
+    [true, true, true],
+    [true, true, false],
+    [true, false, true],
+    [true, false, false],
+    [false, true, true],
+    [false, true, false],
+    [false, false, true],
+    [false, false, false],
   ])(
     'should return contextValue based on server state: isConnected=%s, isManaged=%s, isRunning=%s',
-    (isConnected, isManaged, isRunning, expected) => {
+    (isConnected, isManaged, isRunning) => {
       const actual = getServerContextValue({
         isConnected,
         isManaged,
         isRunning,
       });
-
-      expect(actual).toEqual(expected);
+      expect(actual).toMatchSnapshot();
     }
   );
 });
 
 describe('getServerDescription', () => {
   it.each([
-    [0, true, 'some label', 'pip some label'],
-    [1, true, 'some label', 'pip some label (1)'],
-    [0, false, 'some label', 'some label'],
-    [1, false, 'some label', 'some label (1)'],
-    [0, true, undefined, 'pip'],
-    [1, true, undefined, 'pip (1)'],
-    [0, false, undefined, ''],
-    [1, false, undefined, '(1)'],
+    [0, true, 'some label'],
+    [1, true, 'some label'],
+    [0, false, 'some label'],
+    [1, false, 'some label'],
+    [0, true, undefined],
+    [1, true, undefined],
+    [0, false, undefined],
+    [1, false, undefined],
   ])(
     'should return server description based on parameters: connectionCount=%s, isManaged=%s, label=%s',
-    (connectionCount, isManaged, label, expectedDescription) => {
+    (connectionCount, isManaged, label) => {
       const actual = getServerDescription(connectionCount, isManaged, label);
-      expect(actual).toEqual(expectedDescription);
+      expect(actual).toMatchSnapshot();
     }
   );
 });
 
 describe('getServerGroupContextValue', () => {
   it.each([
-    ['Managed', true, SERVER_TREE_ITEM_CONTEXT.canStartServer],
-    ['Running', true, undefined],
-    ['Managed', false, undefined],
-    ['Running', false, undefined],
+    ['Managed', true],
+    ['Running', true],
+    ['Managed', false],
+    ['Running', false],
   ] as const)(
     'should return context value when servers can be managed: group=%s, canStartServer=%s',
-    (group, canStartServer, expected) => {
+    (group, canStartServer) => {
       const actual = getServerGroupContextValue(group, canStartServer);
-      expect(actual).toEqual(expected);
+      expect(actual).toMatchSnapshot();
     }
   );
 });
@@ -121,32 +118,26 @@ describe('getServerGroupTreeItem', () => {
     'should return server group tree item: group=%s, canStartServer=%s',
     (group, canStartServer) => {
       const actual = getServerGroupTreeItem(group, canStartServer);
-
-      expect(actual).toEqual({
-        label: group,
-        iconPath: new vscode.ThemeIcon(ICON_ID.server),
-        collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
-        contextValue: getServerGroupContextValue(group, canStartServer),
-      });
+      expect(actual).toMatchSnapshot();
     }
   );
 });
 
 describe('getServerIconPath', () => {
   it.each([
-    [true, true, true, ICON_ID.serverConnected],
-    [true, true, false, ICON_ID.connecting],
-    [true, false, true, ICON_ID.serverConnected],
-    [true, false, false, ICON_ID.serverStopped],
-    [false, true, true, ICON_ID.serverRunning],
-    [false, true, false, ICON_ID.connecting],
-    [false, false, true, ICON_ID.serverRunning],
-    [false, false, false, ICON_ID.serverStopped],
+    [true, true, true],
+    [true, true, false],
+    [true, false, true],
+    [true, false, false],
+    [false, true, true],
+    [false, true, false],
+    [false, false, true],
+    [false, false, false],
   ])(
     'should return icon path based on server state: isConnected=%s, isManaged=%s, isRunning=%s',
-    (isConnected, isManaged, isRunning, expected) => {
+    (isConnected, isManaged, isRunning) => {
       const actual = getServerIconPath({ isConnected, isManaged, isRunning });
-      expect(actual).toEqual(expected);
+      expect(actual).toMatchSnapshot();
     }
   );
 });

--- a/src/util/serverUtils.spec.ts
+++ b/src/util/serverUtils.spec.ts
@@ -1,6 +1,57 @@
-import { describe, it, expect } from 'vitest';
-import { getServerContextValue } from './serverUtils';
-import { SERVER_TREE_ITEM_CONTEXT } from '../common';
+import * as vscode from 'vscode';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getInitialServerStates,
+  getPipServerUrl,
+  getServerContextValue,
+  getServerDescription,
+  getServerGroupContextValue,
+  getServerGroupTreeItem,
+  getServerIconPath,
+  getServerTreeItem,
+} from './serverUtils';
+import { ICON_ID, SERVER_TREE_ITEM_CONTEXT } from '../common';
+import type { Port, ServerConnectionConfig, ServerState } from '../types';
+
+// See __mocks__/vscode.ts for the mock implementation
+vi.mock('vscode');
+
+describe('getInitialServerStates', () => {
+  it('should derive server states from config', () => {
+    const givenConfigs: ServerConnectionConfig[] = [
+      { label: 'SomeLabel', url: new URL('http://localhost:10000') },
+      { url: new URL('http://localhost:10001') },
+      new URL('http://localhost:10002'),
+    ];
+
+    const actual = getInitialServerStates('DHC', givenConfigs);
+
+    expect(actual).toEqual([
+      {
+        label: 'SomeLabel',
+        type: 'DHC',
+        url: new URL('http://localhost:10000'),
+      },
+      {
+        type: 'DHC',
+        url: new URL('http://localhost:10001'),
+      },
+      {
+        type: 'DHC',
+        url: new URL('http://localhost:10002'),
+      },
+    ]);
+  });
+});
+
+describe('getPipServerUrl', () => {
+  it('should return a localhost url based on given port', () => {
+    const givenPort = 9000 as Port;
+    const expectedURL = new URL('http://localhost:9000');
+
+    expect(getPipServerUrl(givenPort)).toEqual(expectedURL);
+  });
+});
 
 describe('getServerContextValue', () => {
   it.each([
@@ -22,6 +73,110 @@ describe('getServerContextValue', () => {
       });
 
       expect(actual).toEqual(expected);
+    }
+  );
+});
+
+describe('getServerDescription', () => {
+  it.each([
+    [0, true, 'some label', 'pip some label'],
+    [1, true, 'some label', 'pip some label (1)'],
+    [0, false, 'some label', 'some label'],
+    [1, false, 'some label', 'some label (1)'],
+    [0, true, undefined, 'pip'],
+    [1, true, undefined, 'pip (1)'],
+    [0, false, undefined, ''],
+    [1, false, undefined, '(1)'],
+  ])(
+    'should return server description based on parameters: connectionCount=%s, isManaged=%s, label=%s',
+    (connectionCount, isManaged, label, expectedDescription) => {
+      const actual = getServerDescription(connectionCount, isManaged, label);
+      expect(actual).toEqual(expectedDescription);
+    }
+  );
+});
+
+describe('getServerGroupContextValue', () => {
+  it.each([
+    ['Managed', true, SERVER_TREE_ITEM_CONTEXT.canStartServer],
+    ['Running', true, undefined],
+    ['Managed', false, undefined],
+    ['Running', false, undefined],
+  ] as const)(
+    'should return context value when servers can be managed: group=%s, canStartServer=%s',
+    (group, canStartServer, expected) => {
+      const actual = getServerGroupContextValue(group, canStartServer);
+      expect(actual).toEqual(expected);
+    }
+  );
+});
+
+describe('getServerGroupTreeItem', () => {
+  it.each([
+    ['Managed', true],
+    ['Running', true],
+    ['Managed', false],
+    ['Running', false],
+  ] as const)(
+    'should return server group tree item: group=%s, canStartServer=%s',
+    (group, canStartServer) => {
+      const actual = getServerGroupTreeItem(group, canStartServer);
+
+      expect(actual).toEqual({
+        label: group,
+        iconPath: new vscode.ThemeIcon(ICON_ID.server),
+        collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+        contextValue: getServerGroupContextValue(group, canStartServer),
+      });
+    }
+  );
+});
+
+describe('getServerIconPath', () => {
+  it.each([
+    [true, true, true, ICON_ID.serverConnected],
+    [true, true, false, ICON_ID.connecting],
+    [true, false, true, ICON_ID.serverConnected],
+    [true, false, false, ICON_ID.serverStopped],
+    [false, true, true, ICON_ID.serverRunning],
+    [false, true, false, ICON_ID.connecting],
+    [false, false, true, ICON_ID.serverRunning],
+    [false, false, false, ICON_ID.serverStopped],
+  ])(
+    'should return icon path based on server state: isConnected=%s, isManaged=%s, isRunning=%s',
+    (isConnected, isManaged, isRunning, expected) => {
+      const actual = getServerIconPath({ isConnected, isManaged, isRunning });
+      expect(actual).toEqual(expected);
+    }
+  );
+});
+
+describe('getServerTreeItem', () => {
+  const dhcServerState: ServerState = {
+    type: 'DHC',
+    url: new URL('http://localhost:10000'),
+  };
+
+  it.each([
+    [true, true, true],
+    [true, true, false],
+    [true, false, true],
+    [true, false, false],
+    [false, true, true],
+    [false, true, false],
+    [false, false, true],
+    [false, false, false],
+  ])(
+    'should return DHC server tree item: isConnected=%s, isManaged=%s, isRunning=%s',
+    (isConnected, isManaged, isRunning) => {
+      const actual = getServerTreeItem({
+        server: dhcServerState,
+        isConnected,
+        isManaged,
+        isRunning,
+      });
+
+      expect(actual).toMatchSnapshot();
     }
   );
 });

--- a/src/util/serverUtils.spec.ts
+++ b/src/util/serverUtils.spec.ts
@@ -8,6 +8,7 @@ import {
   getServerGroupTreeItem,
   getServerIconPath,
   getServerTreeItem,
+  groupServers,
 } from './serverUtils';
 import type { Port, ServerConnectionConfig, ServerState } from '../types';
 
@@ -170,4 +171,30 @@ describe('getServerTreeItem', () => {
       expect(actual).toMatchSnapshot();
     }
   );
+});
+
+describe('groupServers', () => {
+  it('should group servers by state', () => {
+    const props = [
+      [true, true],
+      [true, true],
+      [true, false],
+      [true, false],
+      [false, true],
+      [false, true],
+      [false, false],
+      [false, false],
+    ];
+
+    const servers = props.map(([isManaged, isRunning], i) => ({
+      type: 'DHC' as const,
+      url: new URL(`http://localhost:1000${i}`),
+      isManaged,
+      isRunning,
+    }));
+
+    const actual = groupServers(servers);
+
+    expect(actual).toMatchSnapshot();
+  });
 });

--- a/src/util/serverUtils.spec.ts
+++ b/src/util/serverUtils.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { getServerContextValue } from './serverUtils';
+import { SERVER_TREE_ITEM_CONTEXT } from '../common';
+
+describe('getServerContextValue', () => {
+  it.each([
+    [true, true, true, SERVER_TREE_ITEM_CONTEXT.isManagedServerConnected],
+    [true, true, false, SERVER_TREE_ITEM_CONTEXT.isManagedServerConnected],
+    [true, false, true, SERVER_TREE_ITEM_CONTEXT.isServerRunningConnected],
+    [true, false, false, SERVER_TREE_ITEM_CONTEXT.isServerStopped],
+    [false, true, true, SERVER_TREE_ITEM_CONTEXT.isManagedServerDisconnected],
+    [false, true, false, SERVER_TREE_ITEM_CONTEXT.isManagedServerConnecting],
+    [false, false, true, SERVER_TREE_ITEM_CONTEXT.isServerRunningDisconnected],
+    [false, false, false, SERVER_TREE_ITEM_CONTEXT.isServerStopped],
+  ])(
+    'should return contextValue based on server state: isConnected=%s, isManaged=%s, isRunning=%s',
+    (isConnected, isManaged, isRunning, expected) => {
+      const actual = getServerContextValue({
+        isConnected,
+        isManaged,
+        isRunning,
+      });
+
+      expect(actual).toEqual(expected);
+    }
+  );
+});

--- a/src/util/serverUtils.spec.ts
+++ b/src/util/serverUtils.spec.ts
@@ -187,12 +187,16 @@ describe('groupServers', () => {
       [false, false],
     ];
 
-    const servers = props.map(([isManaged, isRunning], i) => ({
-      type: 'DHC' as const,
-      url: new URL(`http://localhost:1000${i}`),
-      isManaged,
-      isRunning,
-    }));
+    const servers = props.map(
+      ([isManaged, isRunning], i) =>
+        ({
+          type: 'DHC' as const,
+          url: new URL(`http://localhost:1000${i}`),
+          isManaged,
+          isRunning,
+          psk: isManaged ? 'mock.psk' : undefined,
+        }) as ServerState
+    );
 
     const actual = groupServers(servers);
 

--- a/src/util/serverUtils.spec.ts
+++ b/src/util/serverUtils.spec.ts
@@ -6,7 +6,7 @@ import {
   getServerDescription,
   getServerGroupContextValue,
   getServerGroupTreeItem,
-  getServerIconPath,
+  getServerIconID,
   getServerTreeItem,
   groupServers,
   parsePort,
@@ -125,7 +125,7 @@ describe('getServerGroupTreeItem', () => {
   );
 });
 
-describe('getServerIconPath', () => {
+describe('getServerIconID', () => {
   it.each([
     [true, true, true],
     [true, true, false],
@@ -136,9 +136,9 @@ describe('getServerIconPath', () => {
     [false, false, true],
     [false, false, false],
   ])(
-    'should return icon path based on server state: isConnected=%s, isManaged=%s, isRunning=%s',
+    'should return icon id based on server state: isConnected=%s, isManaged=%s, isRunning=%s',
     (isConnected, isManaged, isRunning) => {
-      const actual = getServerIconPath({ isConnected, isManaged, isRunning });
+      const actual = getServerIconID({ isConnected, isManaged, isRunning });
       expect(actual).toMatchSnapshot();
     }
   );

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -15,12 +15,12 @@ import { SERVER_LANGUAGE_SET } from '../common';
  */
 export function getInitialServerStates(
   type: ServerType,
-  configs: (CoreConnectionConfig | EnterpriseConnectionConfig)[]
+  configs: (CoreConnectionConfig | EnterpriseConnectionConfig | URL)[]
 ): ServerState[] {
-  return configs.map(({ label, url }) => ({
+  return configs.map(config => ({
     type,
-    label,
-    url,
+    label: config instanceof URL ? undefined : config.label,
+    url: config instanceof URL ? config : config.url,
   }));
 }
 

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -7,7 +7,12 @@ import type {
   CoreConnectionConfig,
   Port,
 } from '../types';
-import { ICON_ID, SERVER_LANGUAGE_SET } from '../common';
+import {
+  ICON_ID,
+  SERVER_LANGUAGE_SET,
+  SERVER_TREE_ITEM_CONTEXT,
+  type ServerTreeItemContextValue,
+} from '../common';
 
 /**
  * Get initial server states based on server configs.
@@ -69,6 +74,38 @@ export async function getFirstConnectionForConsoleType(
  */
 export function getPipServerUrl(port: Port): URL {
   return new URL(`http://localhost:${port}`);
+}
+
+/**
+ * Get `contextValue` for server tree items.
+ * @param isConnected Whether the server is connected
+ * @param isManaged Whether the server is managed
+ * @param isRunning Whether the server is running
+ */
+export function getServerContextValue({
+  isConnected,
+  isManaged,
+  isRunning,
+}: {
+  isConnected: boolean;
+  isManaged: boolean;
+  isRunning: boolean;
+}): ServerTreeItemContextValue {
+  if (isManaged) {
+    return isConnected
+      ? SERVER_TREE_ITEM_CONTEXT.isManagedServerConnected
+      : isRunning
+        ? SERVER_TREE_ITEM_CONTEXT.isManagedServerDisconnected
+        : SERVER_TREE_ITEM_CONTEXT.isManagedServerConnecting;
+  }
+
+  if (isRunning) {
+    return isConnected
+      ? SERVER_TREE_ITEM_CONTEXT.isServerRunningConnected
+      : SERVER_TREE_ITEM_CONTEXT.isServerRunningDisconnected;
+  }
+
+  return SERVER_TREE_ITEM_CONTEXT.isServerStopped;
 }
 
 /**

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -4,10 +4,9 @@ import type {
   ServerState,
   ServerType,
   ConsoleType,
-  EnterpriseConnectionConfig,
-  CoreConnectionConfig,
   Port,
   ServerGroupState,
+  ServerConnectionConfig,
 } from '../types';
 import {
   ICON_ID,
@@ -23,7 +22,7 @@ import {
  */
 export function getInitialServerStates(
   type: ServerType,
-  configs: (CoreConnectionConfig | EnterpriseConnectionConfig | URL)[]
+  configs: ServerConnectionConfig[]
 ): ServerState[] {
   return configs.map(config => ({
     type,
@@ -121,7 +120,7 @@ export function getServerDescription(
   label: string = ''
 ): string | undefined {
   if (isManaged) {
-    label = `pip ${label}`;
+    label = label === '' ? 'pip' : `pip ${label}`;
   }
 
   if (connectionCount === 0) {
@@ -238,7 +237,7 @@ export function getServerTreeItem({
     ),
     command: canConnect
       ? {
-          title: 'Open in Browser',
+          title: 'Connect to server',
           command: 'vscode-deephaven.connectToServer',
           arguments: [server],
         }

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import type {
   IDhService,
   ServerState,
@@ -6,6 +7,7 @@ import type {
   EnterpriseConnectionConfig,
   CoreConnectionConfig,
   Port,
+  ServerGroupState,
 } from '../types';
 import {
   ICON_ID,
@@ -134,6 +136,39 @@ export function getServerDescription(
 }
 
 /**
+ * Get `contextValue` for a server group tree item.
+ * @param group Server group state
+ * @param canStartServer Whether servers can be started
+ */
+export function getServerGroupContextValue(
+  group: ServerGroupState,
+  canStartServer: boolean
+): typeof SERVER_TREE_ITEM_CONTEXT.canStartServer | undefined {
+  if (group === 'Managed' && canStartServer) {
+    return SERVER_TREE_ITEM_CONTEXT.canStartServer;
+  }
+
+  return undefined;
+}
+
+/**
+ * Get tree item for a server group.
+ * @param group Server group state
+ * @param canStartServer Whether servers can be started
+ */
+export function getServerGroupTreeItem(
+  group: ServerGroupState,
+  canStartServer: boolean
+): vscode.TreeItem {
+  return {
+    label: group,
+    iconPath: new vscode.ThemeIcon(ICON_ID.server),
+    collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+    contextValue: getServerGroupContextValue(group, canStartServer),
+  };
+}
+
+/**
  * Get icon path for a server in the UI. e.g. for tree nodes.
  * @param isConnected
  * @param isManaged
@@ -155,6 +190,90 @@ export function getServerIconPath({
     : isManaged
       ? ICON_ID.connecting
       : ICON_ID.serverStopped;
+}
+
+/**
+ * Get tree item for a server.
+ * @param server Server state
+ * @param isConnected Whether the server is connected
+ * @param isManaged Whether the server is managed
+ * @param isRunning Whether the server is running
+ */
+export function getServerTreeItem({
+  server,
+  isConnected,
+  isManaged,
+  isRunning,
+}: {
+  server: ServerState;
+  isConnected: boolean;
+  isManaged: boolean;
+  isRunning: boolean;
+}): vscode.TreeItem | Thenable<vscode.TreeItem> {
+  const contextValue = getServerContextValue({
+    isConnected,
+    isManaged,
+    isRunning,
+  });
+
+  const description = getServerDescription(
+    isConnected ? 1 : 0,
+    isManaged,
+    server.label
+  );
+
+  const urlStr = server.url.toString();
+
+  const canConnect =
+    contextValue === SERVER_TREE_ITEM_CONTEXT.isManagedServerDisconnected ||
+    contextValue === SERVER_TREE_ITEM_CONTEXT.isServerRunningDisconnected;
+
+  return {
+    label: new URL(urlStr).host,
+    description,
+    tooltip: canConnect ? `Click to connect to ${urlStr}` : urlStr,
+    contextValue: server.type === 'DHC' ? contextValue : undefined,
+    iconPath: new vscode.ThemeIcon(
+      getServerIconPath({ isConnected, isManaged, isRunning })
+    ),
+    command: canConnect
+      ? {
+          title: 'Open in Browser',
+          command: 'vscode-deephaven.connectToServer',
+          arguments: [server],
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Group server states.
+ * @param servers Server states
+ */
+export function groupServers(servers: ServerState[]): {
+  managed: ServerState[];
+  running: ServerState[];
+  stopped: ServerState[];
+} {
+  const managed = [];
+  const running = [];
+  const stopped = [];
+
+  for (const server of servers) {
+    if (server.isManaged) {
+      managed.push(server);
+    } else if (server.isRunning) {
+      running.push(server);
+    } else {
+      stopped.push(server);
+    }
+  }
+
+  return {
+    managed,
+    running,
+    stopped,
+  };
 }
 
 /**

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -69,13 +69,18 @@ export async function getFirstConnectionForConsoleType(
  */
 export function getServerDescription(
   connectionCount: number,
-  label?: string
+  isManaged: boolean,
+  label: string = ''
 ): string | undefined {
+  if (isManaged) {
+    label = `pip ${label}`;
+  }
+
   if (connectionCount === 0) {
     return label;
   }
 
-  if (label == null) {
+  if (label === '') {
     return `(${connectionCount})`;
   }
 

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -17,8 +17,9 @@ import {
 
 /**
  * Get initial server states based on server configs.
- * @param type
- * @param configs
+ * @param type Server type
+ * @param configs Server connection configs
+ * @returns Initial server states
  */
 export function getInitialServerStates(
   type: ServerType,
@@ -33,8 +34,9 @@ export function getInitialServerStates(
 
 /**
  * Get connections supporting the given console type.
- * @param connections
- * @param consoleType
+ * @param connections Connections to filter
+ * @param consoleType Console type to filter by
+ * @returns Connections supporting the given console type
  */
 export async function getConnectionsForConsoleType(
   connections: IDhService[],
@@ -54,8 +56,9 @@ export async function getConnectionsForConsoleType(
 
 /**
  * Get the first connection supporting the given console type.
- * @param connections
- * @param consoleType
+ * @param connections Connections to filter
+ * @param consoleType Console type to filter by
+ * @returns First connection supporting the given console type
  */
 export async function getFirstConnectionForConsoleType(
   connections: IDhService[],
@@ -71,7 +74,8 @@ export async function getFirstConnectionForConsoleType(
 
 /**
  * Get the pip server URL for the given port.
- * @param port
+ * @param port The port number to create a URL for
+ * @returns The pip server URL
  */
 export function getPipServerUrl(port: Port): URL {
   return new URL(`http://localhost:${port}`);
@@ -111,8 +115,10 @@ export function getServerContextValue({
 
 /**
  * Get description text for a server in the UI. e.g. for tree nodes.
- * @param connectionCount
- * @param label
+ * @param connectionCount Number of connections
+ * @param isManaged Whether the server is managed
+ * @param label Server label
+ * @returns Description text
  */
 export function getServerDescription(
   connectionCount: number,
@@ -138,6 +144,7 @@ export function getServerDescription(
  * Get `contextValue` for a server group tree item.
  * @param group Server group state
  * @param canStartServer Whether servers can be started
+ * @returns `contextValue` for the server group tree item
  */
 export function getServerGroupContextValue(
   group: ServerGroupState,
@@ -154,6 +161,7 @@ export function getServerGroupContextValue(
  * Get tree item for a server group.
  * @param group Server group state
  * @param canStartServer Whether servers can be started
+ * @returns Tree item for the server group
  */
 export function getServerGroupTreeItem(
   group: ServerGroupState,
@@ -168,12 +176,13 @@ export function getServerGroupTreeItem(
 }
 
 /**
- * Get icon path for a server in the UI. e.g. for tree nodes.
- * @param isConnected
- * @param isManaged
- * @param isRunning
+ * Get icon id for a server in the UI. e.g. for tree nodes.
+ * @param isConnected Whether the server is connected
+ * @param isManaged Whether the server is managed
+ * @param isRunning Whether the server is running
+ * @returns Icon id for server tree item
  */
-export function getServerIconPath({
+export function getServerIconID({
   isConnected,
   isManaged,
   isRunning,
@@ -197,6 +206,7 @@ export function getServerIconPath({
  * @param isConnected Whether the server is connected
  * @param isManaged Whether the server is managed
  * @param isRunning Whether the server is running
+ * @returns Tree item representing the server
  */
 export function getServerTreeItem({
   server,
@@ -233,7 +243,7 @@ export function getServerTreeItem({
     tooltip: canConnect ? `Click to connect to ${urlStr}` : urlStr,
     contextValue: server.type === 'DHC' ? contextValue : undefined,
     iconPath: new vscode.ThemeIcon(
-      getServerIconPath({ isConnected, isManaged, isRunning })
+      getServerIconID({ isConnected, isManaged, isRunning })
     ),
     command: canConnect
       ? {
@@ -248,6 +258,7 @@ export function getServerTreeItem({
 /**
  * Group server states.
  * @param servers Server states
+ * @returns Grouped server states
  */
 export function groupServers(servers: ServerState[]): {
   managed: ServerState[];
@@ -278,7 +289,7 @@ export function groupServers(servers: ServerState[]): {
 /**
  * Determine if the given languageId is supported by DH servers.
  * @param maybeSupported
- * @returns
+ * @returns Whether the languageId is supported
  */
 export function isSupportedLanguageId(
   maybeSupported?: string | null
@@ -289,6 +300,9 @@ export function isSupportedLanguageId(
 /**
  * Lazy async iterator that yields all connections supporting the given console
  * type.
+ * @param connections Connections to iterate
+ * @param consoleType Console type to filter by
+ * @returns Async iterator for connections supporting the given console type
  */
 export async function* iterateConnectionsForConsoleType(
   connections: IDhService[],
@@ -306,7 +320,8 @@ export async function* iterateConnectionsForConsoleType(
 
 /**
  * Parse a port string into a number.
- * @param portStr
+ * @param portStr Numeric port string to parse
+ * @returns Parsed port number
  */
 export function parsePort(portStr: string): Port {
   const parsed = Number(portStr);

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -6,7 +6,7 @@ import type {
   EnterpriseConnectionConfig,
   CoreConnectionConfig,
 } from '../types';
-import { SERVER_LANGUAGE_SET } from '../common';
+import { ICON_ID, SERVER_LANGUAGE_SET } from '../common';
 
 /**
  * Get initial server states based on server configs.
@@ -85,6 +85,30 @@ export function getServerDescription(
   }
 
   return `${label} (${connectionCount})`;
+}
+
+/**
+ * Get icon path for a server in the UI. e.g. for tree nodes.
+ * @param isConnected
+ * @param isManaged
+ * @param isRunning
+ */
+export function getServerIconPath({
+  isConnected,
+  isManaged,
+  isRunning,
+}: {
+  isConnected: boolean;
+  isManaged: boolean;
+  isRunning: boolean;
+}): string {
+  return isRunning
+    ? isConnected
+      ? ICON_ID.serverConnected
+      : ICON_ID.serverRunning
+    : isManaged
+      ? ICON_ID.connecting
+      : ICON_ID.serverStopped;
 }
 
 /**

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -5,6 +5,7 @@ import type {
   ConsoleType,
   EnterpriseConnectionConfig,
   CoreConnectionConfig,
+  Port,
 } from '../types';
 import { ICON_ID, SERVER_LANGUAGE_SET } from '../common';
 
@@ -60,6 +61,14 @@ export async function getFirstConnectionForConsoleType(
   ).next();
 
   return first.value ?? null;
+}
+
+/**
+ * Get the pip server URL for the given port.
+ * @param port
+ */
+export function getPipServerUrl(port: Port): URL {
+  return new URL(`http://localhost:${port}`);
 }
 
 /**
@@ -138,4 +147,17 @@ export async function* iterateConnectionsForConsoleType(
       yield dhService;
     }
   }
+}
+
+/**
+ * Parse a port string into a number.
+ * @param portStr
+ */
+export function parsePort(portStr: string): Port {
+  const parsed = Number(portStr);
+  if (isNaN(parsed)) {
+    throw new Error(`Invalid port: ${portStr}`);
+  }
+
+  return parsed as Port;
 }

--- a/src/util/uiUtils.spec.ts
+++ b/src/util/uiUtils.spec.ts
@@ -5,6 +5,7 @@ import {
   ConnectionOption,
   createConnectionOption,
   updateConnectionStatusBarItem,
+  createSeparatorPickItem,
 } from './uiUtils';
 import type { CoreConnectionConfig } from '../types';
 
@@ -66,4 +67,15 @@ describe('updateConnectionStatusBarItem', () => {
       expect(statusBarItem.text).toBe(text);
     }
   );
+});
+
+describe('createSeparatorPickItem', () => {
+  it('should create a separator quick pick item with label', () => {
+    const label = 'Some Label';
+    const actual = createSeparatorPickItem(label);
+    expect(actual).toEqual({
+      label,
+      kind: vscode.QuickPickItemKind.Separator,
+    });
+  });
 });

--- a/src/util/uiUtils.spec.ts
+++ b/src/util/uiUtils.spec.ts
@@ -44,9 +44,12 @@ describe('createConnectionQuickPickOptions', () => {
   const serverUrlC = new URL('http://localhost:10002');
   const serverUrlD = new URL('http://localhost:10003');
 
-  it.each([undefined, serverUrlA])(
-    'should return quick pick options',
-    editorActiveConnectionUrl => {
+  it.each([
+    ['No active', undefined],
+    ['Active A', serverUrlA],
+  ])(
+    'should return quick pick options: editorActiveConnectionUrl=%s',
+    (_label, editorActiveConnectionUrl) => {
       const serversWithoutConnections: ServerState[] = [
         { type: 'DHC', url: serverUrlB },
         { type: 'DHC', url: serverUrlD },

--- a/src/util/uiUtils.spec.ts
+++ b/src/util/uiUtils.spec.ts
@@ -5,9 +5,15 @@ import {
   ConnectionOption,
   createConnectionOption,
   updateConnectionStatusBarItem,
+  createConnectionQuickPickOptions,
   createSeparatorPickItem,
 } from './uiUtils';
-import type { CoreConnectionConfig } from '../types';
+import type {
+  CoreConnectionConfig,
+  IDhService,
+  ServerConnection,
+  ServerState,
+} from '../types';
 
 // See __mocks__/vscode.ts for the mock implementation
 vi.mock('vscode');
@@ -29,6 +35,44 @@ describe('createConnectionOption', () => {
   ] as const)(`should return connection option: '%s', %s`, (type, config) => {
     const actual = createConnectionOption(type)(config.url);
     expect(actual).toMatchSnapshot();
+  });
+});
+
+describe('createConnectionQuickPickOptions', () => {
+  const serverUrlA = new URL('http://localhost:10000');
+  const serverUrlB = new URL('http://localhost:10001');
+  const serverUrlC = new URL('http://localhost:10002');
+  const serverUrlD = new URL('http://localhost:10003');
+
+  it.each([undefined, serverUrlA])(
+    'should return quick pick options',
+    editorActiveConnectionUrl => {
+      const serversWithoutConnections: ServerState[] = [
+        { type: 'DHC', url: serverUrlB },
+        { type: 'DHC', url: serverUrlD },
+      ];
+      const connections: ServerConnection[] = [
+        { serverUrl: serverUrlA },
+        { serverUrl: serverUrlC },
+      ];
+
+      const actual = createConnectionQuickPickOptions(
+        serversWithoutConnections,
+        connections,
+        'python',
+        editorActiveConnectionUrl
+      );
+      expect(actual).toMatchSnapshot();
+    }
+  );
+
+  it('should throw if no servers or connections', () => {
+    const servers: ServerState[] = [];
+    const connections: IDhService[] = [];
+
+    expect(() =>
+      createConnectionQuickPickOptions(servers, connections, 'python')
+    ).toThrowError('No available servers to connect to.');
   });
 });
 

--- a/src/util/uiUtils.ts
+++ b/src/util/uiUtils.ts
@@ -13,6 +13,7 @@ import type {
   ServerState,
   SeparatorPickItem,
   ConnectionPickOption,
+  ServerConnection,
 } from '../types';
 
 export interface ConnectionOption {
@@ -39,12 +40,14 @@ export interface WorkspaceFolderConfig {
  * @param editorActiveConnectionUrl The active connection url of the editor
  * @returns
  */
-export function createConnectionQuickPickOptions(
+export function createConnectionQuickPickOptions<
+  TConnection extends ServerConnection,
+>(
   servers: ServerState[],
-  connections: IDhService[],
+  connections: TConnection[],
   editorLanguageId: string,
   editorActiveConnectionUrl?: URL | null
-): ConnectionPickOption[] {
+): ConnectionPickOption<TConnection>[] {
   const serverOptions: ConnectionPickItem<'server', ServerState>[] =
     servers.map(data => ({
       type: 'server',
@@ -54,7 +57,7 @@ export function createConnectionQuickPickOptions(
       data,
     }));
 
-  const connectionOptions: ConnectionPickItem<'connection', IDhService>[] = [];
+  const connectionOptions: ConnectionPickItem<'connection', TConnection>[] = [];
 
   for (const dhService of connections) {
     const isActiveConnection =
@@ -91,7 +94,7 @@ export function createConnectionQuickPickOptions(
  * Create quickpick for selecting a connection.
  */
 export async function createConnectionQuickPick(
-  options: ConnectionPickOption[]
+  options: ConnectionPickOption<IDhService>[]
 ): Promise<ServerState | IDhService | null> {
   const result = await vscode.window.showQuickPick(options, {
     title: 'Connect Editor',

--- a/src/util/uiUtils.ts
+++ b/src/util/uiUtils.ts
@@ -43,7 +43,7 @@ export async function createConnectionQuickPick(
     servers.map(data => ({
       type: 'server',
       label: data.url.toString(),
-      description: data.label,
+      description: data.label ?? (data.isManaged ? 'pip' : undefined),
       iconPath: new vscode.ThemeIcon(ICON_ID.server),
       data,
     }));
@@ -78,9 +78,9 @@ export async function createConnectionQuickPick(
       label: 'Active Connections',
       kind: vscode.QuickPickItemKind.Separator,
     },
-    ...connectionOptions,
+    ...connectionOptions.sort((a, b) => a.label.localeCompare(b.label)),
     { label: 'Connect to Server', kind: vscode.QuickPickItemKind.Separator },
-    ...serverOptions,
+    ...serverOptions.sort((a, b) => a.label.localeCompare(b.label)),
   ];
 
   const result = await vscode.window.showQuickPick(options, {


### PR DESCRIPTION
Added Pip server management
- Extension should detect whether `deephaven` python module is importable to determine if it is installed
- If installed, a "Managed" group should appear in the server tree with a play button on hover
  <img width="226" alt="image" src="https://github.com/user-attachments/assets/645053db-da5f-49b7-b2a8-16b61e9c4de4">
- Clicking the play button should start a pip server. Can currently start up to 4.
- The server will be added to the "Managed" group. Each server should show a "stop" button on hover
   <img width="226" alt="image" src="https://github.com/user-attachments/assets/830b24d8-ae58-4339-aa1f-21ab7d61be3e">

- Clicking stop button should discard the server + any connections to it
- Extension will poll a starting server for 30 seconds until it detects it has started. If so, it will automatically create a connection
- Once there is a connection, editors can be associated by drag and drop or via the status bar connector

resolves #108