### PR TITLE
fix: DH-19168: Handle leading / trailing whitespace in Markdown codeblocks

### DIFF
--- a/src/util/documentUtils.ts
+++ b/src/util/documentUtils.ts
@@ -50,16 +50,16 @@ export function parseMarkdownCodeblocks(
 
   // Create ranges for each code block in the document
   for (let i = 0; i < lines.length; ++i) {
-    const line = lines[i];
+    const trimmedLine = lines[i].trim();
 
     // Start of Deephaven supported code block
-    const parsedLanguageId = CODE_BLOCK_STARTS.exec(line)?.[1] ?? '';
+    const parsedLanguageId = CODE_BLOCK_STARTS.exec(trimmedLine)?.[1] ?? '';
     if (parsedLanguageId !== '') {
       languageId = normalizeLanguageId(parsedLanguageId);
       startPos = new vscode.Position(i + 1, 0);
     }
     // End of Deephaven code block
-    else if (line === CODE_BLOCK_END && startPos) {
+    else if (trimmedLine === CODE_BLOCK_END && startPos) {
       codeBlocks.push({
         languageId,
         range: new vscode.Range(

--- a/src/util/selectionUtils.spec.ts
+++ b/src/util/selectionUtils.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as vscode from 'vscode';
+import {
+  expandRangeToFullLines,
+  getCombinedRangeLinesText,
+  trimIndentation,
+} from './selectionUtils';
+
+vi.mock('vscode');
+
+describe('expandRangeToFullLines', () => {
+  const mockDocument = (lines: string[]): vscode.TextDocument => {
+    return {
+      lineAt: (line: number) => ({ text: lines[line] }),
+    } as unknown as vscode.TextDocument;
+  };
+
+  it.each([
+    {
+      description:
+        'should expand a range that starts and ends in the middle of lines',
+      lines: ['line 1', 'line 2', 'line 3'],
+      range: new vscode.Range(0, 2, 1, 3),
+      expected: new vscode.Range(0, 0, 1, 6),
+    },
+    {
+      description: 'should expand a range that already includes full lines',
+      lines: ['line 1', 'line 2', 'line 3'],
+      range: new vscode.Range(0, 0, 1, 6),
+      expected: new vscode.Range(0, 0, 1, 6),
+    },
+    {
+      description: 'should expand a single-line range to include the full line',
+      lines: ['line 1', 'line 2', 'line 3'],
+      range: new vscode.Range(1, 2, 1, 4),
+      expected: new vscode.Range(1, 0, 1, 6),
+    },
+    {
+      description: 'should handle a range that spans multiple lines',
+      lines: ['line 1', 'line 2', 'line 3', 'line 4'],
+      range: new vscode.Range(1, 2, 3, 4),
+      expected: new vscode.Range(1, 0, 3, 6),
+    },
+    {
+      description: 'should handle an empty range',
+      lines: ['line 1', 'line 2', 'line 3'],
+      range: new vscode.Range(1, 0, 1, 0),
+      expected: new vscode.Range(1, 0, 1, 6),
+    },
+    {
+      description:
+        'should handle a range that starts and ends on the same line',
+      lines: ['line 1', 'line 2', 'line 3'],
+      range: new vscode.Range(2, 1, 2, 3),
+      expected: new vscode.Range(2, 0, 2, 6),
+    },
+  ])('$description', ({ lines, range, expected }) => {
+    const document = mockDocument(lines);
+    const expandRange = expandRangeToFullLines(document);
+    const result = expandRange(range);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe('getCombinedRangeLinesText', () => {
+  const mockDocument = (lines: string[]): vscode.TextDocument => {
+    return {
+      lineAt: (line: number) => ({ text: lines[line] }),
+      getText: (range: vscode.Range) => {
+        const startLine = range.start.line;
+        const endLine = range.end.line;
+        return lines.slice(startLine, endLine + 1).join('\n');
+      },
+    } as unknown as vscode.TextDocument;
+  };
+
+  it.each([
+    {
+      description: 'should return combined text from a single range',
+      lines: ['line 1', 'line 2', 'line 3'],
+      ranges: [new vscode.Range(0, 0, 1, 5)],
+      expected: 'line 1\nline 2',
+    },
+    {
+      description: 'should normalize leading whitespace',
+      lines: ['    line 1', '    line 2', '    line 3'],
+      ranges: [new vscode.Range(0, 0, 2, 5)],
+      expected: 'line 1\nline 2\nline 3',
+    },
+    {
+      description: 'should handle multiple ranges',
+      lines: ['line 1', 'line 2', 'line 3', 'line 4'],
+      ranges: [new vscode.Range(0, 0, 0, 5), new vscode.Range(2, 0, 3, 5)],
+      expected: 'line 1\nline 3\nline 4',
+    },
+    {
+      description: 'should normalize leading whitespace for multiple ranges',
+      lines: ['  line 1', '  line 2', '    line 3', '    line 4'],
+      ranges: [new vscode.Range(0, 0, 0, 5), new vscode.Range(2, 0, 3, 5)],
+      expected: 'line 1\nline 3\nline 4',
+    },
+    {
+      description: 'should handle ranges with no leading whitespace',
+      lines: ['line 1', 'line 2', 'line 3'],
+      ranges: [new vscode.Range(0, 0, 2, 5)],
+      expected: 'line 1\nline 2\nline 3',
+    },
+    {
+      description: 'should handle empty ranges',
+      lines: ['line 1', 'line 2', 'line 3'],
+      ranges: [],
+      expected: '',
+    },
+    {
+      description: 'should expand to full lines',
+      lines: ['line 1', 'line 2', 'line 3'],
+      ranges: [new vscode.Range(0, 2, 1, 2)],
+      expected: 'line 1\nline 2',
+    },
+    {
+      description: 'should only replace exact whitespace',
+      lines: ['    line 1', '\tline 2', '  line 3'],
+      ranges: [new vscode.Range(0, 0, 2, 5)],
+      expected: 'line 1\n\tline 2\n  line 3',
+    },
+  ])('$description', ({ lines, ranges, expected }) => {
+    const document = mockDocument(lines);
+    const result = getCombinedRangeLinesText(document, ranges);
+    expect(result).toBe(expected);
+  });
+});
+
+describe('trimIndentation', () => {
+  it.each([
+    {
+      description: 'should remove leading spaces based on the first line',
+      input: ['    line 1', '    line 2', '    line 3'].join('\n'),
+      expected: ['line 1', 'line 2', 'line 3'].join('\n'),
+    },
+    {
+      description: 'should remove leading tabs based on the first line',
+      input: ['\tline 1', '\t\tline 2', '\t\tline 3'].join('\n'),
+      expected: ['line 1', '\tline 2', '\tline 3'].join('\n'),
+    },
+    {
+      description: 'should handle text with no leading indentation',
+      input: ['line 1', 'line 2', 'line 3'].join('\n'),
+      expected: ['line 1', 'line 2', 'line 3'].join('\n'),
+    },
+    {
+      description: 'should only replace exact indentation',
+      input: ['    line 1', '  line 2', '      line 3'].join('\n'),
+      expected: ['line 1', '  line 2', '      line 3'].join('\n'),
+    },
+    {
+      description: 'should handle single-line text',
+      input: ['    line 1'].join('\n'),
+      expected: ['line 1'].join('\n'),
+    },
+    {
+      description: 'should handle empty input',
+      input: [''].join('\n'),
+      expected: [''].join('\n'),
+    },
+    {
+      description: 'should handle text with only whitespace',
+      input: ['    '].join('\n'),
+      expected: [''].join('\n'),
+    },
+    {
+      description: 'should handle text with leading and trailing whitespace',
+      input: ['    line 1    ', '    line 2    ', '    line 3    '].join('\n'),
+      expected: ['line 1    ', 'line 2    ', 'line 3    '].join('\n'),
+    },
+  ])('$description', ({ input, expected }) => {
+    expect(trimIndentation(input)).toBe(expected);
+  });
+});

--- a/src/util/selectionUtils.ts
+++ b/src/util/selectionUtils.ts
@@ -13,6 +13,7 @@ export function getCombinedRangeLinesText(
   return sortRanges(ranges)
     .map(expandRangeToFullLines(document))
     .map(range => document.getText(range))
+    .map(trimIndentation)
     .join('\n');
 }
 
@@ -36,6 +37,29 @@ export function expandRangeToFullLines(document: vscode.TextDocument) {
       document.lineAt(range.end.line).text.length
     );
   };
+}
+
+/**
+ * Trim leading indentation for a block of text based on the leading space of
+ * the first line.
+ * @param text The text to trim.
+ * @returns Text with leading indentation removed.
+ */
+export function trimIndentation(text: string): string {
+  const leadingWhitespace = text.match(/^\s*/)?.[0] ?? '';
+
+  if (leadingWhitespace.length === 0) {
+    return text;
+  }
+
+  // If first line has leading whitespace, remove it from all lines to normalize
+  // indentation. This is mostly useful for Markdown code blocks that can be
+  // indented, but normalizing to the indentation level of the first line in the
+  // range should be safe for other cases as well.
+  return text
+    .split('\n')
+    .map(line => line.replace(new RegExp(`^${leadingWhitespace}`), ''))
+    .join('\n');
 }
 
 /**


### PR DESCRIPTION
DH-19168
- Identify Markdown DH code fences that have leading / trailing whitespace
- Remove leading indentation when running code blocks