### PR TITLE
fix: Pip servers handle config changes gracefully

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import type { ConsoleType, Port, VariableType } from '../types';
+import type { ConsoleType, VariableType } from '../types';
 
 export const EXTENSION_ID = 'vscode-deephaven' as const;
 
@@ -11,10 +11,6 @@ export const CONFIG_KEY = {
 
 export const DEFAULT_CONSOLE_TYPE = 'python' as const;
 // export const DHFS_SCHEME = 'dhfs';
-
-export const DEFAULT_PIP_PORT_RANGE: ReadonlySet<Port> = new Set([
-  10001, 10002, 10003, 10004,
-] as Port[]);
 
 export const PYTHON_ENV_WAIT = 1500 as const;
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import {
   CONNECT_TO_SERVER_CMD,
   CREATE_NEW_TEXT_DOC_CMD,
-  DEFAULT_PIP_PORT_RANGE,
   DISCONNECT_EDITOR_CMD,
   DISCONNECT_FROM_SERVER_CMD,
   DOWNLOAD_LOGS_CMD,
@@ -179,7 +178,6 @@ export class ExtensionController implements Disposable {
     this._pipServerController = new PipServerController(
       this._context,
       this._serverManager,
-      DEFAULT_PIP_PORT_RANGE,
       this._outputChannel,
       this._toaster
     );

--- a/src/services/SerializedKeyMap.ts
+++ b/src/services/SerializedKeyMap.ts
@@ -67,7 +67,7 @@ export abstract class SerializedKeyMap<TKey, TValue> {
     }
   }
 
-  *values(): IterableIterator<TValue> {
-    yield* this._map.values();
+  values(): IteratorObject<TValue> {
+    return this._map.values();
   }
 }

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -48,6 +48,9 @@ export class ServerManager implements IServerManager {
   private readonly _onDidDisconnect = new vscode.EventEmitter<URL>();
   readonly onDidDisconnect = this._onDidDisconnect.event;
 
+  private readonly _onDidLoadConfig = new vscode.EventEmitter<void>();
+  readonly onDidLoadConfig = this._onDidLoadConfig.event;
+
   private readonly _onDidServerStatusChange =
     new vscode.EventEmitter<ServerState>();
   readonly onDidServerStatusChange = this._onDidServerStatusChange.event;
@@ -89,6 +92,8 @@ export class ServerManager implements IServerManager {
     }
 
     await this.updateStatus();
+
+    this._onDidLoadConfig.fire();
   };
 
   connectToServer = async (serverUrl: URL): Promise<IDhService | null> => {

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -120,6 +120,7 @@ export interface IServerManager extends Disposable {
 
   onDidConnect: vscode.Event<URL>;
   onDidDisconnect: vscode.Event<URL>;
+  onDidLoadConfig: vscode.Event<void>;
   onDidRegisterEditor: vscode.Event<vscode.Uri>;
   onDidServerStatusChange: vscode.Event<ServerState>;
   onDidUpdate: vscode.Event<void>;


### PR DESCRIPTION
- Pip servers now support a larger range of ports
- Configured servers now reserve ports so pip servers won't touch them
- If configuration changes such that a running pip server becomes reserved by config, the pip server will be shut down
- Keep server state for running pip servers on config change so that generated PSKs can continue to be used

**Testing**
I used a configuration targetting the first few ports starting at `10000`

**Initial config (servers all commented out)**
```jsonc
"deephaven.coreServers": [
  // "http://localhost:10000/",
  // "http://localhost:10001/",
  // "http://localhost:10002/",
  ```
  
**Pip server port becomes reserved via config change**
- Start a pip server (should start on port `10000`)
- Modify config by uncommenting `"http://localhost:10000/"`
- Pip server should automatically stop. `localhost:10000` should be listed under "Stopped" and no longer under "Managed"

**Start server outside of extension**
- Start a server on port `10000` (outside of extension)
- Refreshing server panel should show it as running and allow connection

**Arbitrary config change**
- Start a pip server
- Make a config change that doesn't affect the port of the running server
- Pip server should remain connected and usable

resolves #137 