### PR TITLE
fix: DH-19010: http2 errors

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Override `DHC_PACKAGES_PATH` with a `.env.local`  
+# Path to a local set of DHC packages to use  
+# DHC_PACKAGES_PATH=/path/to/web-client-ui/packages/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ e2e-testing/.resources
 e2e-testing/.test-extensions
 test-reports/
 tsconfig.tsbuildinfo
-.env.local
+.env*.local

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ e2e-testing/.resources
 e2e-testing/.test-extensions
 test-reports/
 tsconfig.tsbuildinfo
+.env.local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 ## Development
 
 ### Deephaven Packages
-The extension depends on some Deephaven web-client-ui npm packages (`@deephaven/*`). In cases where the dependencies need to be developed as part of extension development, the dependencies can be aliased locally to the location of the web-client-ui source code.
+The extension depends on some Deephaven web-client-ui npm packages (`@deephaven/*`). In cases where the dependencies need to be developed as part of extension development, the dependencies can be aliased locally to the location of the web-client-ui packages source code.
 
 1. Create a `.env.local` file in the root of this project 
 1. Set the `DHC_PACKAGES_PATH` env variable to the path of the web-client-ui/packages directory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,19 @@
 
 ## Development
 
+### Deephaven Packages
+The extension depends on some Deephaven web-client-ui npm packages (`@deephaven/*`). In cases where the dependencies need to be developed as part of extension development, the dependencies can be aliased locally to the location of the web-client-ui source code.
+
+1. Create a `.env.local` file in the root of this project 
+1. Set the `DHC_PACKAGES_PATH` env variable to the path of the web-client-ui/packages directory
+
+e.g.
+```ini
+DHC_PACKAGES_PATH=/path/to/web-client-ui/packages/
+```
+
+Note that if you have already started the debugger, you will need to kill all of the prelaunch tasks and restart the debugger in order for config changes to take effect.
+
 ### Unit Testing
 
 Unit tests are configured to run via `vitest`. To run them:

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
         "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
-        "@deephaven/jsapi-nodejs": "^0.104.0",
+        "@deephaven/jsapi-nodejs": "^0.107.0",
         "archiver": "^7.0.1",
         "chai": "^4.5.0",
         "nanoid": "^5.0.7"
