### PR TITLE
feat: Worker settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,48 @@
           "description": "List of Deephaven Enterprise servers that the extension can connect to.",
           "type": "array",
           "items": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "Deephaven Enterprise server URL"
+              },
+              {
+                "type": "object",
+                "description": "Deephaven Enterprise server config",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "Deephaven Enterprise server URL"
+                  },
+                  "label": {
+                    "type": "string",
+                    "title": "Label",
+                    "description": "Optional label for the server"
+                  },
+                  "experimentalWorkerConfig": {
+                    "type": "object",
+                    "description": "(experimental) Worker configuration used when creating new connections to the server",
+                    "properties": {
+                      "dbServerName": {
+                        "type": "string"
+                      },
+                      "heapSize": {
+                        "type": "number"
+                      },
+                      "jvmArgs": {
+                        "type": "string"
+                      },
+                      "jvmProfile": {
+                        "type": "string"
+                      },
+                      "scriptLanguage": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
           },
           "default": []
         }

--- a/package.json
+++ b/package.json
@@ -57,27 +57,29 @@
         "deephaven.coreServers": {
           "description": "List of Deephaven Core servers that the extension can connect to.",
           "type": "array",
-          "items": [
-            {
-              "type": "string",
-              "description": "Deephaven Core server URL"
-            },
-            {
-              "type": "object",
-              "description": "Deephaven Core server config",
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "description": "Deephaven Core server URL"
-                },
-                "label": {
-                  "type": "string",
-                  "title": "Label",
-                  "description": "Optional label for the server"
+          "items": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "Deephaven Core server URL"
+              },
+              {
+                "type": "object",
+                "description": "Deephaven Core server config",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "Deephaven Core server URL"
+                  },
+                  "label": {
+                    "type": "string",
+                    "title": "Label",
+                    "description": "Optional label for the server"
+                  }
                 }
               }
