### PR TITLE
feat: DH-18882: Run code improvements

### DIFF
--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -30,6 +30,45 @@ export class Position {
 
   readonly line: number;
   readonly character: number;
+
+  /**
+   * Check if this position is before `other`.
+   *
+   * @param other A position.
+   * @returns `true` if position is on a smaller line
+   * or on the same line on a smaller character.
+   */
+  isBefore(other: Position): boolean {
+    return (
+      this.line < other.line ||
+      (this.line === other.line && this.character < other.character)
+    );
+  }
+
+  /**
+   * Check if this position is after `other`.
+   *
+   * @param other A position.
+   * @returns `true` if position is on a greater line
+   * or on the same line on a greater character.
+   */
+  isAfter(other: Position): boolean {
+    return (
+      this.line > other.line ||
+      (this.line === other.line && this.character > other.character)
+    );
+  }
+
+  /**
+   * Check if this position is equal to `other`.
+   *
+   * @param other A position.
+   * @returns `true` if the line and character of the given position are equal to
+   * the line and character of this position.
+   */
+  isEqual(other: Position): boolean {
+    return this.line === other.line && this.character === other.character;
+  }
 }
 
 export enum QuickPickItemKind {
@@ -92,7 +131,10 @@ export class Selection {
       this.active = new Position(args[2], args[3]);
     }
 
-    const { start, end } = determineStartAndEnd(this.anchor, this.active);
+    const [start, end] = this.anchor.isBefore(this.active)
+      ? [this.anchor, this.active]
+      : [this.active, this.anchor];
+
     this.start = start;
     this.end = end;
   }
