### PR TITLE
fix: Fixed broken editor actions

### DIFF
--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -1,4 +1,28 @@
+import type * as vscode from 'vscode';
 import { EXTENSION_ID } from './constants';
+import type { SerializedRange } from '../types';
+
+/** Arguments passed to `RUN_CODE_COMMAND` handler */
+export type RunCodeCmdArgs = [
+  uri?: vscode.Uri,
+  _arg?: { groupId: number },
+  constrainTo?: 'selection' | vscode.Range[],
+  languageId?: string,
+];
+
+/** Arguments passed to `RUN_MARKDOWN_CODEBLOCK_CMD` handler */
+export type RunMarkdownCodeblockCmdArgs = [
+  uri: vscode.Uri,
+  languageId: string,
+  range: vscode.Range | SerializedRange,
+];
+
+/** Arguments passed to `RUN_SELECTION_COMMAND` handler */
+export type RunSelectionCmdArgs = [
+  uri?: vscode.Uri,
+  _arg?: { groupId: number },
+  languageId?: string,
+];
 
 /**
  * Create a command string prefixed with the extension id.

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -25,6 +25,9 @@ import {
   START_SERVER_CMD,
   STOP_SERVER_CMD,
   VIEW_ID,
+  type RunCodeCmdArgs,
+  type RunMarkdownCodeblockCmdArgs,
+  type RunSelectionCmdArgs,
   type ViewID,
 } from '../common';
 import {
@@ -832,7 +835,9 @@ export class ExtensionController implements IDisposable {
    * @param languageId The languageId of the code block
    * @param range The range of the code block
    */
