### PR TITLE
feat: Optional label now replaces url in tree views

### DIFF
--- a/src/providers/ServerConnectionPanelTreeProvider.ts
+++ b/src/providers/ServerConnectionPanelTreeProvider.ts
@@ -34,7 +34,8 @@ export class ServerConnectionPanelTreeProvider extends TreeDataProviderBase<Serv
 
     return getPanelConnectionTreeItem(
       connectionOrVariable,
-      getFirstSupportedConsoleType
+      getFirstSupportedConsoleType,
+      'demo.deephaven.io'
     );
   };
 

--- a/src/providers/ServerConnectionPanelTreeProvider.ts
+++ b/src/providers/ServerConnectionPanelTreeProvider.ts
@@ -32,10 +32,15 @@ export class ServerConnectionPanelTreeProvider extends TreeDataProviderBase<Serv
       return getPanelVariableTreeItem(connectionOrVariable);
     }
 
+    const serverLabel = this.serverManager.getServer(
+      connectionOrVariable.serverUrl,
+      false
+    )?.label;
+
     return getPanelConnectionTreeItem(
       connectionOrVariable,
       getFirstSupportedConsoleType,
-      'demo.deephaven.io'
+      serverLabel
     );
   };
 

--- a/src/providers/ServerConnectionTreeProvider.ts
+++ b/src/providers/ServerConnectionTreeProvider.ts
@@ -46,7 +46,12 @@ export class ServerConnectionTreeProvider extends TreeDataProviderBase<ServerCon
     }
 
     const hasUris = this.serverManager.hasConnectionUris(connectionOrUri);
-    const serverLabel = 'demo.deephaven.io';
+
+    const serverLabel = this.serverManager.getServer(
+      connectionOrUri.serverUrl,
+      false
+    )?.label;
+
     const label =
       serverLabel == null
         ? connectionOrUri.serverUrl.host

--- a/src/providers/ServerConnectionTreeProvider.ts
+++ b/src/providers/ServerConnectionTreeProvider.ts
@@ -52,10 +52,7 @@ export class ServerConnectionTreeProvider extends TreeDataProviderBase<ServerCon
       false
     )?.label;
 
-    const label =
-      serverLabel == null
-        ? connectionOrUri.serverUrl.host
-        : `${serverLabel}:${connectionOrUri.serverUrl.port}`;
+    const label = serverLabel ?? connectionOrUri.serverUrl.host;
 
     // Connection node
     return {

--- a/src/providers/ServerConnectionTreeProvider.ts
+++ b/src/providers/ServerConnectionTreeProvider.ts
@@ -46,10 +46,15 @@ export class ServerConnectionTreeProvider extends TreeDataProviderBase<ServerCon
     }
 
     const hasUris = this.serverManager.hasConnectionUris(connectionOrUri);
