### PR TITLE
fix: Remove runtime esbuild dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
       "dependencies": {
         "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
         "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
-        "@deephaven/jsapi-nodejs": "0.100.0",
-        "esbuild-wasm": "^0.24.0",
+        "@deephaven/jsapi-nodejs": "0.102.0",
         "nanoid": "^5.0.7"
       },
       "devDependencies": {
@@ -31,6 +30,7 @@
         "@wdio/mocha-framework": "^8.39.0",
         "@wdio/spec-reporter": "^8.39.0",
         "ctrf": "^0.0.9",
+        "esbuild-wasm": "^0.24.0",
         "eslint": "^8.57.0",
         "fantasticon": "^3.0.0",
         "github-actions-ctrf": "^0.0.20",
@@ -467,17 +467,14 @@
       }
     },
     "node_modules/@deephaven/jsapi-nodejs": {
-      "version": "0.100.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.100.0.tgz",
-      "integrity": "sha512-VuqRcpunFydsnMIfdRjZfwAmEfjo1onlRn73/xOs3ZeyY0oLZ3jP5fz4U1U/Rezo+1G+hWD5tZlf7IHVT01qGw==",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.102.0.tgz",
+      "integrity": "sha512-BtnhM8CwIHjK+8Vws02MjEUxgMLIBX78jTtFYgbRX8/1gLgq97pnsumhvnucc9JDf8hbIslXtkIUb+6Mc8f9aQ==",
       "dependencies": {
         "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=16"
-      },
-      "peerDependencies": {
-        "esbuild-wasm": "^0.24.0"
       }
     },
     "node_modules/@deephaven/jsapi-types": {
@@ -5824,6 +5821,7 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.24.0.tgz",
       "integrity": "sha512-xhNn5tL1AhkPg4ft59yXT6FkwKXiPSYyz1IeinJHUJpjvOHOIPvdmFQc0pGdjxlKSbzZc2mNmtVOWAR1EF/JAg==",
+      "dev": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -15509,9 +15507,9 @@
       }
     },
     "@deephaven/jsapi-nodejs": {
-      "version": "0.100.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.100.0.tgz",
-      "integrity": "sha512-VuqRcpunFydsnMIfdRjZfwAmEfjo1onlRn73/xOs3ZeyY0oLZ3jP5fz4U1U/Rezo+1G+hWD5tZlf7IHVT01qGw==",
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.102.0.tgz",
+      "integrity": "sha512-BtnhM8CwIHjK+8Vws02MjEUxgMLIBX78jTtFYgbRX8/1gLgq97pnsumhvnucc9JDf8hbIslXtkIUb+6Mc8f9aQ==",
       "requires": {
         "ws": "^8.18.0"
       }
@@ -19451,7 +19449,8 @@
     "esbuild-wasm": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.24.0.tgz",
-      "integrity": "sha512-xhNn5tL1AhkPg4ft59yXT6FkwKXiPSYyz1IeinJHUJpjvOHOIPvdmFQc0pGdjxlKSbzZc2mNmtVOWAR1EF/JAg=="
+      "integrity": "sha512-xhNn5tL1AhkPg4ft59yXT6FkwKXiPSYyz1IeinJHUJpjvOHOIPvdmFQc0pGdjxlKSbzZc2mNmtVOWAR1EF/JAg==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -861,8 +861,7 @@
   "dependencies": {
     "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
     "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
-    "@deephaven/jsapi-nodejs": "0.100.0",
-    "esbuild-wasm": "^0.24.0",
+    "@deephaven/jsapi-nodejs": "0.102.0",
     "nanoid": "^5.0.7"
   },
   "devDependencies": {
@@ -879,6 +878,7 @@
     "@wdio/mocha-framework": "^8.39.0",
     "@wdio/spec-reporter": "^8.39.0",
     "ctrf": "^0.0.9",
+    "esbuild-wasm": "^0.24.0",
     "eslint": "^8.57.0",
     "fantasticon": "^3.0.0",
     "github-actions-ctrf": "^0.0.20",

--- a/src/dh/dhe.ts
+++ b/src/dh/dhe.ts
@@ -53,7 +53,7 @@ export async function getDhe(
     serverPaths: ['irisapi/irisapi.nocache.js'],
     download: true,
     storageDir,
-    sourceModuleType: 'cjs',
+    targetModuleType: 'cjs',
   });
 
   // DHE currently exposes the jsapi via the global `iris` object.


### PR DESCRIPTION
DH-18191: Removed runtime esbuild dependency and move to simpler text replacement methodology to cut down on memory consumption.