### PR TITLE
feat:  Run Markdown codeblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,11 @@
         "icon": "$(run-all)"
       },
       {
+        "command": "vscode-deephaven.runMarkdownCodeblock",
+        "title": "Run Deephaven Markdown Codeblock",
+        "icon": "$(run)"
+      },
+      {
         "command": "vscode-deephaven.runSelection",
         "title": "Run Deephaven Selected Lines",
         "icon": "$(run)"
@@ -676,6 +681,10 @@
         {
           "command": "vscode-deephaven.runCode",
           "when": "editorLangId == python || editorLangId == groovy"
+        },
+        {
+          "command": "vscode-deephaven.runMarkdownCodeblock",
+          "when": "false"
         },
         {
           "command": "vscode-deephaven.runSelection",

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -31,6 +31,7 @@ export const REFRESH_SERVER_CONNECTION_TREE_CMD = cmd(
 );
 export const REFRESH_VARIABLE_PANELS_CMD = cmd('refreshVariablePanels');
 export const RUN_CODE_COMMAND = cmd('runCode');
+export const RUN_MARKDOWN_CODEBLOCK_CMD = cmd('runMarkdownCodeBlock');
 export const RUN_SELECTION_COMMAND = cmd('runSelection');
 export const SEARCH_CONNECTIONS_CMD = cmd('searchConnections');
 export const SEARCH_PANELS_CMD = cmd('searchPanels');

--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -360,7 +360,9 @@ export class ConnectionController extends ControllerBase implements Disposable {
 
     const editor = vscode.window.activeTextEditor;
     const uri = editor.document.uri;
-    languageId = languageId ?? editor.document.languageId;
+    if (languageId == null) {
+      languageId = editor.document.languageId;
+    }
 
     const updateStatusPromise = this._serverManager.updateStatus();
 

--- a/src/controllers/ConnectionController.ts
+++ b/src/controllers/ConnectionController.ts
@@ -14,7 +14,6 @@ import {
   createConnectionQuickPickOptions,
   createConnectStatusBarItem,
   getConsoleType,
-  getEditorForUri,
   isSupportedLanguageId,
   Logger,
   updateConnectionStatusBarItem,
@@ -212,21 +211,15 @@ export class ConnectionController extends ControllerBase implements Disposable {
   /**
    * Get or create a connection for the given uri.
    * @param uri Uri to get or create a connection for.
-   * @param languageId Optional language id to use for the connection. Defaults
-   * to the language id of the uri.
+   * @param languageId Language id to use for the connection.
    */
   getOrCreateConnection = async (
     uri: vscode.Uri,
-    languageId?: string
+    languageId: string
   ): Promise<ConnectionState | null> => {
     assertDefined(this._outputChannel, 'outputChannel');
     assertDefined(this._serverManager, 'serverManager');
     assertDefined(this._toaster, 'toaster');
-
-    if (languageId == null) {
-      const editor = await getEditorForUri(uri);
-      languageId = editor.document.languageId;
-    }
 
     // Get existing connection for the editor
     let dhService = await this._serverManager.getEditorConnection(uri);

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -639,7 +639,11 @@ export class ExtensionController implements Disposable {
 
     const editor = await vscode.window.showTextDocument(doc);
 
-    this._serverManager?.setEditorConnection(editor, dhService);
+    this._serverManager?.setEditorConnection(
+      editor.document.uri,
+      editor.document.languageId,
+      dhService
+    );
   };
 
   /**
@@ -729,7 +733,9 @@ export class ExtensionController implements Disposable {
     assertDefined(uri, 'uri');
 
     const editor = await getEditorForUri(uri);
-    languageId = languageId ?? editor.document.languageId;
+    if (languageId == null) {
+      languageId = editor.document.languageId;
+    }
 
     const connectionState =
       await this._connectionController.getOrCreateConnection(uri, languageId);

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -714,7 +714,8 @@ export class ExtensionController implements Disposable {
    * @param constrainTo Optional arg to constrain the code to run.
    * - If 'selection', run only selected code in the editor.
    * - If `undefined`, run all code in the editor.
-   * - If an array of vscode.Range, run only the code in the ranges.
+   * - If an array of vscode.Range, run only the code in the ranges (Note that
+   *   partial lines will be expanded to include the full line content).
    * @param languageId Optional languageId to run the code as. If none provided,
    * use the languageId of the editor.
    */

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -729,18 +729,16 @@ export class ExtensionController implements Disposable {
     assertDefined(uri, 'uri');
 
     const editor = await getEditorForUri(uri);
+    languageId = languageId ?? editor.document.languageId;
+
     const connectionState =
-      await this._connectionController.getOrCreateConnection(uri);
+      await this._connectionController.getOrCreateConnection(uri, languageId);
 
     if (isInstanceOf(connectionState, DhcService)) {
       const ranges: readonly vscode.Range[] | undefined =
         constrainTo === 'selection' ? editor.selections : constrainTo;
 
-      await connectionState?.runCode(
-        editor.document,
-        languageId ?? editor.document.languageId,
-        ranges
-      );
+      await connectionState?.runCode(editor.document, languageId, ranges);
     }
   };
 

--- a/src/controllers/ServerConnectionTreeDragAndDropController.ts
+++ b/src/controllers/ServerConnectionTreeDragAndDropController.ts
@@ -35,7 +35,11 @@ export class ServerConnectionTreeDragAndDropController
     const editor = await getEditorForUri(uri);
 
     try {
-      await this.serverManager.setEditorConnection(editor, target);
+      await this.serverManager.setEditorConnection(
+        editor.document.uri,
+        editor.document.languageId,
+        target
+      );
     } catch {}
   };
 }

--- a/src/providers/RunCommandCodeLensProvider.ts
+++ b/src/providers/RunCommandCodeLensProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ICON_ID } from '../common';
+import { ICON_ID, RUN_CODE_COMMAND } from '../common';
 import type { Disposable } from '../types';
 
 /**
@@ -35,7 +35,7 @@ export class RunCommandCodeLensProvider
     const codeLenses: vscode.CodeLens[] = [
       new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
         title: `$(${ICON_ID.runAll}) Run Deephaven File`,
-        command: 'vscode-deephaven.runCode',
+        command: RUN_CODE_COMMAND,
         arguments: [document.uri],
       }),
     ];

--- a/src/providers/RunCommandCodeLensProvider.ts
+++ b/src/providers/RunCommandCodeLensProvider.ts
@@ -42,11 +42,4 @@ export class RunCommandCodeLensProvider
 
     return codeLenses;
   }
-
-  resolveCodeLens?(
-    codeLens: vscode.CodeLens,
-    _token: vscode.CancellationToken
-  ): vscode.ProviderResult<vscode.CodeLens> {
-    return codeLens;
-  }
 }

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -60,7 +60,7 @@ export class RunMarkdownCodeBlockCodeLensProvider
           // Put the code lens on the line before the code block
           new vscode.Range(range.start.line - 1, 0, range.start.line - 1, 0),
           {
-            title: `$(${ICON_ID.runSelection}) Run Code Block`,
+            title: `$(${ICON_ID.runSelection}) Run Deephaven Block`,
             command: RUN_MARKDOWN_CODEBLOCK_CMD,
             arguments: [document.uri, languageId, range],
           }

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -45,6 +45,7 @@ export class RunMarkdownCodeBlockCodeLensProvider
           languageId,
           new vscode.Range(start, new vscode.Position(i - 1, 0)),
         ]);
+        start = null;
       } else if (line === '```python' || line === '```groovy') {
         languageId = line.substring(3);
         start = new vscode.Position(i + 1, 0);

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -1,0 +1,75 @@
+import * as vscode from 'vscode';
+import { ICON_ID, RUN_MARKDOWN_CODEBLOCK_CMD } from '../common';
+import type { Disposable } from '../types';
+
+/**
+ * Provides inline editor code lenses for running Deephaven code.
+ */
+export class RunMarkdownCodeBlockCodeLensProvider
+  implements vscode.CodeLensProvider<vscode.CodeLens>, Disposable
+{
+  constructor() {
+    vscode.workspace.onDidChangeConfiguration(() => {
+      this._onDidChangeCodeLenses.fire();
+    });
+    vscode.window.onDidChangeTextEditorSelection(() => {
+      this._onDidChangeCodeLenses.fire();
+    });
+  }
+
+  private readonly _onDidChangeCodeLenses: vscode.EventEmitter<void> =
+    new vscode.EventEmitter<void>();
+
+  readonly onDidChangeCodeLenses: vscode.Event<void> =
+    this._onDidChangeCodeLenses.event;
+
+  dispose = async (): Promise<void> => {
+    this._onDidChangeCodeLenses.dispose();
+  };
+
+  provideCodeLenses(
+    document: vscode.TextDocument,
+    _token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.CodeLens[]> {
+    const lines = document.getText().split('\n');
+
+    const ranges: [string, vscode.Range][] = [];
+    let start: vscode.Position | null = null;
+    let languageId = '';
+
+    for (let i = 0; i < lines.length; ++i) {
+      const line = lines[i];
+
+      if (line === '```' && start) {
+        ranges.push([
+          languageId,
+          new vscode.Range(start, new vscode.Position(i - 1, 0)),
+        ]);
+      } else if (line === '```python' || line === '```groovy') {
+        languageId = line.substring(3);
+        start = new vscode.Position(i + 1, 0);
+      }
+    }
+
+    const codeLenses: vscode.CodeLens[] = ranges.map(
+      ([languageId, range]) =>
+        new vscode.CodeLens(
+          new vscode.Range(range.start.line - 1, 0, range.start.line - 1, 0),
+          {
+            title: `$(${ICON_ID.runAll}) Run Code Block`,
+            command: RUN_MARKDOWN_CODEBLOCK_CMD,
+            arguments: [document.uri, languageId, range],
+          }
+        )
+    );
+
+    return codeLenses;
+  }
+
+  resolveCodeLens?(
+    codeLens: vscode.CodeLens,
+    _token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.CodeLens> {
+    return codeLens;
+  }
+}

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -3,7 +3,8 @@ import { ICON_ID, RUN_MARKDOWN_CODEBLOCK_CMD } from '../common';
 import type { Disposable } from '../types';
 
 /**
- * Provides inline editor code lenses for running Deephaven code.
+ * Provides inline editor code lenses for running Deephaven codeblocks in
+ * Markdown files.
  */
 export class RunMarkdownCodeBlockCodeLensProvider
   implements vscode.CodeLensProvider<vscode.CodeLens>, Disposable
@@ -37,6 +38,7 @@ export class RunMarkdownCodeBlockCodeLensProvider
     let start: vscode.Position | null = null;
     let languageId = '';
 
+    // Create ranges for each code block in the document
     for (let i = 0; i < lines.length; ++i) {
       const line = lines[i];
 
@@ -55,9 +57,10 @@ export class RunMarkdownCodeBlockCodeLensProvider
     const codeLenses: vscode.CodeLens[] = ranges.map(
       ([languageId, range]) =>
         new vscode.CodeLens(
+          // Put the code lens on the line before the code block
           new vscode.Range(range.start.line - 1, 0, range.start.line - 1, 0),
           {
-            title: `$(${ICON_ID.runAll}) Run Code Block`,
+            title: `$(${ICON_ID.runSelection}) Run Code Block`,
             command: RUN_MARKDOWN_CODEBLOCK_CMD,
             arguments: [document.uri, languageId, range],
           }

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -69,11 +69,4 @@ export class RunMarkdownCodeBlockCodeLensProvider
 
     return codeLenses;
   }
-
-  resolveCodeLens?(
-    codeLens: vscode.CodeLens,
-    _token: vscode.CancellationToken
-  ): vscode.ProviderResult<vscode.CodeLens> {
-    return codeLens;
-  }
 }

--- a/src/providers/RunSelectedLinesHoverProvider.ts
+++ b/src/providers/RunSelectedLinesHoverProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ICON_ID, RUN_SELECTION_COMMAND } from '../common';
-import { expandSelectionToFullLines } from '../util';
+import { expandRangeToFullLines } from '../util';
 
 /**
  * Provides hover content for running selected lines in Deephaven.
@@ -15,7 +15,7 @@ export const runSelectedLinesHoverProvider: vscode.HoverProvider = {
 
     // Determine if hover is over a selected line
     const isOverSelection = editor.selections.some(selection =>
-      expandSelectionToFullLines(editor.document)(selection).contains(position)
+      expandRangeToFullLines(editor.document)(selection).contains(position)
     );
 
     if (!isOverSelection) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,5 @@
 export * from './RunCommandCodeLensProvider';
+export * from './RunMarkdownCodeBlockCodeLensProvider';
 export * from './RunSelectedLinesHoverProvider';
 export * from './ServerConnectionTreeProvider';
 export * from './ServerTreeProvider';

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -385,9 +385,9 @@ export class DhcService implements IDhcService {
         const { line, value } = parseServerError(error);
 
         if (line != null) {
-          // If selectionOnly is true, the line number in the error will be
-          // relative to the selection (Python line numbers are 1 based. vscode
-          // line numbers are zero based.)
+          // If ranges were provided, the line number in the error will be
+          // relative to the ranges content (Python line numbers are 1 based.
+          // vscode line numbers are zero based.)
           const fileLine = (ranges ? line + ranges[0].start.line : line) - 1;
 
           // There seems to be an error for certain Python versions where line

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -471,13 +471,12 @@ export class ServerManager implements IServerManager {
   };
 
   /**
-   * Get the connection associated with the URI of the given editor.
-   * @param editor
+   * Get the connection associated with the given URI.
+   * @param uri
    */
   getEditorConnection = async (
-    editor: vscode.TextEditor
+    uri: vscode.Uri
   ): Promise<ConnectionState | null> => {
-    const uri = editor.document.uri;
     return this._uriConnectionsMap.get(uri) ?? null;
   };
 
@@ -532,21 +531,18 @@ export class ServerManager implements IServerManager {
   };
 
   setEditorConnection = async (
-    editor: vscode.TextEditor,
+    uri: vscode.Uri,
+    languageId: string,
     connectionState: ConnectionState
   ): Promise<void> => {
-    const uri = editor.document.uri;
-
     const isConsoleTypeSupported =
-      editor.document.languageId === 'markdown' ||
+      languageId === 'markdown' ||
       (isInstanceOf(connectionState, DhcService) &&
-        (await connectionState.supportsConsoleType(
-          editor.document.languageId as ConsoleType
-        )));
+        (await connectionState.supportsConsoleType(languageId as ConsoleType)));
 
     if (!isConsoleTypeSupported) {
       throw new UnsupportedConsoleTypeError(
-        `Connection '${connectionState.serverUrl}' does not support '${editor.document.languageId}'.`
+        `Connection '${connectionState.serverUrl}' does not support '${languageId}'.`
       );
     }
 

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -538,10 +538,11 @@ export class ServerManager implements IServerManager {
     const uri = editor.document.uri;
 
     const isConsoleTypeSupported =
-      isInstanceOf(connectionState, DhcService) &&
-      (await connectionState.supportsConsoleType(
-        editor.document.languageId as ConsoleType
-      ));
+      editor.document.languageId === 'markdown' ||
+      (isInstanceOf(connectionState, DhcService) &&
+        (await connectionState.supportsConsoleType(
+          editor.document.languageId as ConsoleType
+        )));
 
     if (!isConsoleTypeSupported) {
       throw new UnsupportedConsoleTypeError(

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -20,6 +20,7 @@ import type {
   CoreUnauthenticatedClient,
   Psk,
   CoreAuthenticatedClient,
+  NonEmptyArray,
 } from '../types/commonTypes';
 import type {
   AuthenticatedClient as DheAuthenticatedClient,
@@ -55,9 +56,10 @@ export interface IDhcService extends Disposable, ConnectionState {
   getConsoleTypes: () => Promise<Set<ConsoleType>>;
   supportsConsoleType: (consoleType: ConsoleType) => Promise<boolean>;
 
-  runEditorCode: (
-    editor: vscode.TextEditor,
-    selectionOnly?: boolean
+  runCode: (
+    document: vscode.TextDocument,
+    languageId: string,
+    ranges?: readonly vscode.Range[]
   ) => Promise<void>;
 }
 

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -157,15 +157,14 @@ export interface IServerManager extends Disposable {
   getConnection: (serverUrl: URL) => ConnectionState | undefined;
   getConnections: () => ConnectionState[];
   getConnectionUris: (connection: ConnectionState) => vscode.Uri[];
-  getEditorConnection: (
-    editor: vscode.TextEditor
-  ) => Promise<ConnectionState | null>;
+  getEditorConnection: (uri: vscode.Uri) => Promise<ConnectionState | null>;
   getWorkerCredentials: (
     serverOrWorkerUrl: URL | WorkerURL
   ) => Promise<DhcType.LoginCredentials | null>;
   getWorkerInfo: (workerUrl: WorkerURL) => Promise<WorkerInfo | undefined>;
   setEditorConnection: (
-    editor: vscode.TextEditor,
+    uri: vscode.Uri,
+    languageId: string,
     dhService: ConnectionState
   ) => Promise<void>;
 

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 
 /**
- * Combine content of all range lines (including multi-cursor selections).
- * Any line that is partially selected will be included in its entirety.
+ * Combine content of all range lines. Any partial lines will be expanded to
+ * include the full line content.
  * @param document
  * @param ranges
  */

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -41,7 +41,7 @@ export function expandRangeToFullLines(document: vscode.TextDocument) {
 /**
  * Sort ranges in document order. Useful for converting `TextEditor.selections`
  * which are ordered based on multi-cursor creation order.
- * @param ranges
+ * @param ranges The ranges to sort.
  */
 export function sortRanges<TRange extends vscode.Range>(
   ranges: readonly TRange[]

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -24,8 +24,8 @@ export function getCombinedRangeLinesText(
  */
 export function expandRangeToFullLines(document: vscode.TextDocument) {
   /**
-   * Expand a given selection to include the full lines of any lines that are included
-   * in the selection.
+   * Expand a given range to include the full lines of any lines that are
+   * included in the range.
    * @param selection
    */
   return (range: vscode.Range): vscode.Range => {

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -17,10 +17,10 @@ export function getCombinedRangeLinesText(
 }
 
 /**
- * Create a function that can expand range to include the full lines of any
+ * Create a function that can expand a range to include the full lines of any
  * lines that are included in the range.
- * @param document
- * @returns
+ * @param document The document to provide line lengths for a given range.
+ * @returns Function that expands a range to include full lines.
  */
 export function expandRangeToFullLines(document: vscode.TextDocument) {
   /**

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -3,8 +3,8 @@ import * as vscode from 'vscode';
 /**
  * Combine content of all range lines. Any partial lines will be expanded to
  * include the full line content.
- * @param document
- * @param ranges
+ * @param document The document to extract the range lines from.
+ * @param ranges The ranges to extract the lines from.
  */
 export function getCombinedRangeLinesText(
   document: vscode.TextDocument,

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -1,50 +1,52 @@
 import * as vscode from 'vscode';
 
 /**
- * Combine content of all selected lines (including multi-cursor selections).
+ * Combine content of all range lines (including multi-cursor selections).
  * Any line that is partially selected will be included in its entirety.
- * @param editor
+ * @param document
+ * @param ranges
  */
-export function getCombinedSelectedLinesText(
-  editor: vscode.TextEditor
+export function getCombinedRangeLinesText(
+  document: vscode.TextDocument,
+  ranges: readonly vscode.Range[]
 ): string {
-  return sortSelections(editor.selections)
-    .map(expandSelectionToFullLines(editor.document))
-    .map(selection => editor.document.getText(selection))
+  return sortRanges(ranges)
+    .map(expandRangeToFullLines(document))
+    .map(range => document.getText(range))
     .join('\n');
 }
 
 /**
- * Create a function that can expand selection to include the full lines of any
- * lines that are included in the selection.
+ * Create a function that can expand range to include the full lines of any
+ * lines that are included in the range.
  * @param document
  * @returns
  */
-export function expandSelectionToFullLines(document: vscode.TextDocument) {
+export function expandRangeToFullLines(document: vscode.TextDocument) {
   /**
    * Expand a given selection to include the full lines of any lines that are included
    * in the selection.
    * @param selection
    */
-  return (selection: vscode.Selection): vscode.Selection => {
-    return new vscode.Selection(
-      selection.start.line,
+  return (range: vscode.Range): vscode.Range => {
+    return new vscode.Range(
+      range.start.line,
       0,
-      selection.end.line,
-      document.lineAt(selection.end.line).text.length
+      range.end.line,
+      document.lineAt(range.end.line).text.length
     );
   };
 }
 
 /**
- * Sort selections in document order. Useful for converting `TextEditor.selections`
+ * Sort ranges in document order. Useful for converting `TextEditor.selections`
  * which are ordered based on multi-cursor creation order.
- * @param selections
+ * @param ranges
  */
-export function sortSelections(
-  selections: readonly vscode.Selection[]
-): vscode.Selection[] {
-  return [...selections].sort(
+export function sortRanges<TRange extends vscode.Range>(
+  ranges: readonly TRange[]
+): TRange[] {
+  return [...ranges].sort(
     (s1, s2) =>
       s1.start.line - s2.start.line || s1.start.character - s2.start.character
   );


### PR DESCRIPTION
DH-18353: Run Markdown codeblocks

Testing
Open any Markdown file containing python or groovy codeblocks. Can use this one for simple example:

````markdown
This is a test Markdown file containing some inline codeblocks.

```python
from deephaven import time_table

simple_ticking = time_table("PT2S")
```

Here is a groovy example

```groovy
simple_ticking = timeTable("PT2S")
```
````

A "Run Code Block" code lens should appear above each codeblock. Clicking it should run the codeblock against a DH server.