### PR TITLE
fix: Fixed race condition with debug tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,24 +15,35 @@
       }
     },
     {
+      "label": "npm: clean",
+      "type": "npm",
+      "script": "clean",
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": "build"
+    },
+    {
+      "label": "npm: watch:esbuild",
       "type": "npm",
       "script": "watch:esbuild",
+      "dependsOn": "npm: clean",
       "group": "build",
       "problemMatcher": "$esbuild-watch",
       "isBackground": true,
-      "label": "npm: watch:esbuild",
       "presentation": {
         "group": "watch",
         "reveal": "never"
       }
     },
     {
+      "label": "npm: watch:tsc",
       "type": "npm",
       "script": "watch:tsc",
+      "dependsOn": "npm: clean",
       "group": "build",
       "problemMatcher": "$tsc-watch",
       "isBackground": true,
-      "label": "npm: watch:tsc",
       "presentation": {
         "group": "watch",
         "reveal": "never"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "check:types": "npm run clean && tsc --build ./tsconfig.json && tsc -p tsconfig.unit.json --noEmit --module preserve --moduleResolution bundler && tsc -p e2e/tsconfig.json --noEmit --skipLibCheck",
-    "clean": "rm -rf out packages/*/tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist out packages/*/tsconfig.tsbuildinfo",
     "compile": "npm run check:types && node scripts/esbuild.js",
     "compile:prod": "npm run check:types && npm run test:lint && node scripts/esbuild.js --production",
     "icon:gen": "node icons/generate.mjs",
@@ -48,7 +48,7 @@
     "test": "npm run test:unit",
     "vscode:prepublish": "compile:prod",
     "watch:esbuild": "node scripts/esbuild.js --watch",
-    "watch:tsc": "npm run clean && tsc --build ./tsconfig.json --watch",
+    "watch:tsc": "tsc --build ./tsconfig.json --watch",
     "watch": "npm-run-all -p watch:*"
   },
   "contributes": {


### PR DESCRIPTION
Running the debugger was intermittently failing due to a race condition with the npm `clean` script deleting the `out` directory. This fix should ensure clean is completed before the 2 watch tasks start.