@@ -143,16 +185,16 @@ export const workspace = {
  * @param active The active position.
  * @returns An object containing the start and end positions.
  */
-function determineStartAndEnd(
-  anchor: Position,
-  active: Position
-): { start: Position; end: Position } {
-  if (
-    anchor.line < active.line || // Anchor is on an earlier line
-    (anchor.line === active.line && anchor.character <= active.character) // Same line, but anchor is earlier or equal
-  ) {
-    return { start: anchor, end: active };
-  } else {
-    return { start: active, end: anchor };
-  }
-}
+// function determineStartAndEnd(
+//   anchor: Position,
+//   active: Position
+// ): { start: Position; end: Position } {
+//   if (
+//     anchor.line < active.line || // Anchor is on an earlier line
+//     (anchor.line === active.line && anchor.character <= active.character) // Same line, but anchor is earlier or equal
+//   ) {
+//     return { start: anchor, end: active };
+//   } else {
+//     return { start: active, end: anchor };
+//   }
+// }

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -12,9 +12,44 @@ export class EventEmitter {
   fire = vi.fn().mockName('fire');
 }
 
+export class Position {
+  constructor(line: number, character: number) {
+    this.line = line;
+    this.character = character;
+  }
+
+  readonly line: number;
+  readonly character: number;
+}
+
 export enum QuickPickItemKind {
   Separator = -1,
   Default = 0,
+}
+
+export class Range {
+  constructor(start: Position, end: Position);
+  constructor(
+    startLine: number,
+    startCharacter: number,
+    endLine: number,
+    endCharacter: number
+  );
+  constructor(
+    ...args: [Position, Position] | [number, number, number, number]
+  ) {
+    if (args.length === 2) {
+      this.start = args[0];
+      this.end = args[1];
+    } else {
+      const [startLine, startCharacter, endLine, endCharacter] = args;
+      this.start = new Position(startLine, startCharacter);
+      this.end = new Position(endLine, endCharacter);
+    }
+  }
+
+  readonly start: Position;
+  readonly end: Position;
 }
 
 export const ThemeColor = vi

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -38,9 +38,13 @@ export enum TreeItemCollapsibleState {
   Expanded = 2,
 }
 
+export const window = {};
+
 export const workspace = {
   getConfiguration: vi
     .fn()
     .mockName('getConfiguration')
     .mockReturnValue(new Map()),
+  onDidChangeTextDocument: vi.fn().mockName('onDidChangeTextDocument'),
+  onDidCloseTextDocument: vi.fn().mockName('onDidCloseTextDocument'),
 };

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -177,24 +177,3 @@ export const workspace = {
   onDidChangeTextDocument: vi.fn().mockName('onDidChangeTextDocument'),
   onDidCloseTextDocument: vi.fn().mockName('onDidCloseTextDocument'),
 };
-
-/**
- * Since we are mocking vscode apis, we need a way to determine which anchor /
- * active Position is the start / end.
- * @param anchor The anchor position.
- * @param active The active position.
- * @returns An object containing the start and end positions.
- */
-// function determineStartAndEnd(
-//   anchor: Position,
-//   active: Position
-// ): { start: Position; end: Position } {
-//   if (
-//     anchor.line < active.line || // Anchor is on an earlier line
-//     (anchor.line === active.line && anchor.character <= active.character) // Same line, but anchor is earlier or equal
-//   ) {
-//     return { start: anchor, end: active };
-//   } else {
-//     return { start: active, end: anchor };
-//   }
-// }

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -839,13 +839,14 @@ export class ExtensionController implements IDisposable {
     if (range instanceof Array) {
       range = deserializeRange(range);
     }
-    this.onRunCode(uri, undefined, [range], languageId);
+    this.onRunCode(uri, [range], languageId);
   };
 
   /**
-   * Run all code in editor for given uri.
+   * Run all code in editor for given uri. Note that the parameters are
+   * optional since the RUN_CODE_COMMAND can be called from the CMD palette
+   * which doesn't provide parameters.
    * @param uri The uri of the editor
-   * @param _arg Unused 2nd argument
    * @param constrainTo Optional arg to constrain the code to run.
    * - If 'selection', run only selected code in the editor.
    * - If `undefined`, run all code in the editor.
@@ -856,7 +857,6 @@ export class ExtensionController implements IDisposable {
    */
   onRunCode = async (
     uri?: vscode.Uri,
-    _arg?: { groupId: number },
     constrainTo?: 'selection' | vscode.Range[],
     languageId?: string
   ): Promise<void> => {
@@ -885,15 +885,17 @@ export class ExtensionController implements IDisposable {
   };
 
   /**
-   * Run selected code in editor for given uri.
-   * @param uri
-   * @param arg
+   * Run selected code in editor for given uri. Note that the parameters are
+   * optional since the RUN_SELECTION_COMMAND can be called from the CMD
+   * palette which doesn't provide parameters.
+   * @param uri The uri of the editor
+   * @param languageId Optional languageId to run the code as
    */
   onRunSelectedCode = async (
     uri?: vscode.Uri,
-    arg?: { groupId: number }
+    languageId?: string
   ): Promise<void> => {
-    this.onRunCode(uri, arg, 'selection');
+    this.onRunCode(uri, 'selection', languageId);
   };
 
   /**

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -33,6 +33,7 @@ import {
   getEditorForUri,
   getTempDir,
   isInstanceOf,
+  isSerializedRange,
   isSupportedLanguageId,
   LogFileHandler,
   Logger,
@@ -836,7 +837,7 @@ export class ExtensionController implements IDisposable {
     languageId: string,
     range: vscode.Range | SerializedRange
   ): Promise<void> => {
-    if (range instanceof Array) {
+    if (isSerializedRange(range)) {
       range = deserializeRange(range);
     }
     this.onRunCode(uri, [range], languageId);

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -29,6 +29,7 @@ import {
 } from '../common';
 import {
   assertDefined,
+  deserializeRange,
   getEditorForUri,
   getTempDir,
   isInstanceOf,
@@ -49,6 +50,7 @@ import {
   runSelectedLinesHoverProvider,
   RunMarkdownCodeBlockCodeLensProvider,
   SamlAuthProvider,
+  RunMarkdownCodeBlockHoverProvider,
 } from '../providers';
 import {
   DheJsApiCache,
@@ -85,6 +87,7 @@ import type {
   ConnectionState,
   WorkerURL,
   UniqueID,
+  SerializedRange,
 } from '../types';
 import { ServerConnectionTreeDragAndDropController } from './ServerConnectionTreeDragAndDropController';
 import { ConnectionController } from './ConnectionController';
@@ -357,6 +360,11 @@ export class ExtensionController implements IDisposable {
     vscode.languages.registerHoverProvider(
       'python',
       runSelectedLinesHoverProvider
+    );
+
+    vscode.languages.registerHoverProvider(
+      'markdown',
+      new RunMarkdownCodeBlockHoverProvider()
     );
   };
 
@@ -808,8 +816,11 @@ export class ExtensionController implements IDisposable {
   onRunMarkdownCodeblock = async (
     uri: vscode.Uri,
     languageId: string,
-    range: vscode.Range
+    range: vscode.Range | SerializedRange
   ): Promise<void> => {
+    if (range instanceof Array) {
+      range = deserializeRange(range);
+    }
     this.onRunCode(uri, undefined, [range], languageId);
   };
 

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -34,13 +34,12 @@ export class RunMarkdownCodeBlockCodeLensProvider
   };
 
   /**
-   * Provide a hover for the given position and document.
+   * Compute a list of {@link CodeLens lenses} representing Markdown code blocks
+   * that can be run by Deephaven.
    *
    * @param document The document in which the command was invoked.
-   * @param position The position at which the command was invoked.
    * @param token A cancellation token.
-   * @returns A hover or a thenable that resolves to such. The lack of a result can be
-   * signaled by returning `undefined` or `null`.
+   * @returns An array of code lenses
    */
   provideCodeLenses(
     document: vscode.TextDocument,

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -42,14 +42,26 @@ export class RunMarkdownCodeBlockCodeLensProvider
     for (let i = 0; i < lines.length; ++i) {
       const line = lines[i];
 
+      // End of Deephaven code block
       if (line === '```' && start) {
         ranges.push([
           languageId,
           new vscode.Range(start, new vscode.Position(i - 1, 0)),
         ]);
         start = null;
-      } else if (line === '```python' || line === '```groovy') {
+        // Start of Deephaven supported code block
+      } else if (
+        line === '```python' ||
+        line === '```py' ||
+        line === '```groovy'
+      ) {
         languageId = line.substring(3);
+        // 'py' is an alias for 'python'. We use 'python' and 'groovy' in other
+        // DH apis, so we normalize here.
+        if (languageId === 'py') {
+          languageId = 'python';
+        }
+
         start = new vscode.Position(i + 1, 0);
       }
     }

--- a/src/providers/RunMarkdownCodeBlockHoverProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockHoverProvider.ts
@@ -1,0 +1,93 @@
+import * as vscode from 'vscode';
+import { URIMap } from '../services';
+import {
+  assertDefined,
+  parseMarkdownCodeblocks,
+  serializeRange,
+} from '../util';
+import type { CodeBlock } from '../types';
+import { ICON_ID, RUN_MARKDOWN_CODEBLOCK_CMD } from '../common';
+
+/**
+ * Hover provider that provides a button to run a Deephaven code block in a Markdown file.
+ */
+export class RunMarkdownCodeBlockHoverProvider implements vscode.HoverProvider {
+  private readonly _codeBlockCache = new URIMap<CodeBlock[]>();
+  private readonly _lastDocumentVersion = new URIMap<number>();
+
+  constructor() {
+    // Update caches on document change
+    vscode.workspace.onDidChangeTextDocument(event => {
+      const document = event.document;
+      const uri = document.uri;
+      const lastVersion = this._lastDocumentVersion.get(uri);
+
+      if (lastVersion == null || lastVersion < document.version) {
+        this._updateCache(document);
+      }
+    });
+
+    // Clear caches on document close
+    vscode.workspace.onDidCloseTextDocument(document => {
+      this._codeBlockCache.delete(document.uri);
+      this._lastDocumentVersion.delete(document.uri);
+    });
+  }
+
+  /** Update Caches */
+  private _updateCache(document: vscode.TextDocument): void {
+    const uri = document.uri;
+
+    const codeBlocks = parseMarkdownCodeblocks(document);
+
+    this._codeBlockCache.set(uri, codeBlocks);
+    this._lastDocumentVersion.set(uri, document.version);
+  }
+
+  /**
+   * Provide a hover for the given position and document.
+   *
+   * @param document The document in which the command was invoked.
+   * @param position The position at which the command was invoked.
+   * @param token A cancellation token.
+   * @returns A hover or a thenable that resolves to such. The lack of a result can be
+   * signaled by returning `undefined` or `null`.
+   */
+  provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    _token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.Hover> {
+    const lastVersion = this._lastDocumentVersion.get(document.uri);
+
+    if (lastVersion !== document.version) {
+      this._updateCache(document);
+    }
+
+    const codeBlocks = this._codeBlockCache.get(document.uri);
+
+    assertDefined(codeBlocks, 'codeBlocks');
+
+    for (const { languageId, range } of codeBlocks) {
+      if (range.contains(position)) {
+        const argsStr = JSON.stringify([
+          document.uri,
+          languageId,
+          serializeRange(range),
+        ]);
+        const argsEncoded = encodeURIComponent(argsStr);
+
+        const hoverContent = new vscode.MarkdownString(
+          `[$(${ICON_ID.runSelection}) Run Deephaven Block](command:${RUN_MARKDOWN_CODEBLOCK_CMD}?${argsEncoded})`,
+          true
+        );
+
+        hoverContent.isTrusted = {
+          enabledCommands: [RUN_MARKDOWN_CODEBLOCK_CMD],
+        };
+
+        return new vscode.Hover(hoverContent);
+      }
+    }
+  }
+}

--- a/src/providers/RunMarkdownCodeBlockHoverProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockHoverProvider.ts
@@ -1,48 +1,18 @@
 import * as vscode from 'vscode';
-import { URIMap } from '../services';
-import {
-  assertDefined,
-  parseMarkdownCodeblocks,
-  serializeRange,
-} from '../util';
-import type { CodeBlock } from '../types';
+import { ParsedDocumentCache } from '../services';
+import { serializeRange } from '../util';
 import { ICON_ID, RUN_MARKDOWN_CODEBLOCK_CMD } from '../common';
+import type { CodeBlock } from '../types';
 
 /**
  * Hover provider that provides a button to run a Deephaven code block in a Markdown file.
  */
 export class RunMarkdownCodeBlockHoverProvider implements vscode.HoverProvider {
-  private readonly _codeBlockCache = new URIMap<CodeBlock[]>();
-  private readonly _lastDocumentVersion = new URIMap<number>();
-
-  constructor() {
-    // Update caches on document change
-    vscode.workspace.onDidChangeTextDocument(event => {
-      const document = event.document;
-      const uri = document.uri;
-      const lastVersion = this._lastDocumentVersion.get(uri);
-
-      if (lastVersion == null || lastVersion < document.version) {
-        this._updateCache(document);
-      }
-    });
-
-    // Clear caches on document close
-    vscode.workspace.onDidCloseTextDocument(document => {
-      this._codeBlockCache.delete(document.uri);
-      this._lastDocumentVersion.delete(document.uri);
-    });
+  constructor(codeBlockCache: ParsedDocumentCache<CodeBlock[]>) {
+    this._codeBlockCache = codeBlockCache;
   }
 
-  /** Update Caches */
-  private _updateCache(document: vscode.TextDocument): void {
-    const uri = document.uri;
-
-    const codeBlocks = parseMarkdownCodeblocks(document);
-
-    this._codeBlockCache.set(uri, codeBlocks);
-    this._lastDocumentVersion.set(uri, document.version);
-  }
+  private readonly _codeBlockCache: ParsedDocumentCache<CodeBlock[]>;
 
   /**
    * Provide a hover for the given position and document.
@@ -58,15 +28,7 @@ export class RunMarkdownCodeBlockHoverProvider implements vscode.HoverProvider {
     position: vscode.Position,
     _token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.Hover> {
-    const lastVersion = this._lastDocumentVersion.get(document.uri);
-
-    if (lastVersion !== document.version) {
-      this._updateCache(document);
-    }
-
-    const codeBlocks = this._codeBlockCache.get(document.uri);
-
-    assertDefined(codeBlocks, 'codeBlocks');
+    const codeBlocks = this._codeBlockCache.get(document);
 
     for (const { languageId, range } of codeBlocks) {
       if (range.contains(position)) {

--- a/src/providers/RunSelectedLinesHoverProvider.ts
+++ b/src/providers/RunSelectedLinesHoverProvider.ts
@@ -1,36 +1,16 @@
 import * as vscode from 'vscode';
-import { ICON_ID, RUN_SELECTION_COMMAND } from '../common';
-import { expandRangeToFullLines } from '../util';
+import { getRunSelectedLinesMarkdown } from '../util';
 
 /**
  * Provides hover content for running selected lines in Deephaven.
  */
 export const runSelectedLinesHoverProvider: vscode.HoverProvider = {
-  provideHover(_document, position, _token) {
-    const editor = vscode.window.activeTextEditor;
-
-    if (editor == null) {
+  provideHover(document, position, _token) {
+    const hoverMd = getRunSelectedLinesMarkdown(position, document.languageId);
+    if (hoverMd == null) {
       return;
     }
 
-    // Determine if hover is over a selected line
-    const isOverSelection = editor.selections.some(selection =>
-      expandRangeToFullLines(editor.document)(selection).contains(position)
-    );
-
-    if (!isOverSelection) {
-      return;
-    }
-
-    const hoverContent = new vscode.MarkdownString(
-      `[$(${ICON_ID.runSelection}) Run Deephaven selected lines](command:${RUN_SELECTION_COMMAND})`,
-      true
-    );
-
-    hoverContent.isTrusted = {
-      enabledCommands: [RUN_SELECTION_COMMAND],
-    };
-
-    return new vscode.Hover(hoverContent);
+    return new vscode.Hover(hoverMd);
   },
 };

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,6 @@
 export * from './RunCommandCodeLensProvider';
 export * from './RunMarkdownCodeBlockCodeLensProvider';
+export * from './RunMarkdownCodeBlockHoverProvider';
 export * from './RunSelectedLinesHoverProvider';
 export * from './SamlAuthProvider';
 export * from './ServerConnectionTreeProvider';

--- a/src/services/ParseDocumentCache.spec.ts
+++ b/src/services/ParseDocumentCache.spec.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { vi, it, expect, beforeEach } from 'vitest';
 import { ParsedDocumentCache } from './ParseDocumentCache';
-import { mockDocument, mockT } from '../util';
+import { mockDocument } from '../util';
 
 vi.mock('vscode');
 
@@ -13,20 +13,12 @@ interface MockParsedDocument {
 const mockDoc = {
   av1: mockDocument('fileA', 1),
   av2: mockDocument('fileA', 2),
+  bv1: mockDocument('fileB', 1),
+  bv2: mockDocument('fileB', 2),
   parseDocument: (document: vscode.TextDocument): MockParsedDocument =>
     ({
       label: `mock.parsed.${document.fileName}`,
     }) as MockParsedDocument,
-};
-
-// Event handler mocks
-const mockEvent = {
-  av1: mockT<vscode.TextDocumentChangeEvent>({
-    document: mockDoc.av1,
-  }),
-  av2: mockT<vscode.TextDocumentChangeEvent>({
-    document: mockDoc.av2,
-  }),
 };
 
 // Mock document parser
@@ -39,12 +31,12 @@ const mockParseDocument =
  */
 function initializeCache(initialCachedDoc?: vscode.TextDocument): {
   cache: ParsedDocumentCache<MockParsedDocument>;
-  changeHandler: (e: vscode.TextDocumentChangeEvent) => any;
   closeHandler: (e: vscode.TextDocument) => any;
 } {
   const cache = new ParsedDocumentCache(mockParseDocument);
 
-  const { changeHandler, closeHandler } = getHandlers();
+  const closeHandler = vi.mocked(vscode.workspace.onDidCloseTextDocument).mock
+    .calls[0][0];
 
   if (initialCachedDoc != null) {
     const actual = cache.get(initialCachedDoc);
@@ -52,26 +44,7 @@ function initializeCache(initialCachedDoc?: vscode.TextDocument): {
     expect(actual).toEqual(mockDoc.parseDocument(initialCachedDoc));
   }
 
-  return { cache, changeHandler, closeHandler };
-}
-
-/**
- * Get registered event handlers that are set by ParseDocumentCache constructor.
- */
-function getHandlers(): {
-  changeHandler: (e: vscode.TextDocumentChangeEvent) => any;
-  closeHandler: (e: vscode.TextDocument) => any;
-} {
-  const changeHandler = vi.mocked(vscode.workspace.onDidChangeTextDocument).mock
-    .calls[0][0];
-
-  const closeHandler = vi.mocked(vscode.workspace.onDidCloseTextDocument).mock
-    .calls[0][0];
-
-  return {
-    changeHandler,
-    closeHandler,
-  };
+  return { cache, closeHandler };
 }
 
 beforeEach(() => {
@@ -79,25 +52,35 @@ beforeEach(() => {
   mockParseDocument.mockImplementation(mockDoc.parseDocument);
 });
 
-it('should re-cache if document changed to newer version or explicitly requested', () => {
-  const { cache, changeHandler } = initializeCache(mockDoc.av1);
+it('should cache on doc uri + version', () => {
+  const { cache } = initializeCache(mockDoc.av1);
 
-  // Document changed to newer version
+  // Same doc + version
   vi.clearAllMocks();
-  changeHandler(mockEvent.av2);
-  expect(mockParseDocument).toHaveBeenCalledWith(mockDoc.av2);
-  expect(cache.get(mockDoc.av2)).toEqual(mockDoc.parseDocument(mockDoc.av2));
-
-  // Document changed to older version
-  vi.clearAllMocks();
-  changeHandler(mockEvent.av1);
+  let actual = cache.get(mockDoc.av1);
   expect(mockParseDocument).not.toHaveBeenCalled();
+  expect(actual).toEqual(mockDoc.parseDocument(mockDoc.av1));
 
-  expect(cache.get(mockDoc.av1)).toEqual(mockDoc.parseDocument(mockDoc.av1));
-  expect(mockParseDocument).toHaveBeenCalledWith(mockDoc.av1);
+  // Change version
+  vi.clearAllMocks();
+  actual = cache.get(mockDoc.av2);
+  expect(mockParseDocument).toHaveBeenCalledWith(mockDoc.av2);
+  expect(actual).toEqual(mockDoc.parseDocument(mockDoc.av2));
+
+  // Change doc
+  vi.clearAllMocks();
+  actual = cache.get(mockDoc.bv2);
+  expect(mockParseDocument).toHaveBeenCalledWith(mockDoc.bv2);
+  expect(actual).toEqual(mockDoc.parseDocument(mockDoc.bv2));
+
+  // Change back to previous doc
+  vi.clearAllMocks();
+  actual = cache.get(mockDoc.av2);
+  expect(mockParseDocument).not.toHaveBeenCalledWith(mockDoc.av2);
+  expect(actual).toEqual(mockDoc.parseDocument(mockDoc.av2));
 });
 
-it('should clear cache on document close', () => {
+it('should remove document from cache on close', () => {
   const { cache, closeHandler } = initializeCache(mockDoc.av1);
 
   expect(mockParseDocument).toHaveBeenCalledWith(mockDoc.av1);

--- a/src/services/ParseDocumentCache.spec.ts
+++ b/src/services/ParseDocumentCache.spec.ts
@@ -1,0 +1,104 @@
+import * as vscode from 'vscode';
+import { vi, it, expect, beforeEach } from 'vitest';
+import { ParsedDocumentCache } from './ParseDocumentCache';
+import { mockDocument, mockT } from '../util';
+
+vi.mock('vscode');
+
+interface MockParsedDocument {
+  label: `mock.parsed.${string}`;
+}
+
+const mockDock = {
+  av1: mockDocument('fileA', 1),
+  av2: mockDocument('fileA', 2),
+  parseDocument: (document: vscode.TextDocument): MockParsedDocument =>
+    ({
+      label: `mock.parsed.${document.fileName}`,
+    }) as MockParsedDocument,
+};
+
+const mockEvent = {
+  av1: mockT<vscode.TextDocumentChangeEvent>({
+    document: mockDock.av1,
+  }),
+  av2: mockT<vscode.TextDocumentChangeEvent>({
+    document: mockDock.av2,
+  }),
+};
+
+const parseDocument =
+  vi.fn<(document: vscode.TextDocument) => MockParsedDocument>();
+
+function initializeCache(initialCachedDoc?: vscode.TextDocument): {
+  cache: ParsedDocumentCache<MockParsedDocument>;
+  changeHandler: (e: vscode.TextDocumentChangeEvent) => any;
+  closeHandler: (e: vscode.TextDocument) => any;
+} {
+  const cache = new ParsedDocumentCache(parseDocument);
+
+  const { changeHandler, closeHandler } = getHandlers();
+
+  if (initialCachedDoc != null) {
+    const actual = cache.get(initialCachedDoc);
+    expect(parseDocument).toHaveBeenCalledWith(initialCachedDoc);
+    expect(actual).toEqual(mockDock.parseDocument(initialCachedDoc));
+  }
+
+  return { cache, changeHandler, closeHandler };
+}
+
+function getHandlers(): {
+  changeHandler: (e: vscode.TextDocumentChangeEvent) => any;
+  closeHandler: (e: vscode.TextDocument) => any;
+} {
+  const changeHandler = vi.mocked(vscode.workspace.onDidChangeTextDocument).mock
+    .calls[0][0];
+
+  const closeHandler = vi.mocked(vscode.workspace.onDidCloseTextDocument).mock
+    .calls[0][0];
+
+  return {
+    changeHandler,
+    closeHandler,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  parseDocument.mockImplementation(mockDock.parseDocument);
+});
+
+it('should re-cache if document changed to newer version or explicitly requested', () => {
+  const { cache, changeHandler } = initializeCache(mockDock.av1);
+
+  // Document changed to newer version
+  vi.clearAllMocks();
+  changeHandler(mockEvent.av2);
+  expect(parseDocument).toHaveBeenCalledWith(mockDock.av2);
+  expect(cache.get(mockDock.av2)).toEqual(mockDock.parseDocument(mockDock.av2));
+
+  // Document changed to older version
+  vi.clearAllMocks();
+  changeHandler(mockEvent.av1);
+  expect(parseDocument).not.toHaveBeenCalled();
+
+  expect(cache.get(mockDock.av1)).toEqual(mockDock.parseDocument(mockDock.av1));
+  expect(parseDocument).toHaveBeenCalledWith(mockDock.av1);
+});
+
+it('should clear cache on document close', () => {
+  const { cache, closeHandler } = initializeCache(mockDock.av1);
+
+  expect(parseDocument).toHaveBeenCalledWith(mockDock.av1);
+
+  // Request cached version
+  vi.clearAllMocks();
+  cache.get(mockDock.av1);
+  expect(parseDocument).not.toHaveBeenCalled();
+
+  // Close document and request a again
+  closeHandler(mockDock.av1);
+  cache.get(mockDock.av1);
+  expect(parseDocument).toHaveBeenCalledWith(mockDock.av1);
+});

--- a/src/services/ParseDocumentCache.spec.ts
+++ b/src/services/ParseDocumentCache.spec.ts
@@ -9,7 +9,7 @@ interface MockParsedDocument {
   label: `mock.parsed.${string}`;
 }
 
-const mockDock = {
+const mockDoc = {
   av1: mockDocument('fileA', 1),
   av2: mockDocument('fileA', 2),
   parseDocument: (document: vscode.TextDocument): MockParsedDocument =>
@@ -20,10 +20,10 @@ const mockDock = {
 
 const mockEvent = {
   av1: mockT<vscode.TextDocumentChangeEvent>({
-    document: mockDock.av1,
+    document: mockDoc.av1,
   }),
   av2: mockT<vscode.TextDocumentChangeEvent>({
-    document: mockDock.av2,
+    document: mockDoc.av2,
   }),
 };
 
@@ -42,7 +42,7 @@ function initializeCache(initialCachedDoc?: vscode.TextDocument): {
   if (initialCachedDoc != null) {
     const actual = cache.get(initialCachedDoc);
     expect(parseDocument).toHaveBeenCalledWith(initialCachedDoc);
-    expect(actual).toEqual(mockDock.parseDocument(initialCachedDoc));
+    expect(actual).toEqual(mockDoc.parseDocument(initialCachedDoc));
   }
 
   return { cache, changeHandler, closeHandler };
@@ -66,39 +66,39 @@ function getHandlers(): {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  parseDocument.mockImplementation(mockDock.parseDocument);
+  parseDocument.mockImplementation(mockDoc.parseDocument);
 });
 
 it('should re-cache if document changed to newer version or explicitly requested', () => {
-  const { cache, changeHandler } = initializeCache(mockDock.av1);
+  const { cache, changeHandler } = initializeCache(mockDoc.av1);
 
   // Document changed to newer version
   vi.clearAllMocks();
   changeHandler(mockEvent.av2);
-  expect(parseDocument).toHaveBeenCalledWith(mockDock.av2);
-  expect(cache.get(mockDock.av2)).toEqual(mockDock.parseDocument(mockDock.av2));
+  expect(parseDocument).toHaveBeenCalledWith(mockDoc.av2);
+  expect(cache.get(mockDoc.av2)).toEqual(mockDoc.parseDocument(mockDoc.av2));
 
   // Document changed to older version
   vi.clearAllMocks();
   changeHandler(mockEvent.av1);
   expect(parseDocument).not.toHaveBeenCalled();
 
-  expect(cache.get(mockDock.av1)).toEqual(mockDock.parseDocument(mockDock.av1));
-  expect(parseDocument).toHaveBeenCalledWith(mockDock.av1);
+  expect(cache.get(mockDoc.av1)).toEqual(mockDoc.parseDocument(mockDoc.av1));
+  expect(parseDocument).toHaveBeenCalledWith(mockDoc.av1);
 });
 
 it('should clear cache on document close', () => {
-  const { cache, closeHandler } = initializeCache(mockDock.av1);
+  const { cache, closeHandler } = initializeCache(mockDoc.av1);
 
-  expect(parseDocument).toHaveBeenCalledWith(mockDock.av1);
+  expect(parseDocument).toHaveBeenCalledWith(mockDoc.av1);
 
   // Request cached version
   vi.clearAllMocks();
-  cache.get(mockDock.av1);
+  cache.get(mockDoc.av1);
   expect(parseDocument).not.toHaveBeenCalled();
 
   // Close document and request a again
-  closeHandler(mockDock.av1);
-  cache.get(mockDock.av1);
-  expect(parseDocument).toHaveBeenCalledWith(mockDock.av1);
+  closeHandler(mockDoc.av1);
+  cache.get(mockDoc.av1);
+  expect(parseDocument).toHaveBeenCalledWith(mockDoc.av1);
 });

--- a/src/services/ParseDocumentCache.ts
+++ b/src/services/ParseDocumentCache.ts
@@ -9,40 +9,16 @@ export class ParsedDocumentCache<TParsed> {
   constructor(parserFn: (document: vscode.TextDocument) => TParsed) {
     this._parserFn = parserFn;
 
-    // Update caches on document change
-    vscode.workspace.onDidChangeTextDocument(event => {
-      const document = event.document;
-      const uri = document.uri;
-      const latestVersion = this._latestVersion.get(uri);
-
-      // Update cache with latest version
-      if (latestVersion == null || latestVersion < document.version) {
-        this._updateCaches(document);
-      }
-    });
-
     // Clear caches on document close
     vscode.workspace.onDidCloseTextDocument(document => {
       this._parsedCache.delete(document.uri);
-      this._latestVersion.delete(document.uri);
+      this._version.delete(document.uri);
     });
   }
 
   private readonly _parsedCache = new URIMap<TParsed>();
-  private readonly _latestVersion = new URIMap<number>();
+  private readonly _version = new URIMap<number>();
   private readonly _parserFn: (document: vscode.TextDocument) => TParsed;
-
-  /**
-   * Update the caches.
-   */
-  private _updateCaches(document: vscode.TextDocument): void {
-    const uri = document.uri;
-
-    const parsed = this._parserFn(document);
-
-    this._parsedCache.set(uri, parsed);
-    this._latestVersion.set(uri, document.version);
-  }
 
   /**
    * Get parsed document. Updates the cache if the given document version differs
@@ -50,12 +26,15 @@ export class ParsedDocumentCache<TParsed> {
    * @param document The document to parse
    * @returns Parsed document
    */
+  // If the requested version doesn't match the cached version, re-parse.
   get(document: vscode.TextDocument): TParsed {
-    const lastVersion = this._latestVersion.get(document.uri);
+    if (this._version.get(document.uri) !== document.version) {
+      const uri = document.uri;
 
-    // If the requested version doesn't match the cached version, re-parse.
-    if (lastVersion !== document.version) {
-      this._updateCaches(document);
+      const parsed = this._parserFn(document);
+
+      this._parsedCache.set(uri, parsed);
+      this._version.set(uri, document.version);
     }
 
     const parsed = this._parsedCache.get(document.uri);

--- a/src/services/ParseDocumentCache.ts
+++ b/src/services/ParseDocumentCache.ts
@@ -3,7 +3,7 @@ import { URIMap } from './URIMap';
 import { assertDefined } from '../util';
 
 /**
- * Cache for parsed documents. Cached base on document uri + version.
+ * Cache for parsed documents. Cached based on document uri + version.
  */
 export class ParsedDocumentCache<TParsed> {
   constructor(parserFn: (document: vscode.TextDocument) => TParsed) {

--- a/src/services/ParseDocumentCache.ts
+++ b/src/services/ParseDocumentCache.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import { URIMap } from './URIMap';
+import { assertDefined } from '../util';
+
+/**
+ * Cache for parsed documents. Cached base on document uri + version.
+ */
+export class ParsedDocumentCache<TParsed> {
+  constructor(parserFn: (document: vscode.TextDocument) => TParsed) {
+    this._parserFn = parserFn;
+
+    // Update caches on document change
+    vscode.workspace.onDidChangeTextDocument(event => {
+      const document = event.document;
+      const uri = document.uri;
+      const latestVersion = this._latestVersion.get(uri);
+
+      // Update cache with latest version
+      if (latestVersion == null || latestVersion < document.version) {
+        this._updateCaches(document);
+      }
+    });
+
+    // Clear caches on document close
+    vscode.workspace.onDidCloseTextDocument(document => {
+      this._parsedCache.delete(document.uri);
+      this._latestVersion.delete(document.uri);
+    });
+  }
+
+  private readonly _parsedCache = new URIMap<TParsed>();
+  private readonly _latestVersion = new URIMap<number>();
+  private readonly _parserFn: (document: vscode.TextDocument) => TParsed;
+
+  /**
+   * Update the caches.
+   */
+  private _updateCaches(document: vscode.TextDocument): void {
+    const uri = document.uri;
+
+    const parsed = this._parserFn(document);
+
+    this._parsedCache.set(uri, parsed);
+    this._latestVersion.set(uri, document.version);
+  }
+
+  /**
+   * Get parsed document. Updates the cache if the given document version differs
+   * from the last version.
+   * @param document The document to parse
+   * @returns Parsed document
+   */
+  get(document: vscode.TextDocument): TParsed {
+    const lastVersion = this._latestVersion.get(document.uri);
+
+    // If the requested version doesn't match the cached version, re-parse.
+    if (lastVersion !== document.version) {
+      this._updateCaches(document);
+    }
+
+    const parsed = this._parsedCache.get(document.uri);
+
+    assertDefined(parsed, 'codeBlparsedocks');
+
+    return parsed;
+  }
+}

--- a/src/services/ParseDocumentCache.ts
+++ b/src/services/ParseDocumentCache.ts
@@ -22,7 +22,7 @@ export class ParsedDocumentCache<TParsed> {
 
   /**
    * Get parsed document. Updates the cache if the given document version differs
-   * from the last version.
+   * from the cached version.
    * @param document The document to parse
    * @returns Parsed document
    */

--- a/src/services/ParseDocumentCache.ts
+++ b/src/services/ParseDocumentCache.ts
@@ -60,7 +60,7 @@ export class ParsedDocumentCache<TParsed> {
 
     const parsed = this._parsedCache.get(document.uri);
 
-    assertDefined(parsed, 'codeBlparsedocks');
+    assertDefined(parsed, 'parsed');
 
     return parsed;
   }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,6 +5,7 @@ export * from './DhcService';
 export * from './DheService';
 export * from './DisposableBase';
 export * from './PanelService';
+export * from './ParseDocumentCache';
 export * from './PollingService';
 export * from './SecretService';
 export * from './SerializedKeyMap';

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -225,3 +225,15 @@ export interface SessionDetailsResponsePostMessage {
   };
   targetOrigin: IdeURL;
 }
+
+export interface CodeBlock {
+  languageId: string;
+  range: vscode.Range;
+}
+
+export interface SerializedPoint {
+  line: number;
+  character: number;
+}
+
+export type SerializedRange = [start: SerializedPoint, end: SerializedPoint];

--- a/src/util/__snapshots__/documentUtils.spec.ts.snap
+++ b/src/util/__snapshots__/documentUtils.spec.ts.snap
@@ -1,0 +1,45 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parseMarkdownCodeblocks > should parse Deephaven code blocks from a Markdown document 1`] = `
+[
+  {
+    "languageId": "python",
+    "range": Range {
+      "end": Position {
+        "character": 35,
+        "line": 3,
+      },
+      "start": Position {
+        "character": 0,
+        "line": 1,
+      },
+    },
+  },
+  {
+    "languageId": "python",
+    "range": Range {
+      "end": Position {
+        "character": 35,
+        "line": 9,
+      },
+      "start": Position {
+        "character": 0,
+        "line": 7,
+      },
+    },
+  },
+  {
+    "languageId": "groovy",
+    "range": Range {
+      "end": Position {
+        "character": 34,
+        "line": 15,
+      },
+      "start": Position {
+        "character": 0,
+        "line": 15,
+      },
+    },
+  },
+]
+`;

--- a/src/util/__snapshots__/documentUtils.spec.ts.snap
+++ b/src/util/__snapshots__/documentUtils.spec.ts.snap
@@ -41,5 +41,18 @@ exports[`parseMarkdownCodeblocks > should parse Deephaven code blocks from a Mar
       },
     },
   },
+  {
+    "languageId": "groovy",
+    "range": Range {
+      "end": Position {
+        "character": 34,
+        "line": 19,
+      },
+      "start": Position {
+        "character": 0,
+        "line": 19,
+      },
+    },
+  },
 ]
 `;

--- a/src/util/documentUtils.spec.ts
+++ b/src/util/documentUtils.spec.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  deserializeRange,
+  normalizeLanguageId,
+  parseMarkdownCodeblocks,
+  serializeRange,
+} from './documentUtils';
+import { mockDocument } from './testUtils';
+import type { SerializedRange } from '../types';
+
+vi.mock('vscode');
+
+const markdownDocContent = [
+  '```py',
+  'from deephaven import time_table',
+  '',
+  'simple_ticking = time_table("PT2S")',
+  '```',
+  '',
+  '```python',
+  'from deephaven import time_table',
+  '',
+  'simple_ticking = time_table("PT2S")',
+  '```',
+  '',
+  '## Groovy Example',
+  '',
+  '```groovy',
+  'simple_ticking = timeTable("PT2S")',
+  '```',
+].join('\n');
+
+describe('parseMarkdownCodeblocks', () => {
+  it('should parse Deephaven code blocks from a Markdown document', () => {
+    const codeBlocks = parseMarkdownCodeblocks(
+      mockDocument('test.md', 1, markdownDocContent)
+    );
+
+    expect(codeBlocks).toMatchSnapshot();
+  });
+});
+
+describe('normalizeLanguageId', () => {
+  it.each([
+    ['python', 'python'],
+    ['py', 'python'],
+    ['groovy', 'groovy'],
+    ['other', 'other'],
+  ])('should normalize languageId: %s->%s', (given, expected) => {
+    const normalized = normalizeLanguageId(given);
+    expect(normalized).toBe(expected);
+  });
+});
+
+describe('deserializeRange', () => {
+  it('should deserialize a SerializedRange object to a vscode.Range', () => {
+    const serializedRange: SerializedRange = [
+      { line: 1, character: 4 },
+      { line: 3, character: 9 },
+    ];
+
+    const actual = deserializeRange(serializedRange);
+
+    expect(actual).toEqual(
+      new vscode.Range(
+        serializedRange[0].line,
+        serializedRange[0].character,
+        serializedRange[1].line,
+        serializedRange[1].character
+      )
+    );
+  });
+});
+
+describe('serializeRange', () => {
+  it('should serialize a vscode.Range object to a SerializedRange', () => {
+    const range = new vscode.Range(1, 4, 3, 9);
+    const actual = serializeRange(range);
+
+    expect(actual).toEqual([
+      { line: range.start.line, character: range.start.character },
+      { line: range.end.line, character: range.end.character },
+    ]);
+  });
+});

--- a/src/util/documentUtils.ts
+++ b/src/util/documentUtils.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import type { CodeBlock, SerializedRange } from '../types';
+
+const CODE_BLOCK_STARTS = new Set(['```python', '```py', '```groovy']);
+const CODE_BLOCK_END = '```';
+
+/**
+ * Parse code blocks from a Markdown document that can be run by Deephaven.
+ * @param document The document to parse code blocks from.
+ * @returns Code blocks that can be run by Deephaven.
+ */
+export function parseMarkdownCodeblocks(
+  document: vscode.TextDocument
+): CodeBlock[] {
+  const lines = document.getText().split('\n');
+
+  const codeBlocks: CodeBlock[] = [];
+  let startPos: vscode.Position | null = null;
+  let languageId = '';
+
+  // Create ranges for each code block in the document
+  for (let i = 0; i < lines.length; ++i) {
+    const line = lines[i];
+
+    // Start of Deephaven supported code block
+    if (CODE_BLOCK_STARTS.has(line)) {
+      languageId = normalizeLanguageId(line.substring(3));
+      startPos = new vscode.Position(i + 1, 0);
+    }
+    // End of Deephaven code block
+    else if (line === CODE_BLOCK_END && startPos) {
+      codeBlocks.push({
+        languageId,
+        range: new vscode.Range(
+          startPos,
+          new vscode.Position(i - 1, lines[i - 1].length)
+        ),
+      });
+      startPos = null;
+    }
+  }
+
+  return codeBlocks;
+}
+
+/**
+ * Deephaven supports 'python' and 'groovy', but Markdown supports some aliases
+ * such as `py` for `python`. Normalize the language ID to a DH supported one.
+ * @param languageId Language ID to normalize
+ * @returns Normalized language ID
+ */
+export function normalizeLanguageId(languageId: string): string {
+  if (languageId === 'py') {
+    return 'python';
+  }
+
+  return languageId;
+}
+
+/**
+ * Deserialize a given `SerializedRange` object to a `vscode.Range`
+ * @param serializedRange `SerializedRange` object to deserialize
+ * @returns Deserialized `vscode.Range`
+ */
+export function deserializeRange(
+  serializedRange: SerializedRange
+): vscode.Range {
+  return new vscode.Range(
+    serializedRange[0].line,
+    serializedRange[0].character,
+    serializedRange[1].line,
+    serializedRange[1].character
+  );
+}
+
+/**
+ * Serialize a given `vscode.Range` to a `SerializedRange` object.
+ * @param range Range to serialize
+ * @returns `SerializedRange` object
+ */
+export function serializeRange(range: vscode.Range): SerializedRange {
+  return [
+    { line: range.start.line, character: range.start.character },
+    { line: range.end.line, character: range.end.character },
+  ];
+}

--- a/src/util/hoverUtils.spec.ts
+++ b/src/util/hoverUtils.spec.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import {
+  getRunMarkdownCodeBlockMarkdown,
+  getRunSelectedLinesMarkdown,
+} from './hoverUtils';
+import { mockDocument, mockT, mockUri } from './testUtils';
+import type { CodeBlock } from '../types';
+import { RUN_MARKDOWN_CODEBLOCK_CMD, RUN_SELECTION_COMMAND } from '../common';
+
+vi.mock('vscode');
+
+beforeEach(() => {
+  vscode.window.activeTextEditor = undefined;
+});
+
+describe('getRunMarkdownCodeBlockMarkdown', () => {
+  it('should return a MarkdownString with the correct command and arguments', () => {
+    const uri = mockUri('file://testUri');
+
+    const codeBlock: CodeBlock = {
+      languageId: 'testLanguage',
+      range: new vscode.Range(0, 0, 1, 10),
+    };
+
+    const expectedArgs = [
+      uri,
+      'testLanguage',
+      [
+        { line: 0, character: 0 },
+        { line: 1, character: 10 },
+      ],
+    ];
+
+    const expectedCmd = RUN_MARKDOWN_CODEBLOCK_CMD;
+    const expectedQuery = encodeURIComponent(JSON.stringify(expectedArgs));
+    const expected = `[$(run) Run Deephaven Block](command:${expectedCmd}?${expectedQuery})`;
+
+    const actual = getRunMarkdownCodeBlockMarkdown(uri, codeBlock);
+
+    expect(actual.value).toBe(expected);
+  });
+});
+
+describe('getRunSelectedLinesMarkdown', () => {
+  it('should return undefined if there is no active text editor', () => {
+    const position = new vscode.Position(0, 0);
+    const languageId = 'testLanguage';
+
+    const actual = getRunSelectedLinesMarkdown(position, languageId);
+
+    expect(actual).toBeUndefined();
+  });
+
+  it('should return undefined if position is not contained in the selection', () => {
+    vscode.window.activeTextEditor = mockT<vscode.TextEditor>({
+      document: mockDocument('testUri', 1, 'line1\nline2\nline3'),
+      selections: [
+        new vscode.Selection(
+          new vscode.Position(2, 0),
+          new vscode.Position(3, 0)
+        ),
+      ],
+    });
+
+    const position = new vscode.Position(0, 0);
+    const languageId = 'testLanguage';
+
+    const actual = getRunSelectedLinesMarkdown(position, languageId);
+
+    expect(actual).toBeUndefined();
+  });
+
+  it('should return a MarkdownString with the correct command and arguments if position is contained in the selection', () => {
+    const document = mockDocument('testUri', 1, 'line1\nline2\nline3');
+
+    vscode.window.activeTextEditor = mockT<vscode.TextEditor>({
+      document,
+      selections: [
+        new vscode.Selection(
+          new vscode.Position(1, 0),
+          new vscode.Position(2, 0)
+        ),
+      ],
+    });
+
+    const position = new vscode.Position(1, 0);
+    const languageId = 'testLanguage';
+
+    const expectedArgs = [document.uri, 'testLanguage'];
+    const expectedCmd = RUN_SELECTION_COMMAND;
+    const expectedQuery = encodeURIComponent(JSON.stringify(expectedArgs));
+    const expected = `[$(run) Run Deephaven selected lines](command:${expectedCmd}?${expectedQuery})`;
+
+    const actual = getRunSelectedLinesMarkdown(position, languageId);
+
+    expect(actual?.value).toBe(expected);
+  });
+});

--- a/src/util/hoverUtils.ts
+++ b/src/util/hoverUtils.ts
@@ -1,0 +1,75 @@
+import * as vscode from 'vscode';
+import { expandRangeToFullLines } from './selectionUtils';
+import {
+  ICON_ID,
+  RUN_MARKDOWN_CODEBLOCK_CMD,
+  RUN_SELECTION_COMMAND,
+} from '../common';
+import type { CodeBlock } from '../types';
+import { serializeRange } from './documentUtils';
+
+/**
+ * Get markdown string for running a Deephaven code block in a Markdown file.
+ * @param uri Editor uri containing the code block
+ * @param codeBlock Code block to run
+ * @returns Markdown string
+ */
+export function getRunMarkdownCodeBlockMarkdown(
+  uri: vscode.Uri,
+  codeBlock: CodeBlock
+): vscode.MarkdownString {
+  const { languageId, range } = codeBlock;
+
+  const argsStr = JSON.stringify([uri, languageId, serializeRange(range)]);
+  const argsEncoded = encodeURIComponent(argsStr);
+
+  const mdValue = `[$(${ICON_ID.runSelection}) Run Deephaven Block](command:${RUN_MARKDOWN_CODEBLOCK_CMD}?${argsEncoded})`;
+
+  const mdString = new vscode.MarkdownString(mdValue, true);
+
+  mdString.isTrusted = {
+    enabledCommands: [RUN_MARKDOWN_CODEBLOCK_CMD],
+  };
+
+  return mdString;
+}
+
+/**
+ * Get markdown string for running selected lines in a Deephaven file if a
+ * given position overlaps the current selection.
+ * @param position Position to check
+ * @param languageId Language ID of the file
+ * @returns Markdown string
+ */
+export function getRunSelectedLinesMarkdown(
+  position: vscode.Position,
+  languageId: string
+): vscode.MarkdownString | undefined {
+  const editor = vscode.window.activeTextEditor;
+
+  if (editor == null) {
+    return;
+  }
+
+  // Determine if hover is over a selected line
+  const isOverSelection = editor.selections.some(selection =>
+    expandRangeToFullLines(editor.document)(selection).contains(position)
+  );
+
+  if (!isOverSelection) {
+    return;
+  }
+
+  const argsStr = JSON.stringify([editor.document.uri, languageId]);
+  const argsEncoded = encodeURIComponent(argsStr);
+
+  const mdValue = `[$(${ICON_ID.runSelection}) Run Deephaven selected lines](command:${RUN_SELECTION_COMMAND}?${argsEncoded})`;
+
+  const mdString = new vscode.MarkdownString(mdValue, true);
+
+  mdString.isTrusted = {
+    enabledCommands: [RUN_SELECTION_COMMAND],
+  };
+
+  return mdString;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,7 @@
 export * from './assertUtil';
 export * from './dataUtils';
 export * from './documentUtils';
+export * from './hoverUtils';
 export * from './idUtils';
 export * from './isInstanceOf';
 export * from './isDisposable';

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,5 +1,6 @@
 export * from './assertUtil';
 export * from './dataUtils';
+export * from './documentUtils';
 export * from './idUtils';
 export * from './isInstanceOf';
 export * from './isDisposable';

--- a/src/util/testUtils.ts
+++ b/src/util/testUtils.ts
@@ -56,5 +56,6 @@ export function mockT<T>(partial: Partial<T>): T {
 export function mockUri(path: string): vscode.Uri {
   return mockT<vscode.Uri>({
     path,
+    toString: () => path,
   });
 }

--- a/src/util/testUtils.ts
+++ b/src/util/testUtils.ts
@@ -35,10 +35,28 @@ export function matrix<
   );
 }
 
+function lineAt(this: vscode.TextDocument, line: number): vscode.TextLine;
+function lineAt(
+  this: vscode.TextDocument,
+  position: vscode.Position
+): vscode.TextLine;
+function lineAt(
+  this: vscode.TextDocument,
+  lineOrPosition: number | vscode.Position
+): vscode.TextLine {
+  const lineNumber =
+    typeof lineOrPosition === 'number' ? lineOrPosition : lineOrPosition.line;
+
+  return mockT<vscode.TextLine>({
+    lineNumber,
+    text: this.getText().split('\n')[lineNumber] ?? '',
+  });
+}
+
 /** Mock a `vscode.TextDocument` */
 export function mockDocument(
   fileName: string,
-  version: number,
+  version: number = 1,
   content = ''
 ): vscode.TextDocument {
   return mockT<vscode.TextDocument>({
@@ -46,6 +64,7 @@ export function mockDocument(
     uri: mockUri(`file://mock/path/${fileName}`),
     version,
     getText: () => content,
+    lineAt,
   });
 }
 

--- a/src/util/testUtils.ts
+++ b/src/util/testUtils.ts
@@ -38,12 +38,14 @@ export function matrix<
 /** Mock a `vscode.TextDocument` */
 export function mockDocument(
   fileName: string,
-  version: number
+  version: number,
+  content = ''
 ): vscode.TextDocument {
   return mockT<vscode.TextDocument>({
     fileName,
     uri: mockUri(`file://mock/path/${fileName}`),
     version,
+    getText: () => content,
   });
 }
 

--- a/src/util/testUtils.ts
+++ b/src/util/testUtils.ts
@@ -1,3 +1,4 @@
+import type * as vscode from 'vscode';
 export const bitValues = [0, 1] as const;
 export const boolValues = [true, false] as const;
 
@@ -32,4 +33,28 @@ export function matrix<
   return first.flatMap(value =>
     restMatrix.map(values => [value, ...values] as TReturn)
   );
+}
+
+/** Mock a `vscode.TextDocument` */
+export function mockDocument(
+  fileName: string,
+  version: number
+): vscode.TextDocument {
+  return mockT<vscode.TextDocument>({
+    fileName,
+    uri: mockUri(`file://mock/path/${fileName}`),
+    version,
+  });
+}
+
+/** Mock an object providing partial properties */
+export function mockT<T>(partial: Partial<T>): T {
+  return partial as T;
+}
+
+/** Mock a `vscode.Uri` */
+export function mockUri(path: string): vscode.Uri {
+  return mockT<vscode.Uri>({
+    path,
+  });
 }


### PR DESCRIPTION
DH-18882:
* Added support for running `py` code blocks in Markdown files. Previously `python` worked but not the `py` alias
* Added a hover provider that allows running Markdown code blocks. This is useful for longer code blocks where the code lens at the top may be outside of the view. Previously, you had to scroll to get back to the action.
* General cleanup on hover providers

## Testing

### Setup
1. Run a python and a groovy Community server. Configure the VS Code extension to recognize them both. e.g.
   ```jsonc
   "deephaven.coreServers": [
     "http://localhost:10000", // Python server
     "http://localhost:10001", // Groovy server
   ]
   ```
2. In VS code, create  3 files:

   **test.md**
   ````markdown
   ## py example

   ```py
   from deephaven import time_table

   py = time_table("PT2S")
   ```

   ```groovy
   simple_ticking = timeTable("PT2S")
   ```

   ## python example

   ```python
   from deephaven import time_table

   python = time_table("PT2S")
   ```
   ````

   **test.py**
   ```python
   from deephaven import time_table

   t1 = time_table("PT2S")
   ```

   **test.groovy**
   ```groovy
   simple_ticking = timeTable("PT2S")
   ```

### Tests
**test.md**
* Each codeblock should display a "Run Deephaven Block" code lens above it. Clicking it should run code against a DH server
* Hovering over a codeblock should show a "Run Deephaven Block" hover action. Clicking it should run code
* If you select any text in the codeblock and hover over it, it should show a "Run Deephaven selected lines" hover action. Clicking should run only the selection
* These should all work each of the language code blocks

**test.py & test.groovy**
* "Run Deephaven File" code lens should show at top of file
* Selecting code and hovering should show a "Run Deephaven selected lines" action at the end of the hover popup
* Clicking either of these should run the respective code
* Command palette: `> Run Deephaven file` should also run the file
* Command palette: `> Run Deephaven selected lines` should also run the selection