-            }
-          ],
+            ]
+          },
           "default": [
             "http://localhost:10000/"
           ]

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -311,6 +311,7 @@ export class ExtensionController implements Disposable {
     );
 
     this._dheServiceFactory = DheService.factory(
+      this._config,
       this._coreCredentialsCache,
       this._dheClientCache,
       this._dheCredentialsCache,

--- a/src/dh/dhe.ts
+++ b/src/dh/dhe.ts
@@ -138,7 +138,9 @@ export async function createInteractiveConsoleQuery(
   const heapSize = workerConfig?.heapSize ?? queryConstants.pqDefaultHeap;
 
   // We have to use websockets since fetch over http2 is not sufficiently
-  // supported in the nodejs environment (v20 at time of this comment).
+  // supported in the nodejs environment bundled with `vscode` (v20 at time of
+  // this comment). Note that the `http` in the key name does not indicate
+  // insecure websockets. The connection will be a `wss:` secure connection.
   const jvmArgs = workerConfig?.jvmArgs
     ? `'-Dhttp.websockets=true' ${workerConfig.jvmArgs}`
     : '-Dhttp.websockets=true';

--- a/src/dh/dhe.ts
+++ b/src/dh/dhe.ts
@@ -136,11 +136,13 @@ export async function createInteractiveConsoleQuery(
   const dbServerName =
     workerConfig?.dbServerName ?? dbServers[0]?.name ?? 'Query 1';
   const heapSize = workerConfig?.heapSize ?? queryConstants.pqDefaultHeap;
-  // TODO: deephaven/vscode-deephaven/issues/153 to update this to secure websocket
-  // connection and remove the http.websockets property
+
+  // We have to use websockets since fetch over http2 is not sufficiently
+  // supported in the nodejs environment (v20 at time of this comment).
   const jvmArgs = workerConfig?.jvmArgs
     ? `'-Dhttp.websockets=true' ${workerConfig.jvmArgs}`
     : '-Dhttp.websockets=true';
+
   const jvmProfile =
     workerConfig?.jvmProfile ?? serverConfigValues.jvmProfileDefault;
   const scriptLanguage =
@@ -178,9 +180,7 @@ export async function createInteractiveConsoleQuery(
     dbServerName,
     heapSize: heapSize,
     scheduling,
-    // We have to use websockets since http2 is not sufficiently supported in
-    // the nodejs environment (v20 at time of this comment).
-    jvmArgs: '-Dhttp.websockets=true',
+    jvmArgs,
     jvmProfile,
     scriptLanguage,
     timeout,

--- a/src/services/ConfigService.ts
+++ b/src/services/ConfigService.ts
@@ -29,17 +29,7 @@ function getCoreServers(): CoreConnectionConfig[] {
   logger.info('Core servers:', JSON.stringify(expandedConfig));
 
   return expandedConfig
-    .filter(server => {
-      try {
-        // Filter out any invalid server configs to avoid crashing the extension
-        // further upstream.
-        new URL(server.url);
-        return true;
-      } catch (err) {
-        logger.error(err, server.url);
-        return false;
-      }
-    })
+    .filter(hasValidURL)
     .map(server => ({ ...server, url: new URL(server.url) }));
 }
 
@@ -49,23 +39,31 @@ function getEnterpriseServers(): EnterpriseConnectionConfig[] {
     []
   );
 
-  const expandedConfig = config.map(url => ({ url }));
+  // Expand each server config to a full `ConnectionConfig` object.
+  const expandedConfig = config.map(server =>
+    typeof server === 'string' ? { url: server } : server
+  );
 
   logger.info('Enterprise servers:', JSON.stringify(expandedConfig));
 
   return expandedConfig
-    .filter(server => {
-      try {
-        // Filter out any invalid server configs to avoid crashing the extension
-        // further upstream.
-        new URL(server.url);
-        return true;
-      } catch (err) {
-        logger.error(err, server.url);
-        return false;
-      }
-    })
+    .filter(hasValidURL)
     .map(server => ({ ...server, url: new URL(server.url) }));
+}
+
+/**
+ * Attempt to parse a `url` string prop into a `URL` object.
+ * @param objectWithUrl An object with a `url` string prop.
+ * @returns `true` if the `url` prop is a valid URL, `false` otherwise.
+ */
+function hasValidURL({ url }: { url: string }): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch (err) {
+    logger.error(err, url);
+    return false;
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -28,17 +28,27 @@ export interface CoreConnectionConfig {
 }
 
 export type EnterpriseConnectionConfigStored =
-  Brand<'EnterpriseConnectionConfigStored'>;
+  | Brand<'EnterpriseConnectionConfigStored'>
+  | { url: string; label?: string; experimentalWorkerConfig?: WorkerConfig };
 
 export interface EnterpriseConnectionConfig {
-  label?: string;
   url: URL;
+  label?: string;
+  experimentalWorkerConfig?: WorkerConfig;
 }
 
 export type ServerConnectionConfig =
   | CoreConnectionConfig
   | EnterpriseConnectionConfig
   | URL;
+
+export interface WorkerConfig {
+  dbServerName?: string;
+  heapSize?: number;
+  jvmArgs?: string;
+  jvmProfile?: string;
+  scriptLanguage?: string;
+}
 
 export interface ConnectionState {
   readonly isConnected: boolean;


### PR DESCRIPTION
Enterprise settings now support an expanded config:
- Optional server label
- Experimental worker config - an object of optional worker settings that will drive PQ creation

Also fixed a small json schema bug for community settings that was breaking intellisense in settings.json

**Testing**
Simple config should still work:
```jsonc
"deephaven.enterpriseServers": [
  https://dev-vplus.int.illumon.com:8123/
]
```

Expanded config should drive server label in the server tree and / or worker creation settings:
```jsonc
"deephaven.enterpriseServers": [
  {
    "url": "https://dev-vplus.int.illumon.com:8123/",
    "label": "San Luis", // optional label
    "experimentalWorkerConfig": {
      // custom heap size
      "heapSize": 0.5
    }
  },
]
```