### PR TITLE
fix: Cleanup worker event handling

### DIFF
--- a/src/dh/dhe.ts
+++ b/src/dh/dhe.ts
@@ -195,15 +195,25 @@ export async function getWorkerInfoFromQuery(
   // The query will go through multiple config updates before the worker is ready.
   // This Promise will respond to config update events and resolve when the worker
   // is ready.
-  const queryInfo = await new Promise<QueryInfo>(resolve => {
-    dheClient.addEventListener(
+  const queryInfo = await new Promise<QueryInfo>((resolve, reject) => {
+    const removeEventListener = dheClient.addEventListener(
       dhe.Client.EVENT_CONFIG_UPDATED,
       ({ detail: queryInfo }: CustomEvent<QueryInfo>) => {
-        if (
-          queryInfo.serial === querySerial &&
-          queryInfo.designated?.status === 'Running'
-        ) {
-          resolve(queryInfo);
+        if (queryInfo.serial !== querySerial) {
+          return;
+        }
+
+        switch (queryInfo.designated?.status) {
+          case 'Running':
+            removeEventListener();
+            resolve(queryInfo);
+            break;
+          case 'Error':
+          case 'Failed':
+            removeEventListener();
+            reject(new Error('Query failed to start'));
+            deleteQueries(dheClient, [querySerial]);
+            break;
         }
       }
     );


### PR DESCRIPTION
- Remove event handler when query is running or fails
- Handle failed query starts and cleanup 

resolves #158 