### PR TITLE
feat: DH-18969: Use python extension api for Pip server

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -34,8 +34,6 @@ export const INTERACTIVE_CONSOLE_QUERY_TYPE = 'InteractiveConsole';
 export const INTERACTIVE_CONSOLE_TEMPORARY_QUEUE_NAME =
   'InteractiveConsoleTemporaryQueue';
 
-export const PYTHON_ENV_WAIT = 1500 as const;
-
 export const PIP_SERVER_STATUS_CHECK_INTERVAL = 3000;
 export const PIP_SERVER_STATUS_CHECK_TIMEOUT = 30000;
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -745,6 +745,7 @@ export class ExtensionController implements IDisposable {
     }
 
     this._serverManager?.updateStatus();
+    this._pipServerController?.syncManagedServers();
   };
 
   /**

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
 import { execFileSync } from 'node:child_process';
-import { getPipServerUrl, Logger, parsePort } from '../util';
+import {
+  getMsPythonExtensionApi,
+  getPipServerUrl,
+  Logger,
+  parsePort,
+} from '../util';
 import type {
   IDisposable,
   Port,
@@ -17,12 +22,6 @@ import { pollUntilTrue } from '../services';
 import path from 'node:path';
 
 const logger = new Logger('PipServerController');
-
-interface PythonExtensionApi {
-  environments: {
-    getActiveEnvironmentPath: () => Promise<{ path: string }>;
-  };
-}
 
 export class PipServerController implements IDisposable {
   constructor(
@@ -128,8 +127,8 @@ export class PipServerController implements IDisposable {
    * @returns The Python interpreter path or `null` if not found.
    */
   getPythonInterpreterPath = async (): Promise<string | null> => {
-    const pythonExtension =
-      vscode.extensions.getExtension<PythonExtensionApi>('ms-python.python');
+    const pythonExtension = getMsPythonExtensionApi();
+
     if (pythonExtension == null) {
       logger.debug('Python extension not found');
       return null;

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { execFileSync } from 'node:child_process';
+import path from 'node:path';
 import {
   getMsPythonExtensionApi,
   getPipServerUrl,
@@ -19,7 +20,6 @@ import {
 } from '../common';
 import { isDhcServerRunning } from '../dh/dhc';
 import { pollUntilTrue } from '../services';
-import path from 'node:path';
 
 const logger = new Logger('PipServerController');
 

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -263,8 +263,6 @@ export class PipServerController implements IDisposable {
       .map(([key, value]) => `${key}=${value}`)
       .join(' ');
 
-    // const venvPath = path.dirname(interpreterPath);
-    // terminal.sendText(`export PATH=${venvPath}:$PATH`);
     terminal.sendText(
       [
         'deephaven server',

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -220,16 +220,21 @@ export class PipServerController implements IDisposable {
       return;
     }
 
+    const interpreterBinDirPath = path.dirname(interpreterPath);
+    const interpreterEnvPath = path.dirname(interpreterBinDirPath);
+
     const terminal = vscode.window.createTerminal({
       name: `Deephaven (${port})`,
       env: {
         /* eslint-disable @typescript-eslint/naming-convention */
         // This allows us to use the `venv` configured by the Python extension
         // without having to wait for the extension to activate it.
-        PATH: path.dirname(interpreterPath),
+        PATH: `${interpreterBinDirPath}:${process.env.PATH}`,
         // Set the workspace root as PYTHONPATH so we can use Python modules in
-        // the workspace
+        // the workspace.
         PYTHONPATH: './',
+        // Venv activation typically sets this, so mimic that here.
+        VIRTUAL_ENV: interpreterEnvPath,
         /* eslint-enable @typescript-eslint/naming-convention */
       },
       isTransient: true,

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { execFile, execFileSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { getPipServerUrl, Logger, parsePort } from '../util';
 import type {
   IDisposable,
@@ -81,7 +81,7 @@ export class PipServerController implements IDisposable {
   };
 
   /**
-   * Start a terminal and attempt an import of `deephaven_server` to check if
+   * Attempt an import of `deephaven_server` to check if
    * servers can be managed from the extension.
    */
   checkPipInstall = async (): Promise<boolean> => {

--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -66,7 +66,6 @@ export class PipServerController implements IDisposable {
   private readonly _serverUrlTerminalMap: Map<Port, vscode.Terminal>;
   private readonly _serverManager: IServerManager;
   private readonly _toaster: IToastService;
-  private _checkPipInstallPromise: Promise<boolean> | null = null;
   private _isPipServerInstalled = false;
   private _reservedPorts: ReadonlySet<Port> = new Set();
 
@@ -86,8 +85,11 @@ export class PipServerController implements IDisposable {
    */
   checkPipInstall = async (): Promise<boolean> => {
     if (!PIP_SERVER_SUPPORTED_PLATFORMS.has(process.platform)) {
+      logger.debug(`Pip server not supported on platform: ${process.platform}`);
       return false;
     }
+
+    logger.debug('Checking pip install');
 
     const pythonInterpreterPath = await this.getPythonInterpreterPath();
     if (pythonInterpreterPath == null) {

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -183,8 +183,6 @@ export class ServerManager implements IServerManager {
 
     // Pip managed local server
     if (serverState.isManaged) {
-      this.updateConnectionCount(serverUrl, 1);
-
       this._secretService.storePsk(serverUrl, serverState.psk);
     }
     // DHE server
@@ -197,6 +195,9 @@ export class ServerManager implements IServerManager {
         return null;
       }
 
+      // The `serverUrl` in this block is for the DHE server but gets set to the
+      // newly created worker url before leaving the block, so we need to update
+      // the connection count while we still have the reference.
       this.updateConnectionCount(serverUrl, 1);
       tagId = uniqueId();
 

--- a/src/util/extensionApiUtils.ts
+++ b/src/util/extensionApiUtils.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+
+const MS_PYTHON_EXTENSION_ID = 'ms-python.python';
+
+/** Microsoft Python extension api */
+interface MsPythonExtensionApi {
+  environments: {
+    getActiveEnvironmentPath: () => Promise<{ path: string }>;
+  };
+}
+
+/** Get Microsoft Python extension api */
+export function getMsPythonExtensionApi():
+  | vscode.Extension<MsPythonExtensionApi>
+  | undefined {
+  return vscode.extensions.getExtension<MsPythonExtensionApi>(
+    MS_PYTHON_EXTENSION_ID
+  );
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,7 @@
 export * from './assertUtil';
 export * from './dataUtils';
 export * from './documentUtils';
+export * from './extensionApiUtils';
 export * from './hoverUtils';
 export * from './idUtils';
 export * from './isInstanceOf';

--- a/src/util/serverUtils.ts
+++ b/src/util/serverUtils.ts
@@ -1,4 +1,3 @@
-import * as path from 'node:path';
 import type {
   ServerState,
   ServerType,
@@ -6,8 +5,7 @@ import type {
   Port,
   ServerConnectionConfig,
 } from '../types';
-import { PIP_SERVER_STATUS_DIRECTORY, SERVER_LANGUAGE_SET } from '../common';
-import { getTempDir } from './tmpUtils';
+import { SERVER_LANGUAGE_SET } from '../common';
 
 /**
  * Get initial server states based on server configs.
@@ -50,18 +48,6 @@ export function getConsoleType(
  */
 export function getPipServerUrl(port: Port): URL {
   return new URL(`http://localhost:${port}`);
-}
-
-/**
- * Get the path to the pip server status file.
- * @returns The path to the pip server status file
- */
-export function getPipStatusFilePath(): string {
-  const dirPath = getTempDir({
-    subDirectory: PIP_SERVER_STATUS_DIRECTORY,
-  });
-  const statusFileName = `status-pip.txt`;
-  return path.join(dirPath, statusFileName);
 }
 
 /**


### PR DESCRIPTION
DH-18969: This addresses a few pip server issues:
- Pip status check no longer requires opening a terminal. This was previously stealing cursor focus and was disruptive
- Pip server no longer has to wait for python extension to activate the venv. Not really noticable but avoids a potential race condition if venv activation were slow
- Fixed a bug where pip server connection count was saying (2) instead of (1)

### Testing
> Note that pip server feature is not supported on Windows
- Open a workspace / folder in VS Code that has a venv that has been activated by VS Code
- DH server tree should show "Managed" node. If not, clicking the refresh button in the panel should cause it to show up.
- Click on "Refresh Server Tree" button in top right of DH panel. Should no longer open a terminal to do the pip server check
- Starting a pip server should still work