### PR TITLE
build: Fixed botched release

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,9 +13,4 @@
 !out/**/*.js
 !snippets.code-snippets
 
-!node_modules/**/LICENSE
-!node_modules/**/package.json
-!node_modules/**/README.md
-
-!node_modules/@deephaven/require-jsapi/**/*.js
-!node_modules/ws/**/*.{js,mjs}
+!node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
         "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
         "@deephaven/jsapi-nodejs": "^0.99.0",
+        "esbuild": "^0.24.0",
         "nanoid": "^5.0.7"
       },
       "devDependencies": {
@@ -30,7 +31,6 @@
         "@wdio/mocha-framework": "^8.39.0",
         "@wdio/spec-reporter": "^8.39.0",
         "ctrf": "^0.0.9",
-        "esbuild": "^0.24.0",
         "eslint": "^8.57.0",
         "fantasticon": "^3.0.0",
         "github-actions-ctrf": "^0.0.20",

--- a/package.json
+++ b/package.json
@@ -849,6 +849,7 @@
     "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
     "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
     "@deephaven/jsapi-nodejs": "^0.99.0",
+    "esbuild": "^0.24.0",
     "nanoid": "^5.0.7"
   },
   "devDependencies": {
@@ -865,7 +866,6 @@
     "@wdio/mocha-framework": "^8.39.0",
     "@wdio/spec-reporter": "^8.39.0",
     "ctrf": "^0.0.9",
-    "esbuild": "^0.24.0",
     "eslint": "^8.57.0",
     "fantasticon": "^3.0.0",
     "github-actions-ctrf": "^0.0.20",


### PR DESCRIPTION
- Converted esbuild from devDependency to runtime dependency
- Removed node_modules exclusions from packaging. It looks like the vscode packaging is "supposed" to exclude dev dependencies. https://github.com/microsoft/vscode-vsce/issues/52