+    const serverLabel = 'demo.deephaven.io';
+    const label =
+      serverLabel == null
+        ? connectionOrUri.serverUrl.host
+        : `${serverLabel}:${connectionOrUri.serverUrl.port}`;
 
     // Connection node
     return {
-      label: `demo.deephaven.io:${connectionOrUri.serverUrl.port}`, // new URL(connectionOrUri.serverUrl.toString()).host,
+      label,
       description: descriptionTokens.join(' - '),
       contextValue: CONNECTION_TREE_ITEM_CONTEXT.isConnection,
       collapsibleState: hasUris

--- a/src/providers/ServerConnectionTreeProvider.ts
+++ b/src/providers/ServerConnectionTreeProvider.ts
@@ -49,7 +49,7 @@ export class ServerConnectionTreeProvider extends TreeDataProviderBase<ServerCon
 
     // Connection node
     return {
-      label: new URL(connectionOrUri.serverUrl.toString()).host,
+      label: `demo.deephaven.io:${connectionOrUri.serverUrl.port}`, // new URL(connectionOrUri.serverUrl.toString()).host,
       description: descriptionTokens.join(' - '),
       contextValue: CONNECTION_TREE_ITEM_CONTEXT.isConnection,
       collapsibleState: hasUris

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -404,10 +404,22 @@ export class ServerManager implements IServerManager {
   /**
    * Get the server state for the given URL.
    * @param serverUrl The URL of the server to get.
+   * @param matchPort If `true`, include the port when matching the server URL. Defaults to `true`.
    * @returns The server state, or `undefined` if no server with the given URL exists.
    */
-  getServer = (serverUrl: URL): ServerState | undefined => {
-    return this._serverMap.get(serverUrl);
+  getServer = (
+    serverUrl: URL,
+    matchPort: boolean = true
+  ): ServerState | undefined => {
+    if (matchPort) {
+      return this._serverMap.get(serverUrl);
+    }
+
+    for (const server of this._serverMap.values()) {
+      if (server.url.hostname === serverUrl.hostname) {
+        return server;
+      }
+    }
   };
 
   getServers = ({

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -167,7 +167,7 @@ export interface IServerManager extends Disposable {
     dhService: ConnectionState
   ) => Promise<void>;
 
-  getServer: (serverUrl: URL) => ServerState | undefined;
+  getServer: (serverUrl: URL, matchPort?: boolean) => ServerState | undefined;
   getServers: (filter?: {
     isRunning?: boolean;
     hasConnections?: boolean;

--- a/src/util/__snapshots__/treeViewUtils.spec.ts.snap
+++ b/src/util/__snapshots__/treeViewUtils.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`getPanelConnectionTreeItem > should return panel connection tree item: isConnected:false, isInitialized:false 1`] = `
 {
   "collapsibleState": 2,
-  "description": "",
+  "description": undefined,
   "iconPath": {
     "color": undefined,
     "id": "sync~spin",
@@ -27,7 +27,7 @@ exports[`getPanelConnectionTreeItem > should return panel connection tree item: 
 exports[`getPanelConnectionTreeItem > should return panel connection tree item: isConnected:true, isInitialized:false 1`] = `
 {
   "collapsibleState": 2,
-  "description": "",
+  "description": undefined,
   "iconPath": {
     "color": undefined,
     "id": "vm-connect",

--- a/src/util/__snapshots__/treeViewUtils.spec.ts.snap
+++ b/src/util/__snapshots__/treeViewUtils.spec.ts.snap
@@ -415,7 +415,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "circle-slash",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -442,7 +442,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "circle-large-outline",
   },
   "label": "localhost:10000",
-  "tooltip": "Click to connect to http://localhost:10000/",
+  "tooltip": "Click to connect to localhost:10000",
 }
 `;
 
@@ -456,7 +456,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "sync~spin",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -484,7 +484,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "circle-large-outline",
   },
   "label": "localhost:10000",
-  "tooltip": "Click to connect to http://localhost:10000/",
+  "tooltip": "Click to connect to localhost:10000",
 }
 `;
 
@@ -498,7 +498,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "circle-slash",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -512,7 +512,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "circle-large-filled",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -526,7 +526,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "sync~spin",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -540,7 +540,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHC, isConnect
     "id": "circle-large-filled",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -554,7 +554,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "circle-slash",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -581,7 +581,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "circle-large-outline",
   },
   "label": "localhost:10000",
-  "tooltip": "Click to connect to http://localhost:10000/",
+  "tooltip": "Click to connect to localhost:10000",
 }
 `;
 
@@ -595,7 +595,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "sync~spin",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -623,7 +623,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "circle-large-outline",
   },
   "label": "localhost:10000",
-  "tooltip": "Click to connect to http://localhost:10000/",
+  "tooltip": "Click to connect to localhost:10000",
 }
 `;
 
@@ -637,7 +637,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "circle-slash",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -664,7 +664,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "circle-large-filled",
   },
   "label": "localhost:10000",
-  "tooltip": "Click to connect to http://localhost:10000/",
+  "tooltip": "Click to connect to localhost:10000",
 }
 `;
 
@@ -678,7 +678,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "sync~spin",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 
@@ -692,7 +692,7 @@ exports[`getServerTreeItem > should return server tree item: type=DHE, isConnect
     "id": "circle-large-filled",
   },
   "label": "localhost:10000",
-  "tooltip": "http://localhost:10000/",
+  "tooltip": "localhost:10000",
 }
 `;
 

--- a/src/util/__snapshots__/treeViewUtils.spec.ts.snap
+++ b/src/util/__snapshots__/treeViewUtils.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`getPanelConnectionTreeItem > should return panel connection tree item: isConnected:false, isInitialized:false 1`] = `
 {
   "collapsibleState": 2,
-  "description": undefined,
+  "description": "",
   "iconPath": {
     "color": undefined,
     "id": "sync~spin",
@@ -27,7 +27,7 @@ exports[`getPanelConnectionTreeItem > should return panel connection tree item: 
 exports[`getPanelConnectionTreeItem > should return panel connection tree item: isConnected:true, isInitialized:false 1`] = `
 {
   "collapsibleState": 2,
-  "description": undefined,
+  "description": "",
   "iconPath": {
     "color": undefined,
     "id": "vm-connect",

--- a/src/util/treeViewUtils.ts
+++ b/src/util/treeViewUtils.ts
@@ -58,15 +58,23 @@ export async function getPanelConnectionTreeItem(
   ) => Promise<ConsoleType | undefined>,
   serverLabel?: string
 ): Promise<vscode.TreeItem> {
+  const descriptionTokens: string[] = [];
+
   const consoleType = await getConsoleType(connection);
-  const label =
-    serverLabel == null
-      ? new URL(connection.serverUrl).host
-      : `${serverLabel}:${connection.serverUrl.port}`;
+
+  if (consoleType) {
+    descriptionTokens.push(consoleType);
+  }
+
+  if (connection.tagId) {
+    descriptionTokens.push(connection.tagId);
+  }
+
+  const label = serverLabel ?? connection.serverUrl.host;
 
   return {
     label,
-    description: consoleType,
+    description: descriptionTokens.join(' - '),
     collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
     iconPath: new vscode.ThemeIcon(
       connection.isConnected ? ICON_ID.connected : ICON_ID.connecting
@@ -259,7 +267,7 @@ export function getServerTreeItem(server: ServerState): vscode.TreeItem {
     contextValue === SERVER_TREE_ITEM_CONTEXT.isDHEServerRunningDisconnected;
 
   const url = new URL(urlStr);
-  const label = server.label == null ? url.host : `${server.label}:${url.port}`;
+  const label = server.label ?? url.host;
 
   return {
     label,

--- a/src/util/treeViewUtils.ts
+++ b/src/util/treeViewUtils.ts
@@ -248,11 +248,7 @@ export function getServerTreeItem(server: ServerState): vscode.TreeItem {
     isRunning,
   });
 
-  const description = getServerDescription(
-    connectionCount,
-    isManaged
-    // server.label
-  );
+  const description = getServerDescription(connectionCount, isManaged);
 
   const urlStr = server.url.toString();
 

--- a/src/util/treeViewUtils.ts
+++ b/src/util/treeViewUtils.ts
@@ -71,10 +71,12 @@ export async function getPanelConnectionTreeItem(
   }
 
   const label = serverLabel ?? connection.serverUrl.host;
+  const description =
+    descriptionTokens.length === 0 ? undefined : descriptionTokens.join(' - ');
 
   return {
     label,
-    description: descriptionTokens.join(' - '),
+    description,
     collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
     iconPath: new vscode.ThemeIcon(
       connection.isConnected ? ICON_ID.connected : ICON_ID.connecting

--- a/src/util/treeViewUtils.ts
+++ b/src/util/treeViewUtils.ts
@@ -60,7 +60,7 @@ export async function getPanelConnectionTreeItem(
   const consoleType = await getConsoleType(connection);
 
   return {
-    label: new URL(connection.serverUrl.toString()).host,
+    label: `demo.deephaven.io:${connection.serverUrl.port}`, //  new URL(connection.serverUrl.toString()).host,
     description: consoleType,
     collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
     iconPath: new vscode.ThemeIcon(
@@ -257,10 +257,13 @@ export function getServerTreeItem(server: ServerState): vscode.TreeItem {
     contextValue === SERVER_TREE_ITEM_CONTEXT.isDHEServerRunningConnected ||
     contextValue === SERVER_TREE_ITEM_CONTEXT.isDHEServerRunningDisconnected;
 
+  const mockUrl = new URL(urlStr);
+  mockUrl.hostname = 'demo.deephaven.io';
+
   return {
-    label: new URL(urlStr).host,
+    label: mockUrl.host,
     description,
-    tooltip: canConnect ? `Click to connect to ${urlStr}` : urlStr,
+    tooltip: canConnect ? `Click to connect to ${mockUrl.href}` : mockUrl.href,
     contextValue,
     iconPath: new vscode.ThemeIcon(
       getServerIconID({ isConnected, isManaged, isRunning })

--- a/src/util/treeViewUtils.ts
+++ b/src/util/treeViewUtils.ts
@@ -55,12 +55,17 @@ export async function getPanelConnectionTreeItem(
   connection: ConnectionState,
   getConsoleType: (
     connection: ConnectionState
-  ) => Promise<ConsoleType | undefined>
+  ) => Promise<ConsoleType | undefined>,
+  serverLabel?: string
 ): Promise<vscode.TreeItem> {
   const consoleType = await getConsoleType(connection);
+  const label =
+    serverLabel == null
+      ? new URL(connection.serverUrl).host
+      : `${serverLabel}:${connection.serverUrl.port}`;
 
   return {
-    label: `demo.deephaven.io:${connection.serverUrl.port}`, //  new URL(connection.serverUrl.toString()).host,
+    label,
     description: consoleType,
     collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
     iconPath: new vscode.ThemeIcon(
@@ -245,8 +250,8 @@ export function getServerTreeItem(server: ServerState): vscode.TreeItem {
 
   const description = getServerDescription(
     connectionCount,
-    isManaged,
-    server.label
+    isManaged
+    // server.label
   );
 
   const urlStr = server.url.toString();
@@ -257,13 +262,13 @@ export function getServerTreeItem(server: ServerState): vscode.TreeItem {
     contextValue === SERVER_TREE_ITEM_CONTEXT.isDHEServerRunningConnected ||
     contextValue === SERVER_TREE_ITEM_CONTEXT.isDHEServerRunningDisconnected;
 
-  const mockUrl = new URL(urlStr);
-  mockUrl.hostname = 'demo.deephaven.io';
+  const url = new URL(urlStr);
+  const label = server.label == null ? url.host : `${server.label}:${url.port}`;
 
   return {
-    label: mockUrl.host,
+    label,
     description,
-    tooltip: canConnect ? `Click to connect to ${mockUrl.href}` : mockUrl.href,
+    tooltip: canConnect ? `Click to connect to ${label}` : label,
     contextValue,
     iconPath: new vscode.ThemeIcon(
       getServerIconID({ isConnected, isManaged, isRunning })


### PR DESCRIPTION
I tweaked this to make it easier to anonymize demos / documentation videos. The optional `label` config now replaces the URL instead of being displayed beside it.

```jsonc
"deephaven.enterpriseServers": [
  {
    "url": "https://bmingles-grizzly.int.illumon.com:8123",
    "label": "demo.deephaven.io",
  }
]
```

<img width="513" alt="image" src="https://github.com/user-attachments/assets/7fab7a46-8507-4557-8f1e-a54babc8bec6">
