### PR TITLE
feat: gRPC transport logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
         "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
-        "@deephaven/jsapi-nodejs": "^0.103.0",
+        "@deephaven/jsapi-nodejs": "^0.104.0",
         "nanoid": "^5.0.7"
       },
       "devDependencies": {
@@ -467,12 +467,12 @@
       }
     },
     "node_modules/@deephaven/jsapi-nodejs": {
-      "version": "0.103.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.103.0.tgz",
-      "integrity": "sha512-dkAi321+Jx56STJK9jTrpyhiTigPDz5/sFBiXHsj/fHRYpdKieUFFAxEu3rYfy5gDOFs7EXB50VSQI7FP0D7iQ==",
+      "version": "0.104.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.104.0.tgz",
+      "integrity": "sha512-e284BE+MYIwN9Nflb13M9Hxs8ZQS2k1z1S7uZGqZQYsci85vhIAoCWhpU+UX2YUlhR8+QE0Aehf8ywheWF+W2g==",
       "dependencies": {
-        "@deephaven/log": "^0.103.0",
-        "@deephaven/utils": "^0.103.0",
+        "@deephaven/log": "^0.104.0",
+        "@deephaven/utils": "^0.104.0",
         "ws": "^8.18.0"
       },
       "engines": {
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/@deephaven/jsapi-nodejs/node_modules/@deephaven/log": {
-      "version": "0.103.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.103.0.tgz",
-      "integrity": "sha512-8vQktsmaoJrPwZIZALRyFAWyYhFg5DzaN0Ye7HObe3n/kBBe5+GXbhv0F/AUbMzLngYkj7WLIXjsDzYRw70qNQ==",
+      "version": "0.104.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.104.0.tgz",
+      "integrity": "sha512-xsGSmdVNjCXF9Zii7/VitzX5mDpcST/MzTRA+bLgtHlChKEcw9U46rU68RPJKfKuW4BpGBQCvoMI4pKC+quZiw==",
       "dependencies": {
         "event-target-shim": "^6.0.2",
         "jszip": "^3.10.1"
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@deephaven/jsapi-nodejs/node_modules/@deephaven/utils": {
-      "version": "0.103.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.103.0.tgz",
-      "integrity": "sha512-1N0bBG5fpl89Ktt1Y0CUj3thl2uFFgHUMqJMvBje5D38DIuuu7VUifEXtFGcOSgi67z62hkFt0ODLWMzZuZcEQ==",
+      "version": "0.104.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.104.0.tgz",
+      "integrity": "sha512-KxWmrgHarAZ2fYP3R2ee2LjA3lUiYKK3zbxi1cu9V2jAi+H3iaUn1Xl/FIkCjq2Q5wrOfTkuKgg9MyG61DREyA==",
       "engines": {
         "node": ">=16"
       }
@@ -15516,28 +15516,28 @@
       }
     },
     "@deephaven/jsapi-nodejs": {
-      "version": "0.103.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.103.0.tgz",
-      "integrity": "sha512-dkAi321+Jx56STJK9jTrpyhiTigPDz5/sFBiXHsj/fHRYpdKieUFFAxEu3rYfy5gDOFs7EXB50VSQI7FP0D7iQ==",
+      "version": "0.104.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.104.0.tgz",
+      "integrity": "sha512-e284BE+MYIwN9Nflb13M9Hxs8ZQS2k1z1S7uZGqZQYsci85vhIAoCWhpU+UX2YUlhR8+QE0Aehf8ywheWF+W2g==",
       "requires": {
-        "@deephaven/log": "^0.103.0",
-        "@deephaven/utils": "^0.103.0",
+        "@deephaven/log": "^0.104.0",
+        "@deephaven/utils": "^0.104.0",
         "ws": "^8.18.0"
       },
       "dependencies": {
         "@deephaven/log": {
-          "version": "0.103.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.103.0.tgz",
-          "integrity": "sha512-8vQktsmaoJrPwZIZALRyFAWyYhFg5DzaN0Ye7HObe3n/kBBe5+GXbhv0F/AUbMzLngYkj7WLIXjsDzYRw70qNQ==",
+          "version": "0.104.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.104.0.tgz",
+          "integrity": "sha512-xsGSmdVNjCXF9Zii7/VitzX5mDpcST/MzTRA+bLgtHlChKEcw9U46rU68RPJKfKuW4BpGBQCvoMI4pKC+quZiw==",
           "requires": {
             "event-target-shim": "^6.0.2",
             "jszip": "^3.10.1"
           }
         },
         "@deephaven/utils": {
-          "version": "0.103.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.103.0.tgz",
-          "integrity": "sha512-1N0bBG5fpl89Ktt1Y0CUj3thl2uFFgHUMqJMvBje5D38DIuuu7VUifEXtFGcOSgi67z62hkFt0ODLWMzZuZcEQ=="
+          "version": "0.104.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.104.0.tgz",
+          "integrity": "sha512-KxWmrgHarAZ2fYP3R2ee2LjA3lUiYKK3zbxi1cu9V2jAi+H3iaUn1Xl/FIkCjq2Q5wrOfTkuKgg9MyG61DREyA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -870,7 +870,7 @@
   "dependencies": {
     "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
     "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
-    "@deephaven/jsapi-nodejs": "^0.103.0",
+    "@deephaven/jsapi-nodejs": "^0.104.0",
     "nanoid": "^5.0.7"
   },
   "devDependencies": {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -9,6 +9,8 @@ export const CONFIG_KEY = {
   enterpriseServers: 'enterpriseServers',
 } as const;
 
+export const CENSORED_TEXT = '********' as const;
+
 export const DEFAULT_CONSOLE_TYPE = 'python' as const;
 // export const DHFS_SCHEME = 'dhfs';
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -34,6 +34,7 @@ import {
   isSupportedLanguageId,
   Logger,
   OutputChannelWithHistory,
+  sanitizeGRPCLogMessageArgs,
   Toaster,
 } from '../util';
 import {
@@ -316,6 +317,12 @@ export class ExtensionController implements Disposable {
 
     Logger.addConsoleHandler();
     Logger.addOutputChannelHandler(this._outputChannelDebug);
+
+    const handler = Logger.createOutputChannelHandler(this._outputChannelDebug);
+    NodeHttp2gRPCTransport.onLogMessage((logLevel, ...args: unknown[]) => {
+      args = sanitizeGRPCLogMessageArgs(args);
+      handler(logLevel)('[NodeHttp2gRPCTransport]', ...args);
+    });
 
     this._toaster = new Toaster();
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -320,10 +320,12 @@ export class ExtensionController implements Disposable {
     Logger.addConsoleHandler();
     Logger.addOutputChannelHandler(this._outputChannelDebug);
 
-    const handler = Logger.createOutputChannelHandler(this._outputChannelDebug);
+    const gRPCOutputChannelHandler = Logger.createOutputChannelHandler(
+      this._outputChannelDebug
+    );
     NodeHttp2gRPCTransport.onLogMessage((logLevel, ...args: unknown[]) => {
       args = sanitizeGRPCLogMessageArgs(args);
-      handler(logLevel)('[NodeHttp2gRPCTransport]', ...args);
+      gRPCOutputChannelHandler(logLevel)('[NodeHttp2gRPCTransport]', ...args);
     });
 
     this._toaster = new Toaster();

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -108,6 +108,8 @@ export class ExtensionController implements Disposable {
     this.initializeWebViews();
     this.initializeServerUpdates();
 
+    this._context.subscriptions.push(NodeHttp2gRPCTransport);
+
     logger.info(
       'Congratulations, your extension "vscode-deephaven" is now active!'
     );

--- a/src/controllers/PanelController.ts
+++ b/src/controllers/PanelController.ts
@@ -161,7 +161,16 @@ export class PanelController extends ControllerBase {
         workerInfo,
       });
 
-      logger.debug('Posting LoginOptions response:', response);
+      logger.debug('Posting LoginOptions response:', {
+        ...response,
+        payload: {
+          ...response.payload,
+          payload: {
+            ...response.payload.payload,
+            token: '********',
+          },
+        },
+      });
 
       postResponseMessage(response);
 

--- a/src/controllers/PanelController.ts
+++ b/src/controllers/PanelController.ts
@@ -19,6 +19,7 @@ import {
 } from '../util';
 import { DhcService } from '../services';
 import {
+  CENSORED_TEXT,
   DEEPHAVEN_POST_MSG,
   DH_PANEL_VIEW_TYPE,
   OPEN_VARIABLE_PANELS_CMD,
@@ -167,7 +168,7 @@ export class PanelController extends ControllerBase {
           ...response.payload,
           payload: {
             ...response.payload.payload,
-            token: '********',
+            token: CENSORED_TEXT,
           },
         },
       });

--- a/src/util/dataUtils.ts
+++ b/src/util/dataUtils.ts
@@ -1,6 +1,19 @@
 import type { NonEmptyArray } from '../types';
 
 /**
+ * Type guard to determine if an object has a property.
+ * @param obj The object to check.
+ * @param prop The property to check for.
+ * @returns true if the property exists, false otherwise.
+ */
+export function hasProperty<TProp extends string>(
+  obj: unknown,
+  prop: TProp
+): obj is Record<TProp, unknown> {
+  return obj != null && typeof obj === 'object' && prop in obj;
+}
+
+/**
  * Type guard to check if an array is non-empty.
  * @param array
  * @returns true if the array is non-empty, false otherwise

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -7,6 +7,7 @@ export * from './Logger';
 export * from './OutputChannelWithHistory';
 export * from './panelUtils';
 export * from './promiseUtils';
+export * from './sanitizeUtils';
 export * from './selectionUtils';
 export * from './serverUtils';
 export * from './testUtils';

--- a/src/util/sanitizeUtils.ts
+++ b/src/util/sanitizeUtils.ts
@@ -1,0 +1,60 @@
+import { hasProperty } from './dataUtils';
+
+/**
+ * Sanitize an auth header value.
+ * @param authHeaderValue Sanitize secret portion of known auth headers. If
+ * unrecognized, replace the whole thing.
+ * @returns The sanitized auth header value.
+ */
+export function sanitizeAuthHeaderValue(authHeaderValue: string): string {
+  if (
+    authHeaderValue.startsWith('io.deephaven.proto.auth.Token') ||
+    authHeaderValue.startsWith('Bearer')
+  ) {
+    return authHeaderValue.replace(/ \S+$/, ' ********');
+  }
+
+  return '********';
+}
+
+/**
+ * Sanitize an auth header.
+ * @param authorization The authorization header value. This can be a string
+ * or an array of strings. Any other data types will be treated as an empty
+ * string.
+ * @returns The sanitized auth header value.
+ */
+export function sanitizeAuthHeader(authorization: unknown): string | string[] {
+  if (typeof authorization === 'string') {
+    return sanitizeAuthHeaderValue(authorization);
+  }
+
+  if (Array.isArray(authorization)) {
+    return authorization.map(sanitizeAuthHeaderValue);
+  }
+
+  return sanitizeAuthHeaderValue('');
+}
+
+/**
+ * Sanitize auth headers in a gRPC log message.
+ * @param args The arguments to sanitize.
+ * @returns The sanitized arguments.
+ */
+export function sanitizeGRPCLogMessageArgs([
+  arg0,
+  arg1,
+  ...args
+]: unknown[]): unknown[] {
+  if (arg0 === 'start' && hasProperty(arg1, 'authorization')) {
+    return [
+      arg0,
+      {
+        ...arg1,
+        authorization: sanitizeAuthHeader(arg1.authorization),
+      },
+    ];
+  }
+
+  return [arg0, arg1, ...args];
+}

--- a/src/util/sanitizeUtils.ts
+++ b/src/util/sanitizeUtils.ts
@@ -1,3 +1,4 @@
+import { CENSORED_TEXT } from '../common';
 import { hasProperty } from './dataUtils';
 
 /**
@@ -11,10 +12,10 @@ export function sanitizeAuthHeaderValue(authHeaderValue: string): string {
     authHeaderValue.startsWith('io.deephaven.proto.auth.Token') ||
     authHeaderValue.startsWith('Bearer')
   ) {
-    return authHeaderValue.replace(/ \S+$/, ' ********');
+    return authHeaderValue.replace(/ \S+$/, ` ${CENSORED_TEXT}`);
   }
 
-  return '********';
+  return CENSORED_TEXT;
 }
 
 /**
@@ -33,7 +34,7 @@ export function sanitizeAuthHeader(authorization: unknown): string | string[] {
     return authorization.map(sanitizeAuthHeaderValue);
   }
 
-  return sanitizeAuthHeaderValue('');
+  return CENSORED_TEXT;
 }
 
 /**


### PR DESCRIPTION
DH-18086: gRPC transport logging

### Testing
I tested this using a local http1 proxy on a Grizzly dev server to see errors logged via gRPC transport. I was able to see the following when creating new Core+ workers:
```
[NodeHttp2gRPCTransport] ERROR: Session error Error: Protocol error
    at Http2Session.onSessionInternalError (node:internal/http2/core:793:26)
    at Http2Session.callbackTrampoline (node:internal/async_hooks:130:17)
```

I also tested without the proxy and can see debug messages for gRPC transport communication. This is easy to test by connecting a server and looking at the Output -> Deephaven Debug panel and looking for [NodeHttp2gRPCTransport] messages.