### PR TITLE
docs: Better documentation of trusting SSL certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,18 +64,18 @@ Deephaven servers using self-signed certificates or internal CA's will require c
 1. Save the signing certificate in PEM format somewhere on the machine running VS Code. Multiple certificates can be concatenated together in the same file if there are multiple certs that need to be configured.
 1. Set the `NODE_EXTRA_CA_CERTS` environment variable to the path of the signing certificate.
    
-   On Mac / Linux
+   On Mac / Linux, you set the env variable or if you'd like for it to persist, you can export it from an appropriate config file for your shell.
    ```sh
-   export NODE_EXTRA_CA_CERTS=/path/to/cert.pm
+   export NODE_EXTRA_CA_CERTS=/path/to/cert.pem
    ```
 
-   Windows
+   On Windows, you can use `set` to set the variable in your current shell, or `setx` to persist it.
 
    ```sh
-   setx NODE_EXTRA_CA_CERTS=C:\Path\To\cert.pm
+   setx NODE_EXTRA_CA_CERTS C:\Path\To\cert.pem
    ```
    > Note that paths in env variables should not be wrapped in quotes on Windows.
-1. Start VS Code in the environment where you set the `NODE_EXTRA_CA_CERTS` variable.
+1. Start VS Code in a shell that has the `NODE_EXTRA_CA_CERTS` variable set.
 
 > Note that VS Code runs in NodeJS which does not consult the trust store of the OS to determine trusted certificates. Instead, it comes pre-installed with a set of trusted root CA's. Any CA's that are not installed with NodeJS will need to be configured as described above.
 

--- a/README.md
+++ b/README.md
@@ -78,9 +78,7 @@ certificate.
    > Note that paths in env variables should not be wrapped in quotes on Windows.
 1. Start VS Code in the environment where you set the `NODE_EXTRA_CA_CERTS` variable.
 
-> Note that VS Code runs in NodeJS which does not consult the trust store of the OS to
-determine trusted certificates. Instead, it comes pre-installed with a set of
-trusted root CA's. Any CA's that are not installed with NodeJS will need to be configured as described above.
+> Note that VS Code runs in NodeJS which does not consult the trust store of the OS to determine trusted certificates. Instead, it comes pre-installed with a set of trusted root CA's. Any CA's that are not installed with NodeJS will need to be configured as described above.
 
 See https://nodejs.org/docs/latest-v22.x/api/cli.html#node_extra_ca_certsfile for more information on `NODE_EXTRA_CA_CERTS`.
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Enterprise servers can be configured via the `"deephaven.enterpriseServers"` set
 ![Enterprise Server Settings](./docs/assets/dhe-settings.gif)
 
 ## SSL Certificates
-Deephaven servers using self-signed certificates or internal CA's will require configuring VS Code to trust the signing
-certificate.
+Deephaven servers using self-signed certificates or internal CA's will require configuring VS Code to trust the signing certificate.
 
 1. Save the signing certificate in PEM format somewhere on the machine running VS Code. Multiple certificates can be concatenated together in the same file if there are multiple certs that need to be configured.
 1. Set the `NODE_EXTRA_CA_CERTS` environment variable to the path of the signing certificate.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ Community servers can be configured via the `"deephaven.coreServers"` setting in
 
 ![Community Server Settings](./docs/assets/add-community-server.gif)
 
-#### Self-signed SSL Certificates
-If you are running a Community server with a self-signed SSL certificate, vscode will need to be run in an environment that has the `NODE_EXTRA_CA_CERTS` environment variable set to the path of the cert that was used to sign your cert. Depending on your setup, this could be the server certificate or a CA certificate.
-
 ### Enterprise Servers
 Enterprise servers can be configured via the `"deephaven.enterpriseServers"` setting in `VS Code` user or workspace settings.
 
@@ -60,6 +57,32 @@ Enterprise servers can be configured via the `"deephaven.enterpriseServers"` set
 ```
 
 ![Enterprise Server Settings](./docs/assets/dhe-settings.gif)
+
+## SSL Certificates
+Deephaven servers using self-signed certificates or internal CA's will require configuring VS Code to trust the signing
+certificate.
+
+1. Save the signing certificate in PEM format somewhere on the machine running VS Code. Multiple certificates can be concatenated together in the same file if there are multiple certs that need to be configured.
+1. Set the `NODE_EXTRA_CA_CERTS` environment variable to the path of the signing certificate.
+   
+   On Mac / Linux
+   ```sh
+   export NODE_EXTRA_CA_CERTS=/path/to/cert.pm
+   ```
+
+   Windows
+
+   ```sh
+   setx NODE_EXTRA_CA_CERTS=C:\Path\To\cert.pm
+   ```
+   > Note that paths in env variables should not be wrapped in quotes on Windows.
+1. Start VS Code in the environment where you set the `NODE_EXTRA_CA_CERTS` variable.
+
+> Note that VS Code runs in NodeJS which does not consult the trust store of the OS to
+determine trusted certificates. Instead, it comes pre-installed with a set of
+trusted root CA's. Any CA's that are not installed with NodeJS will need to be configured as described above.
+
+See https://nodejs.org/docs/latest-v22.x/api/cli.html#node_extra_ca_certsfile for more information on `NODE_EXTRA_CA_CERTS`.
 
 ## Workspace Setup
 It is recommended to configure a virtual python environment within your `VS Code` workspace. See https://code.visualstudio.com/docs/python/python-tutorial#_create-a-virtual-environment for a general overview. To get features like intellisense for packages that are installed on the Deephaven server, you will need to install the same packages in your local `venv`.


### PR DESCRIPTION
DH-18191: Better documentation of trusting SSL certs

NodeJS doesn't use the OS cert store to determine which signing certificates it trusts. Instead, it has a static list of trusted certs included in the install. For certificates not in this list, there is a `NODE_EXTRA_CA_CERTS` environment variable that can be set to tell NodeJS about additional certs to trust. This PR updates the docs with instructions of how to set this.

> Note there is some indication that extensions may eventually allow using Chrome's `fetch`. If / when that happens, it might be possible to use that for Deephaven extension instead of our current grpc transport implementation that uses `node:http2` module. This could allow extensions to use the OS cert store instead of this env variable.
https://github.com/microsoft/vscode/issues/12588#issuecomment-2111861237