### PR TITLE
fix: Changed pip server check mechanism

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -68,6 +68,8 @@ export const CONNECTION_TREE_ITEM_CONTEXT = {
   isUri: 'isUri',
 } as const;
 
+export const PIP_SERVER_STATUS_DIRECTORY = 'pip-server-status';
+
 export const SERVER_TREE_ITEM_CONTEXT = {
   canStartServer: 'canStartServer',
   isManagedServerConnected: 'isManagedServerConnected',

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import type {
   IDhService,
   ServerState,
@@ -6,7 +7,8 @@ import type {
   Port,
   ServerConnectionConfig,
 } from '../types';
-import { SERVER_LANGUAGE_SET } from '../common';
+import { PIP_SERVER_STATUS_DIRECTORY, SERVER_LANGUAGE_SET } from '../common';
+import { getTempDir } from './downloadUtils';
 
 /**
  * Get initial server states based on server configs.
@@ -72,6 +74,16 @@ export async function getFirstConnectionForConsoleType(
  */
 export function getPipServerUrl(port: Port): URL {
   return new URL(`http://localhost:${port}`);
+}
+
+/**
+ * Get the path to the pip server status file.
+ * @returns The path to the pip server status file
+ */
+export function getPipStatusFilePath(): string {
+  const dirPath = getTempDir(false, PIP_SERVER_STATUS_DIRECTORY);
+  const statusFileName = `status-pip.txt`;
+  return path.join(dirPath, statusFileName);
 }
 
 /**


### PR DESCRIPTION
Fixed issue with error message showing up in non-pip env.

Testing Performed
- Load workspace without pip env. "Managed" server node is not shown. No toast error message
- Load a `.venv` via vscode Python features. Refresh servers. "Managed" shows and can start server
- Renamed `.venv` to `.venv-bak`. Without restarting workspace, try starting Pip server. Toast error shows "Could not find `deephaven_server` Python module, and "Managed" server node is removed.

resolves #126