### PR TITLE
fix: Targetting Node v20 apis / types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+  "files.associations": {
+    "node*tsconfig.json": "jsonc"
+  },
   "files.exclude": {
     "out": false // set this to true to hide the "out" folder with the compiled JS files
   },

--- a/node20tsconfig.json
+++ b/node20tsconfig.json
@@ -1,0 +1,7 @@
+// Based on https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-20
+{
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM"],
+    "target": "ES2023"
+  }
+}

--- a/src/dh/dhe.ts
+++ b/src/dh/dhe.ts
@@ -248,7 +248,7 @@ export async function getWorkerInfoFromQuery(
   const queryInfo = await new Promise<QueryInfo>((resolve, reject) => {
     const removeEventListener = dheClient.addEventListener(
       dhe.Client.EVENT_CONFIG_UPDATED,
-      ({ detail: queryInfo }: CustomEvent<QueryInfo>) => {
+      ({ detail: queryInfo }: DhcType.Event<QueryInfo>) => {
         if (queryInfo.serial !== querySerial) {
           return;
         }

--- a/src/dh/dhe.ts
+++ b/src/dh/dhe.ts
@@ -248,7 +248,7 @@ export async function getWorkerInfoFromQuery(
   const queryInfo = await new Promise<QueryInfo>((resolve, reject) => {
     const removeEventListener = dheClient.addEventListener(
       dhe.Client.EVENT_CONFIG_UPDATED,
-      ({ detail: queryInfo }: DhcType.Event<QueryInfo>) => {
+      ({ detail: queryInfo }: CustomEvent<QueryInfo>) => {
         if (queryInfo.serial !== querySerial) {
           return;
         }

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -120,9 +120,9 @@ export class ServerManager implements IServerManager {
     // We want to keep any existing managed servers that aren't overridden by
     // the latest config so we don't lose the PSKs that were generated when
     // the servers were created.
-    const managedServersStates = this._serverMap
-      .values()
-      .filter(v => v.isManaged);
+    const managedServersStates = [...this._serverMap.values()].filter(
+      v => v.isManaged
+    );
 
     const configuredDhcServerState = getInitialServerStates(
       'DHC',

--- a/src/util/uiUtils.ts
+++ b/src/util/uiUtils.ts
@@ -496,11 +496,9 @@ export async function saveRequirementsTxt(
     return;
   }
 
-  const sorted = [
-    ...dependencies
-      .entries()
-      .map(([packageName, version]) => `${packageName}==${version}`),
-  ].sort((a, b) => a.localeCompare(b));
+  const sorted = [...dependencies.entries()]
+    .map(([packageName, version]) => `${packageName}==${version}`)
+    .sort((a, b) => a.localeCompare(b));
 
   fs.writeFileSync(uri.fsPath, sorted.join('\n'));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
+  "extends": "./node20tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "ESNext",
+    "module": "CommonJS",
     "outDir": "dist",
-    "lib": ["ESNext", "DOM"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,


### PR DESCRIPTION
DH-18667:
The VS Code extension has been using iterator helper methods such as 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter. Things have been working fine on all machines we've tested, but a Genesis user reported an error that indicates the apis are not available on a remote Linux machine he was testing. 

Looking at the docs, it seems that the iterator helpers aren't officially available until Node 22, but VS Code is still using Node 20.
https://nodejs.org/en/blog/announcements/v22-release-announce#v8-update-to-124
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter#browser_compatibility

Not really sure why this works on some machines, but seemed best to remove usage of the apis for now and update the types to complain about their usage.