### PR TITLE
fix: DH-18424: Force websocket connections for 0.37.x+ Core servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Community servers can be configured via the `"deephaven.coreServers"` setting in
 
 ![Community Server Settings](./docs/assets/add-community-server.gif)
 
+#### Self-signed SSL Certificates
+If you are running a Community server with a self-signed SSL certificate, vscode will need to be run in an environment that has the `NODE_EXTRA_CA_CERTS` environment variable set to the path of the cert that was used to sign your cert. Depending on your setup, this could be the server certificate or a CA certificate.
 
 ### Enterprise Servers
 Enterprise servers can be configured via the `"deephaven.enterpriseServers"` setting in `VS Code` user or workspace settings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@deephaven-enterprise/jsapi-types": "^1.20240723.124-beta",
-        "@deephaven/jsapi-types": "^1.0.0-dev0.36.1",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.37.3",
         "@types/node": "22.5.4",
         "@types/vscode": "^1.91.0",
         "@types/ws": "^8.5.10",
@@ -478,9 +478,9 @@
       }
     },
     "node_modules/@deephaven/jsapi-types": {
-      "version": "1.0.0-dev0.36.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.36.1.tgz",
-      "integrity": "sha512-Q7we+JYMqQrHp3hQfbKF3YmjjCLTjy+D3an8x6IsfVMv7Uv7LqvuA0c/tKCIT19JDa2b9giFWf3TV8apzXry/A=="
+      "version": "1.0.0-dev0.37.3",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.37.3.tgz",
+      "integrity": "sha512-EyAEpiOWNA3fUsp3LGBTwsOeAu5As7CoCibRec4kBOMLJ7jaEhAx1RHQEWnm3sVhhxBWREfmJy3OESWwcXZLQw=="
     },
     "node_modules/@deephaven/log": {
       "version": "0.97.0",
@@ -15515,9 +15515,9 @@
       }
     },
     "@deephaven/jsapi-types": {
-      "version": "1.0.0-dev0.36.1",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.36.1.tgz",
-      "integrity": "sha512-Q7we+JYMqQrHp3hQfbKF3YmjjCLTjy+D3an8x6IsfVMv7Uv7LqvuA0c/tKCIT19JDa2b9giFWf3TV8apzXry/A=="
+      "version": "1.0.0-dev0.37.3",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-types/-/jsapi-types-1.0.0-dev0.37.3.tgz",
+      "integrity": "sha512-EyAEpiOWNA3fUsp3LGBTwsOeAu5As7CoCibRec4kBOMLJ7jaEhAx1RHQEWnm3sVhhxBWREfmJy3OESWwcXZLQw=="
     },
     "@deephaven/log": {
       "version": "0.97.0",

--- a/package.json
+++ b/package.json
@@ -875,7 +875,7 @@
   },
   "devDependencies": {
     "@deephaven-enterprise/jsapi-types": "^1.20240723.124-beta",
-    "@deephaven/jsapi-types": "^1.0.0-dev0.36.1",
+    "@deephaven/jsapi-types": "^1.0.0-dev0.37.3",
     "@types/node": "22.5.4",
     "@types/vscode": "^1.91.0",
     "@types/ws": "^8.5.10",

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -342,9 +342,11 @@ export class ExtensionController implements Disposable {
       assertDefined(this._coreJsApiCache, 'coreJsApiCache');
       const dhc = await this._coreJsApiCache.get(url);
 
-      const client = new dhc.CoreClient(
-        url.toString()
-      ) as CoreUnauthenticatedClient;
+      const client = new dhc.CoreClient(url.toString(), {
+        // `useWebsockets: true` is needed for 0.37.x servers until we enable
+        // the http2 based gRPC transport DH-18086
+        useWebsockets: true,
+      }) as CoreUnauthenticatedClient;
 
       // Attach a dispose method so that client caches can dispose of the client
       return Object.assign(client, {


### PR DESCRIPTION
DH-18424: Force websocket connections for 0.37.x+ Core servers

**Testing**
I tested the following scenarios on my Mac:
* Grizzly with Core+ 0.37.x (can use dev-grizzly2)
* San Luis with Core+ 0.37.x (can use dev-sanluis)
* Community http
* Community https (note `-Dhttp.websockets=true` needs to be set when starting the server)
Example `START_OPTS -Dhttp.port=444 -Dhttp.websockets=true -Dssl.identity.type=privatekey -Dssl.identity.certChainPath=/dev-certs/localhost.crt -Dssl.identity.privateKeyPath=/dev-certs/localhost.key`. Also `NODE_EXTRA_CA_CERTS` needs to be set when using self signed SSL certs (see README).

NOTE: Would be good to test at least the first 2 items on Windows since the user originally had some Windows specific issues. I don't have a way to do this since my Windows machine does not have access to the VPN