-  onRunMarkdownCodeblock = async (
+  onRunMarkdownCodeblock: (
+    ...args: RunMarkdownCodeblockCmdArgs
+  ) => Promise<void> = async (
     uri: vscode.Uri,
     languageId: string,
     range: vscode.Range | SerializedRange
@@ -840,7 +845,7 @@ export class ExtensionController implements IDisposable {
     if (isSerializedRange(range)) {
       range = deserializeRange(range);
     }
-    this.onRunCode(uri, [range], languageId);
+    this.onRunCode(uri, undefined, [range], languageId);
   };
 
   /**
@@ -848,6 +853,8 @@ export class ExtensionController implements IDisposable {
    * optional since the RUN_CODE_COMMAND can be called from the CMD palette
    * which doesn't provide parameters.
    * @param uri The uri of the editor
+   * @param _arg Ignored arg that is passed in from `editor/context` and
+   * `editor/title/run` actions.
    * @param constrainTo Optional arg to constrain the code to run.
    * - If 'selection', run only selected code in the editor.
    * - If `undefined`, run all code in the editor.
@@ -856,8 +863,9 @@ export class ExtensionController implements IDisposable {
    * @param languageId Optional languageId to run the code as. If none provided,
    * use the languageId of the editor.
    */
-  onRunCode = async (
+  onRunCode: (...args: RunCodeCmdArgs) => Promise<void> = async (
     uri?: vscode.Uri,
+    _arg?: { groupId: number },
     constrainTo?: 'selection' | vscode.Range[],
     languageId?: string
   ): Promise<void> => {
@@ -890,13 +898,16 @@ export class ExtensionController implements IDisposable {
    * optional since the RUN_SELECTION_COMMAND can be called from the CMD
    * palette which doesn't provide parameters.
    * @param uri The uri of the editor
+   * @param _arg Ignored arg that is passed in from `editor/context` and
+   * `editor/title/run` actions.
    * @param languageId Optional languageId to run the code as
    */
-  onRunSelectedCode = async (
+  onRunSelectedCode: (...args: RunSelectionCmdArgs) => Promise<void> = async (
     uri?: vscode.Uri,
+    _arg?: { groupId: number },
     languageId?: string
   ): Promise<void> => {
-    this.onRunCode(uri, 'selection', languageId);
+    this.onRunCode(uri, undefined, 'selection', languageId);
   };
 
   /**

--- a/src/providers/RunCommandCodeLensProvider.ts
+++ b/src/providers/RunCommandCodeLensProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ICON_ID, RUN_CODE_COMMAND } from '../common';
+import { ICON_ID, RUN_CODE_COMMAND, type RunCodeCmdArgs } from '../common';
 import type { IDisposable } from '../types';
 
 /**
@@ -32,11 +32,13 @@ export class RunCommandCodeLensProvider
     _token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.CodeLens[]> {
     // Always show the run all code lens
+    const args: RunCodeCmdArgs = [document.uri];
+
     const codeLenses: vscode.CodeLens[] = [
       new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), {
         title: `$(${ICON_ID.runAll}) Run Deephaven File`,
         command: RUN_CODE_COMMAND,
-        arguments: [document.uri],
+        arguments: args,
       }),
     ];
 

--- a/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
+++ b/src/providers/RunMarkdownCodeBlockCodeLensProvider.ts
@@ -1,5 +1,9 @@
 import * as vscode from 'vscode';
-import { ICON_ID, RUN_MARKDOWN_CODEBLOCK_CMD } from '../common';
+import {
+  ICON_ID,
+  RUN_MARKDOWN_CODEBLOCK_CMD,
+  type RunMarkdownCodeblockCmdArgs,
+} from '../common';
 import type { CodeBlock, IDisposable } from '../types';
 import type { ParsedDocumentCache } from '../services';
 
@@ -48,16 +52,23 @@ export class RunMarkdownCodeBlockCodeLensProvider
     const codeBlocks = this._codeBlockCache.get(document);
 
     const codeLenses: vscode.CodeLens[] = codeBlocks.map(
-      ({ languageId, range }) =>
-        new vscode.CodeLens(
+      ({ languageId, range }) => {
+        const args: RunMarkdownCodeblockCmdArgs = [
+          document.uri,
+          languageId,
+          range,
+        ];
+
+        return new vscode.CodeLens(
           // Put the code lens on the line before the code block
           new vscode.Range(range.start.line - 1, 0, range.start.line - 1, 0),
           {
             title: `$(${ICON_ID.runSelection}) Run Deephaven Block`,
             command: RUN_MARKDOWN_CODEBLOCK_CMD,
-            arguments: [document.uri, languageId, range],
+            arguments: args,
           }
-        )
+        );
+      }
     );
 
     return codeLenses;

--- a/src/util/hoverUtils.spec.ts
+++ b/src/util/hoverUtils.spec.ts
@@ -87,7 +87,7 @@ describe('getRunSelectedLinesMarkdown', () => {
     const position = new vscode.Position(1, 0);
     const languageId = 'testLanguage';
 
-    const expectedArgs = [document.uri, 'testLanguage'];
+    const expectedArgs = [document.uri, undefined, 'testLanguage'];
     const expectedCmd = RUN_SELECTION_COMMAND;
     const expectedQuery = encodeURIComponent(JSON.stringify(expectedArgs));
     const expected = `[$(run) Run Deephaven selected lines](command:${expectedCmd}?${expectedQuery})`;

--- a/src/util/hoverUtils.ts
+++ b/src/util/hoverUtils.ts
@@ -4,6 +4,8 @@ import {
   ICON_ID,
   RUN_MARKDOWN_CODEBLOCK_CMD,
   RUN_SELECTION_COMMAND,
+  type RunMarkdownCodeblockCmdArgs,
+  type RunSelectionCmdArgs,
 } from '../common';
 import type { CodeBlock } from '../types';
 import { serializeRange } from './documentUtils';
@@ -20,8 +22,13 @@ export function getRunMarkdownCodeBlockMarkdown(
 ): vscode.MarkdownString {
   const { languageId, range } = codeBlock;
 
-  const argsStr = JSON.stringify([uri, languageId, serializeRange(range)]);
-  const argsEncoded = encodeURIComponent(argsStr);
+  const args: RunMarkdownCodeblockCmdArgs = [
+    uri,
+    languageId,
+    serializeRange(range),
+  ];
+
+  const argsEncoded = encodeURIComponent(JSON.stringify(args));
 
   const mdValue = `[$(${ICON_ID.runSelection}) Run Deephaven Block](command:${RUN_MARKDOWN_CODEBLOCK_CMD}?${argsEncoded})`;
 
@@ -60,8 +67,12 @@ export function getRunSelectedLinesMarkdown(
     return;
   }
 
-  const argsStr = JSON.stringify([editor.document.uri, languageId]);
-  const argsEncoded = encodeURIComponent(argsStr);
+  const args: RunSelectionCmdArgs = [
+    editor.document.uri,
+    undefined,
+    languageId,
+  ];
+  const argsEncoded = encodeURIComponent(JSON.stringify(args));
 
   const mdValue = `[$(${ICON_ID.runSelection}) Run Deephaven selected lines](command:${RUN_SELECTION_COMMAND}?${argsEncoded})`;
 


### PR DESCRIPTION
DH-19157: Fixed broken editor actions

I broke the editor toolbar actions as part of https://github.com/deephaven/vscode-deephaven/pull/230 by removing positional args.

- Added unused _args back
- Added some types to better protect against mismatched args in the future

### Testing
Follow test plan on https://github.com/deephaven/vscode-deephaven/pull/230