@@ -376,12 +376,13 @@
       }
     },
     "node_modules/@deephaven/jsapi-nodejs": {
-      "version": "0.104.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.104.0.tgz",
-      "integrity": "sha512-e284BE+MYIwN9Nflb13M9Hxs8ZQS2k1z1S7uZGqZQYsci85vhIAoCWhpU+UX2YUlhR8+QE0Aehf8ywheWF+W2g==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.107.0.tgz",
+      "integrity": "sha512-ga6Tivsr7OrHZ0zNHaa/gXmMlp4pj4TXMvW1o6RE/XR4l8hMddfzdvHkfkUGIc3cUTS7hA3jxn6JH4Dd+i0SHA==",
       "dependencies": {
-        "@deephaven/log": "^0.104.0",
-        "@deephaven/utils": "^0.104.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.37.2",
+        "@deephaven/log": "^0.107.0",
+        "@deephaven/utils": "^0.107.0",
         "ws": "^8.18.0"
       },
       "engines": {
@@ -389,9 +390,9 @@
       }
     },
     "node_modules/@deephaven/jsapi-nodejs/node_modules/@deephaven/log": {
-      "version": "0.104.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.104.0.tgz",
-      "integrity": "sha512-xsGSmdVNjCXF9Zii7/VitzX5mDpcST/MzTRA+bLgtHlChKEcw9U46rU68RPJKfKuW4BpGBQCvoMI4pKC+quZiw==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.107.0.tgz",
+      "integrity": "sha512-2QZPfwuF6P4NNFMXcHDiMV4ULHUIfZtq91oJbeSG5y8VHJc+CzlziKdkEKXnySiYuIlli6Q+qWqDMbVE7qcHbQ==",
       "dependencies": {
         "event-target-shim": "^6.0.2",
         "jszip": "^3.10.1"
@@ -401,9 +402,9 @@
       }
     },
     "node_modules/@deephaven/jsapi-nodejs/node_modules/@deephaven/utils": {
-      "version": "0.104.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.104.0.tgz",
-      "integrity": "sha512-KxWmrgHarAZ2fYP3R2ee2LjA3lUiYKK3zbxi1cu9V2jAi+H3iaUn1Xl/FIkCjq2Q5wrOfTkuKgg9MyG61DREyA==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.107.0.tgz",
+      "integrity": "sha512-1xnDVmkoo5//lelBPlrZ5nwYgS8SA2/hfZ2qAB8PHsc8ZiKmA+DUGV8kFlQjnB1htk63s9ZFzpeE8fYVFtP+HQ==",
       "engines": {
         "node": ">=16"
       }
@@ -11618,28 +11619,29 @@
       }
     },
     "@deephaven/jsapi-nodejs": {
-      "version": "0.104.0",
-      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.104.0.tgz",
-      "integrity": "sha512-e284BE+MYIwN9Nflb13M9Hxs8ZQS2k1z1S7uZGqZQYsci85vhIAoCWhpU+UX2YUlhR8+QE0Aehf8ywheWF+W2g==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@deephaven/jsapi-nodejs/-/jsapi-nodejs-0.107.0.tgz",
+      "integrity": "sha512-ga6Tivsr7OrHZ0zNHaa/gXmMlp4pj4TXMvW1o6RE/XR4l8hMddfzdvHkfkUGIc3cUTS7hA3jxn6JH4Dd+i0SHA==",
       "requires": {
-        "@deephaven/log": "^0.104.0",
-        "@deephaven/utils": "^0.104.0",
+        "@deephaven/jsapi-types": "^1.0.0-dev0.37.2",
+        "@deephaven/log": "^0.107.0",
+        "@deephaven/utils": "^0.107.0",
         "ws": "^8.18.0"
       },
       "dependencies": {
         "@deephaven/log": {
-          "version": "0.104.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.104.0.tgz",
-          "integrity": "sha512-xsGSmdVNjCXF9Zii7/VitzX5mDpcST/MzTRA+bLgtHlChKEcw9U46rU68RPJKfKuW4BpGBQCvoMI4pKC+quZiw==",
+          "version": "0.107.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/log/-/log-0.107.0.tgz",
+          "integrity": "sha512-2QZPfwuF6P4NNFMXcHDiMV4ULHUIfZtq91oJbeSG5y8VHJc+CzlziKdkEKXnySiYuIlli6Q+qWqDMbVE7qcHbQ==",
           "requires": {
             "event-target-shim": "^6.0.2",
             "jszip": "^3.10.1"
           }
         },
         "@deephaven/utils": {
-          "version": "0.104.0",
-          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.104.0.tgz",
-          "integrity": "sha512-KxWmrgHarAZ2fYP3R2ee2LjA3lUiYKK3zbxi1cu9V2jAi+H3iaUn1Xl/FIkCjq2Q5wrOfTkuKgg9MyG61DREyA=="
+          "version": "0.107.0",
+          "resolved": "https://registry.npmjs.org/@deephaven/utils/-/utils-0.107.0.tgz",
+          "integrity": "sha512-1xnDVmkoo5//lelBPlrZ5nwYgS8SA2/hfZ2qAB8PHsc8ZiKmA+DUGV8kFlQjnB1htk63s9ZFzpeE8fYVFtP+HQ=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@typescript-eslint/parser": "^7.16.0",
         "@vscode/vsce": "^2.30.0",
         "ctrf": "^0.0.9",
+        "dotenv": "^16.4.7",
         "esbuild-wasm": "^0.24.0",
         "eslint": "^8.57.0",
         "fantasticon": "^3.0.0",
@@ -3742,6 +3743,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer2": {
@@ -14008,6 +14021,12 @@
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3"
       }
+    },
+    "dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true
     },
     "duplexer2": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -869,7 +869,7 @@
   "dependencies": {
     "@deephaven-enterprise/auth-nodejs": "^1.20240723.124-beta",
     "@deephaven-enterprise/query-utils": "^1.20240723.124-beta",
-    "@deephaven/jsapi-nodejs": "^0.104.0",
+    "@deephaven/jsapi-nodejs": "^0.107.0",
     "archiver": "^7.0.1",
     "chai": "^4.5.0",
     "nanoid": "^5.0.7"

--- a/package.json
+++ b/package.json
@@ -887,6 +887,7 @@
     "@typescript-eslint/parser": "^7.16.0",
     "@vscode/vsce": "^2.30.0",
     "ctrf": "^0.0.9",
+    "dotenv": "^16.4.7",
     "esbuild-wasm": "^0.24.0",
     "eslint": "^8.57.0",
     "fantasticon": "^3.0.0",

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -3,7 +3,7 @@ const esbuild = require('esbuild-wasm');
 const fs = require('node:fs');
 const path = require('node:path');
 
-require('dotenv').config({ path: path.resolve(__dirname, '../.env.local') });
+require('dotenv').config({ path: ['.env.local', '.env'] });
 
 const production = process.argv.includes('--production');
 const watch = process.argv.includes('--watch');

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -6,7 +6,7 @@ import type {
   DependencyName,
   DependencyVersion,
 } from '../types';
-import { hasStatusCode, loadModules } from '@deephaven/jsapi-nodejs';
+import { hasStatusCode, loadDhModules } from '@deephaven/jsapi-nodejs';
 import {
   REQUIREMENTS_QUERY_TXT,
   REQUIREMENTS_TABLE_NAME,
@@ -44,28 +44,8 @@ export async function getDhc(
   globalThis.self = globalThis;
 
   // Download jsapi `ESM` files from DH Community server.
-  const coreModule = await loadModules<typeof DhType>({
+  const coreModule = await loadDhModules({
     serverUrl,
-    serverPaths: ['jsapi/dh-core.js', 'jsapi/dh-internal.js'],
-    download: (serverPath, content) => {
-      if (serverPath === 'jsapi/dh-core.js') {
-        return content
-          .replace(
-            `import {dhinternal} from './dh-internal.js';`,
-            `const {dhinternal} = require("./dh-internal.js");`
-          )
-          .replace(`export default dh;`, `module.exports = dh;`);
-      }
-
-      if (serverPath === 'jsapi/dh-internal.js') {
-        return content.replace(
-          `export{__webpack_exports__dhinternal as dhinternal};`,
-          `module.exports={dhinternal:__webpack_exports__dhinternal};`
-        );
-      }
-
-      return content;
-    },
     storageDir,
     targetModuleType: 'cjs',
   });

--- a/src/dh/dhe.ts
+++ b/src/dh/dhe.ts
@@ -55,7 +55,7 @@ export async function getDhe(
 ): Promise<DheType> {
   polyfillDhe();
 
-  // Download jsapi `CJS` files from DH Community server.
+  // Download jsapi `CJS` files from DHE server.
   await loadModules({
     serverUrl,
     serverPaths: ['irisapi/irisapi.nocache.js'],

--- a/src/services/DisposableBase.ts
+++ b/src/services/DisposableBase.ts
@@ -36,7 +36,7 @@ export abstract class DisposableBase implements IDisposable {
     this._isDisposing = true;
     await this.onDisposing();
 
-    this._logger.debug2('Disposing disposables', this.disposables.size);
+    this._logger.debug2(`Disposing ${this.disposables.size} disposables`);
     const disposing = [...this.disposables].map(disposable =>
       typeof disposable === 'function' ? disposable() : disposable.dispose()
     );

--- a/src/services/DisposableBase.ts
+++ b/src/services/DisposableBase.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import type { IDisposable } from '../types';
+import { Logger } from '../util';
+
+/** Base class for disposing of dependencies. */
+export abstract class DisposableBase implements IDisposable {
+  constructor() {
+    this._logger = new Logger(`${this.constructor.name}: DisposableBase`);
+  }
+
+  protected readonly disposables = new Set<
+    (() => void) | IDisposable | vscode.Disposable
+  >();
+  private readonly _logger: Logger;
+
+  private _isDisposed = false;
+  private _isDisposing = false;
+  private _disposalPromise: Promise<any> | undefined;
+
+  /**
+   * Dispose of dependencies. Returns immediately if already called.
+   * @returns Promise that resolves when disposal is complete.
+   */
+  async dispose(): Promise<void> {
+    if (this._isDisposing) {
+      this._logger.debug2('Already disposing');
+      return this._disposalPromise;
+    }
+
+    if (this._isDisposed) {
+      this._logger.debug2('Already disposed');
+      return this._disposalPromise;
+    }
+
+    this._logger.debug2('Disposing');
+    this._isDisposing = true;
+    await this.onDisposing();
+
+    this._logger.debug2('Disposing disposables', this.disposables.size);
+    const disposing = [...this.disposables].map(disposable =>
+      typeof disposable === 'function' ? disposable() : disposable.dispose()
+    );
+    this.disposables.clear();
+
+    this._disposalPromise = Promise.all(disposing);
+
+    await this._disposalPromise;
+
+    this._isDisposed = true;
+    this._isDisposing = false;
+  }
+
+  /** Override this method to call additional disposal logic. */
+  protected async onDisposing(): Promise<void> {}
+}

--- a/src/services/DisposableBase.ts
+++ b/src/services/DisposableBase.ts
@@ -25,7 +25,7 @@ export abstract class DisposableBase implements IDisposable {
       return this._disposalPromise;
     }
 
-    const { promise, resolve } = withResolvers<void>();
+    const { promise, resolve } = withResolvers<unknown>();
     this._disposalPromise = promise;
 
     this._logger.debug2('Disposing');
@@ -37,8 +37,7 @@ export abstract class DisposableBase implements IDisposable {
     );
     this.disposables.clear();
 
-    await Promise.all(disposing);
-    resolve();
+    resolve(Promise.all(disposing));
 
     return this._disposalPromise;
   }

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -261,6 +261,11 @@ export class ServerManager implements IServerManager {
       return null;
     }
 
+    connection.onDidDisconnect(() => {
+      logger.debug('onDidDisconnect fired for:', serverUrl.href);
+      this.disconnectFromServer(serverUrl);
+    });
+
     this.updateConnectionCount(serverUrl, 1);
 
     this._onDidConnect.fire(serverUrl);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,6 +3,7 @@ export * from './ConfigService';
 export * from './consoleTypeUtils';
 export * from './DhcService';
 export * from './DheService';
+export * from './DisposableBase';
 export * from './PanelService';
 export * from './PollingService';
 export * from './SecretService';


### PR DESCRIPTION
DH-19010:
* Handle client disconnects and proper disposal of DhService (Note this depends on changes made in https://github.com/deephaven/web-client-ui/pull/2400 which have been brought in by @deephaven/jsapi-nodejs@0.107.0)
* Added support for `DHC_PACKAGES_PATH` env variable. If set, this aliases `@deephaven/*` packages to the specified path
* Upgraded dhc loader to use the simpler `loadDhModules` function

### Testing
#### Disconnect Handling
To test the disconnect handling, you can introduce this code block after the `new dhc.CoreClient` block in `ExtensionController.ts`
```typescript
// Destroy the http2 session after 2 seconds to mimic disconnect outside
// of jsapi
setTimeout(() => {
  for (var session of (
    NodeHttp2gRPCTransport as any
  ).sessionMap.values()) {
    session.destroy();
  }
}, 2000);
```

1. Click on Community server node to connect
2. The added codeblock should destroy the http2 session after 2 seconds which will cause client to disconnect and the CONNECTION node to be removed
3. Should be able to reconnect (it will disconnect 2 seconds later, but we are proving that a disconnect can recover)

#### DHC_PACKAGES_PATH
The `DHC_PACKAGES_PATH` env variable can be tested by creating a `.env.local` file and setting the it to the path of a local DHC web `/packages` directory.

> Note that if you have previously run the debugger, you will need to kill the terminals for the build tasks in order to get a fresh build.