### PR TITLE
feat: DH-20578: Groovy remote file source

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   e2e:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-e2e

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -128,8 +128,20 @@ export class DiagnosticCollection
   }
 }
 
-export class EventEmitter {
-  fire = vi.fn().mockName('fire');
+export class EventEmitter<T> {
+  listeners = new Set<(...args: any[]) => void>();
+  event = (listener: (e: T) => any) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+  fire = vi
+    .fn()
+    .mockName('fire')
+    .mockImplementation((event: T) => {
+      this.listeners.forEach(listener => listener(event));
+    });
 }
 
 export class MarkdownString {

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -306,6 +306,7 @@ export const workspace = {
     .fn()
     .mockName('createFileSystemWatcher')
     .mockReturnValue({
+      onDidChange: vi.fn().mockName('onDidChange'),
       onDidCreate: vi.fn().mockName('onDidCreate'),
       onDidDelete: vi.fn().mockName('onDidDelete'),
     }),

--- a/e2e-testing/src/mocharc.ts
+++ b/e2e-testing/src/mocharc.ts
@@ -1,8 +1,8 @@
 import { MochaOptions } from 'vscode-extension-tester';
 
 const options: MochaOptions = {
-  timeout: 60000,
-  slow: 40000,
+  timeout: 30000,
+  slow: 20000,
   reporter: 'mocha-multi-reporters',
   reporterOptions: {
     reporterEnabled: 'spec, mocha-ctrf-json-reporter',

--- a/e2e-testing/src/mocharc.ts
+++ b/e2e-testing/src/mocharc.ts
@@ -1,8 +1,8 @@
 import { MochaOptions } from 'vscode-extension-tester';
 
 const options: MochaOptions = {
-  timeout: 30000,
-  slow: 20000,
+  timeout: 60000,
+  slow: 40000,
   reporter: 'mocha-multi-reporters',
   reporterOptions: {
     reporterEnabled: 'spec, mocha-ctrf-json-reporter',

--- a/e2e-testing/src/runner.mts
+++ b/e2e-testing/src/runner.mts
@@ -45,7 +45,7 @@ const exTester = new ExTester(
   extensionsPath
 );
 
-const vscodeVersion = '1.114.0';
+const vscodeVersion = 'latest';
 
 if (isSetup) {
   console.log('Downloading VS Code...');

--- a/e2e-testing/src/runner.mts
+++ b/e2e-testing/src/runner.mts
@@ -45,7 +45,7 @@ const exTester = new ExTester(
   extensionsPath
 );
 
-const vscodeVersion = '1.115.0';
+const vscodeVersion = '1.114.0';
 
 if (isSetup) {
   console.log('Downloading VS Code...');

--- a/e2e-testing/src/runner.mts
+++ b/e2e-testing/src/runner.mts
@@ -45,7 +45,7 @@ const exTester = new ExTester(
   extensionsPath
 );
 
-const vscodeVersion = 'latest';
+const vscodeVersion = '1.115.0';
 
 if (isSetup) {
   console.log('Downloading VS Code...');

--- a/e2e-testing/src/runner.mts
+++ b/e2e-testing/src/runner.mts
@@ -10,7 +10,21 @@ const isSetup = args.includes('--setup');
 const __dirname = import.meta.dirname;
 const e2eTestingPath = path.resolve(__dirname, '..');
 
-const storagePath = path.join(e2eTestingPath, '.resources');
+const storagePath =
+  process.env.TEST_RESOURCES ?? path.join(e2eTestingPath, '.resources');
+
+// Warn about Unix socket path length constraints
+// Electron/VS Code creates an IPC socket under storagePath/settings/<version>-main.sock
+// Unix platforms (macOS, Linux) have varying socket path length limits.
+// Storage path length > 70 is conservative to avoid constraints on different OSs.
+if (process.platform !== 'win32' && storagePath.length > 70) {
+  console.warn(
+    `\nWARNING: Storage path length (${storagePath.length} chars) may hit socket path length ` +
+      `constraints on some OSs.\n` +
+      `  Path: ${storagePath}\n` +
+      `If e2e tests fail with connection errors, try setting a shorter TEST_RESOURCES path.\n`
+  );
+}
 const extensionsPath = path.join(e2eTestingPath, '.test-extensions');
 const testFilesPattern = path.join(e2eTestingPath, 'out', '**', '*.spec.js');
 const mochaConfig = path.join(

--- a/package.json
+++ b/package.json
@@ -326,13 +326,23 @@
         "icon": "$(close)"
       },
       {
-        "command": "vscode-deephaven.addRemoteFileSource",
-        "title": "Add to Deephaven remote file sources",
+        "command": "vscode-deephaven.addGroovyRemoteFileSource",
+        "title": "Add to Deephaven Groovy remote file sources",
         "icon": "$(add)"
       },
       {
-        "command": "vscode-deephaven.removeRemoteFileSource",
-        "title": "Remove from Deephaven remote file sources",
+        "command": "vscode-deephaven.removeGroovyRemoteFileSource",
+        "title": "Remove from Deephaven Groovy remote file sources",
+        "icon": "$(remove)"
+      },
+      {
+        "command": "vscode-deephaven.addPythonRemoteFileSource",
+        "title": "Add to Deephaven Python remote file sources",
+        "icon": "$(add)"
+      },
+      {
+        "command": "vscode-deephaven.removePythonRemoteFileSource",
+        "title": "Remove from Deephaven Python remote file sources",
         "icon": "$(remove)"
       },
       {
@@ -865,11 +875,19 @@
           "when": "false"
         },
         {
-          "command": "vscode-deephaven.addRemoteFileSource",
+          "command": "vscode-deephaven.addGroovyRemoteFileSource",
           "when": "false"
         },
         {
-          "command": "vscode-deephaven.removeRemoteFileSource",
+          "command": "vscode-deephaven.removeGroovyRemoteFileSource",
+          "when": "false"
+        },
+        {
+          "command": "vscode-deephaven.addPythonRemoteFileSource",
+          "when": "false"
+        },
+        {
+          "command": "vscode-deephaven.removePythonRemoteFileSource",
           "when": "false"
         },
         {
@@ -903,12 +921,22 @@
       ],
       "explorer/context": [
         {
-          "command": "vscode-deephaven.addRemoteFileSource",
+          "command": "vscode-deephaven.addGroovyRemoteFileSource",
           "group": "deephaven",
           "when": "explorerResourceIsFolder"
         },
         {
-          "command": "vscode-deephaven.removeRemoteFileSource",
+          "command": "vscode-deephaven.removeGroovyRemoteFileSource",
+          "group": "deephaven",
+          "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "vscode-deephaven.addPythonRemoteFileSource",
+          "group": "deephaven",
+          "when": "explorerResourceIsFolder"
+        },
+        {
+          "command": "vscode-deephaven.removePythonRemoteFileSource",
           "group": "deephaven",
           "when": "explorerResourceIsFolder"
         }
@@ -999,13 +1027,23 @@
           "group": "inline@2"
         },
         {
-          "command": "vscode-deephaven.addRemoteFileSource",
-          "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem == canAddRemoteFileSource",
+          "command": "vscode-deephaven.addGroovyRemoteFileSource",
+          "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem == canAddRemoteFileSource:groovy",
           "group": "inline"
         },
         {
-          "command": "vscode-deephaven.removeRemoteFileSource",
-          "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem == canRemoveRemoteFileSource",
+          "command": "vscode-deephaven.removeGroovyRemoteFileSource",
+          "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem == canRemoveRemoteFileSource:groovy",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-deephaven.addPythonRemoteFileSource",
+          "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem == canAddRemoteFileSource:python",
+          "group": "inline"
+        },
+        {
+          "command": "vscode-deephaven.removePythonRemoteFileSource",
+          "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem == canRemoveRemoteFileSource:python",
           "group": "inline"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -349,6 +349,11 @@
         "command": "vscode-deephaven.deleteVariable",
         "title": "Delete Deephaven Variable",
         "icon": "$(trash)"
+      },
+      {
+        "command": "vscode-deephaven.revealInExplorer",
+        "title": "Reveal in Explorer",
+        "icon": "$(eye)"
       }
     ],
     "icons": {
@@ -893,6 +898,10 @@
         {
           "command": "vscode-deephaven.deleteVariable",
           "when": "false"
+        },
+        {
+          "command": "vscode-deephaven.revealInExplorer",
+          "when": "false"
         }
       ],
       "editor/context": [
@@ -1045,6 +1054,10 @@
           "command": "vscode-deephaven.removePythonRemoteFileSource",
           "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem == canRemoveRemoteFileSource:python",
           "group": "inline"
+        },
+        {
+          "command": "vscode-deephaven.revealInExplorer",
+          "when": "view == vscode-deephaven.view.remoteImportSourceTree && viewItem != root && viewItem != languageRoot"
         }
       ]
     },

--- a/skills/deephaven-vscode-using/SKILL.md
+++ b/skills/deephaven-vscode-using/SKILL.md
@@ -76,11 +76,13 @@ Community servers always support panel URLs. Enterprise servers require Grizzly+
 
 ### Remote File Sources
 
-Enable server to fetch source files during execution:
+Configure which workspace folders the server fetches source files from during execution:
 
 - Add folder URIs as remote sources (`addRemoteFileSources`)
 - List current sources (`listRemoteFileSources`)
 - Remove sources when done (`removeRemoteFileSources`)
+
+If an import error occurs, follow the hint in the tool response — it will specify how to resolve it.
 
 ### Troubleshooting
 
@@ -113,6 +115,10 @@ Server connections are managed through MCP tools. Use `listConnections`, `listSe
 ### Tool Availability
 
 All MCP tools are available when the MCP server is enabled via `deephaven.mcp.enabled` setting. If tools aren't available, ensure MCP is enabled (see Troubleshooting).
+
+### Tool Response Hints
+
+Tool responses may include hints that guide next steps. Consider them before deciding how to proceed.
 
 ### Variable Management
 

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -12,6 +12,7 @@ import type {
 
 /** Arguments passed to `ADD_REMOTE_FILE_SOURCE_CMD` handler */
 export type AddRemoteFileSourceCmdArgs = [
+  languageId: 'groovy' | 'python',
   folderElementOrUri:
     | RemoteImportSourceTreeFolderElement
     | vscode.Uri
@@ -39,6 +40,7 @@ export type RefreshVariablePanelsCmdArgs = [
 
 /** Arguments passed to `REMOVE_REMOTE_FILE_SOURCE_CMD` handler */
 export type RemoveRemoteFileSourceCmdArgs = [
+  languageId: 'groovy' | 'python',
   folderElementOrUri:
     | RemoteImportSourceTreeFolderElement
     | vscode.Uri
@@ -76,6 +78,19 @@ export type RunSelectionCmdArgs = [
 function cmd<T extends string>(cmd: T): `${typeof EXTENSION_ID}.${T}` {
   return `${EXTENSION_ID}.${cmd}`;
 }
+
+export const ADD_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
+  'addGroovyRemoteFileSource'
+);
+export const REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
+  'removeGroovyRemoteFileSource'
+);
+export const ADD_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
+  'addPythonRemoteFileSource'
+);
+export const REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
+  'removePythonRemoteFileSource'
+);
 
 export const CLEAR_SECRET_STORAGE_CMD = cmd('clearSecretStorage');
 export const CLOSE_CREATE_QUERY_VIEW_CMD = cmd('view.createQuery.close');

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -79,19 +79,6 @@ function cmd<T extends string>(cmd: T): `${typeof EXTENSION_ID}.${T}` {
   return `${EXTENSION_ID}.${cmd}`;
 }
 
-export const ADD_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
-  'addGroovyRemoteFileSource'
-);
-export const REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
-  'removeGroovyRemoteFileSource'
-);
-export const ADD_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
-  'addPythonRemoteFileSource'
-);
-export const REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
-  'removePythonRemoteFileSource'
-);
-
 export const CLEAR_SECRET_STORAGE_CMD = cmd('clearSecretStorage');
 export const CLOSE_CREATE_QUERY_VIEW_CMD = cmd('view.createQuery.close');
 export const CONNECT_TO_SERVER_CMD = cmd('connectToServer');
@@ -133,6 +120,20 @@ export const STOP_SERVER_CMD = cmd('stopServer');
 export const TOGGLE_MCP_CMD = cmd('toggleMcp');
 export const ADD_REMOTE_FILE_SOURCE_CMD = cmd('addRemoteFileSource');
 export const REMOVE_REMOTE_FILE_SOURCE_CMD = cmd('removeRemoteFileSource');
+export const REVEAL_IN_EXPLORER_CMD = cmd('revealInExplorer');
+
+export const ADD_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
+  'addGroovyRemoteFileSource'
+);
+export const REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
+  'removeGroovyRemoteFileSource'
+);
+export const ADD_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
+  'addPythonRemoteFileSource'
+);
+export const REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
+  'removePythonRemoteFileSource'
+);
 
 /**
  * Execute the add remote file source command with type safety.

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -10,7 +10,7 @@ import type {
   WorkerURL,
 } from '../types';
 
-/** Arguments passed to `ADD_REMOTE_FILE_SOURCE_CMD` handler */
+/** Arguments passed to `ADD_GROOVY_REMOTE_FILE_SOURCE_CMD` and `ADD_PYTHON_REMOTE_FILE_SOURCE_CMD` handlers */
 export type AddRemoteFileSourceCmdArgs = [
   languageId: 'groovy' | 'python',
   folderElementOrUri:
@@ -38,7 +38,7 @@ export type RefreshVariablePanelsCmdArgs = [
   variables: NonEmptyArray<VariableDefintion>,
 ];
 
-/** Arguments passed to `REMOVE_REMOTE_FILE_SOURCE_CMD` handler */
+/** Arguments passed to `REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD` and `REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD` handlers */
 export type RemoveRemoteFileSourceCmdArgs = [
   languageId: 'groovy' | 'python',
   folderElementOrUri:

--- a/src/common/commands.ts
+++ b/src/common/commands.ts
@@ -79,6 +79,12 @@ function cmd<T extends string>(cmd: T): `${typeof EXTENSION_ID}.${T}` {
   return `${EXTENSION_ID}.${cmd}`;
 }
 
+export const ADD_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
+  'addGroovyRemoteFileSource'
+);
+export const ADD_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
+  'addPythonRemoteFileSource'
+);
 export const CLEAR_SECRET_STORAGE_CMD = cmd('clearSecretStorage');
 export const CLOSE_CREATE_QUERY_VIEW_CMD = cmd('view.createQuery.close');
 export const CONNECT_TO_SERVER_CMD = cmd('connectToServer');
@@ -108,6 +114,13 @@ export const REFRESH_SERVER_CONNECTION_TREE_CMD = cmd(
 );
 export const REFRESH_PANELS_TREE_CMD = cmd('refreshPanelsTree');
 export const REFRESH_VARIABLE_PANELS_CMD = cmd('refreshVariablePanels');
+export const REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
+  'removeGroovyRemoteFileSource'
+);
+export const REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
+  'removePythonRemoteFileSource'
+);
+export const REVEAL_IN_EXPLORER_CMD = cmd('revealInExplorer');
 export const RUN_CODE_COMMAND = cmd('runCode');
 export const RUN_MARKDOWN_CODEBLOCK_CMD = cmd('runMarkdownCodeBlock');
 export const RUN_SELECTION_COMMAND = cmd('runSelection');
@@ -118,31 +131,22 @@ export const SHOW_MCP_QUICK_PICK_CMD = cmd('showMcpQuickPick');
 export const START_SERVER_CMD = cmd('startServer');
 export const STOP_SERVER_CMD = cmd('stopServer');
 export const TOGGLE_MCP_CMD = cmd('toggleMcp');
-export const ADD_REMOTE_FILE_SOURCE_CMD = cmd('addRemoteFileSource');
-export const REMOVE_REMOTE_FILE_SOURCE_CMD = cmd('removeRemoteFileSource');
-export const REVEAL_IN_EXPLORER_CMD = cmd('revealInExplorer');
-
-export const ADD_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
-  'addGroovyRemoteFileSource'
-);
-export const REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD = cmd(
-  'removeGroovyRemoteFileSource'
-);
-export const ADD_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
-  'addPythonRemoteFileSource'
-);
-export const REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD = cmd(
-  'removePythonRemoteFileSource'
-);
 
 /**
  * Execute the add remote file source command with type safety.
- * @param uris The folder URIs to add as remote file sources.
+ * @param args The arguments for adding the remote file source, including the language ID and folder URI(s).
+ * @returns A Thenable that resolves when the command has been executed.
  */
 export function execAddRemoteFileSource(
   ...args: AddRemoteFileSourceCmdArgs
 ): Thenable<void> {
-  return vscode.commands.executeCommand(ADD_REMOTE_FILE_SOURCE_CMD, ...args);
+  const [languageId, ...rest] = args;
+  return vscode.commands.executeCommand(
+    languageId === 'groovy'
+      ? ADD_GROOVY_REMOTE_FILE_SOURCE_CMD
+      : ADD_PYTHON_REMOTE_FILE_SOURCE_CMD,
+    ...rest
+  );
 }
 
 /**
@@ -169,12 +173,21 @@ export function execOpenVariablePanels(
 
 /**
  * Execute the remove remote file source command with type safety.
- * @param uris The folder URIs to remove as remote file sources.
+ * @param args The arguments for removing the remote file source, including the
+ * language ID and folder URI(s).
+ * @returns A Thenable that resolves when the command has been executed.
  */
 export function execRemoveRemoteFileSource(
   ...args: RemoveRemoteFileSourceCmdArgs
 ): Thenable<void> {
-  return vscode.commands.executeCommand(REMOVE_REMOTE_FILE_SOURCE_CMD, ...args);
+  const [languageId, ...rest] = args;
+
+  return vscode.commands.executeCommand(
+    languageId === 'groovy'
+      ? REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD
+      : REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD,
+    ...rest
+  );
 }
 
 /**

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -123,6 +123,8 @@ export const ICON_ID = {
   connected: 'vm-connect',
   connecting: 'sync~spin',
   disconnected: 'plug',
+  groovy: 'coffee',
+  python: 'dh-python',
   runAll: 'run-all',
   runSelection: 'run',
   runningCode: 'sync~spin',

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -44,6 +44,8 @@ import {
   createExtensionInfo,
   deserializeRange,
   getEditorForUri,
+  getGroovyTopLevelPackageName,
+  getPythonTopLevelModuleFullname,
   getTempDir,
   isInstanceOf,
   isSerializedRange,
@@ -122,6 +124,8 @@ import type {
   RemoteImportSourceTreeView,
   VariableDefintion,
   RemoteImportSourceTreeElement,
+  GroovyPackageName,
+  PythonModuleFullname,
 } from '../types';
 import { ServerConnectionTreeDragAndDropController } from './ServerConnectionTreeDragAndDropController';
 import { ConnectionController } from './ConnectionController';
@@ -192,8 +196,9 @@ export class ExtensionController implements IDisposable {
   private _dhcServiceFactory: IDhcServiceFactory | null = null;
   private _dheJsApiCache: IAsyncCacheService<URL, DheType> | null = null;
   private _dheServiceFactory: IDheServiceFactory | null = null;
-  private _groovyWorkspace: FilteredWorkspace | null = null;
-  private _pythonWorkspace: FilteredWorkspace | null = null;
+  private _groovyWorkspace: FilteredWorkspace<GroovyPackageName> | null = null;
+  private _pythonWorkspace: FilteredWorkspace<PythonModuleFullname> | null =
+    null;
   private _remoteFileSourceService: RemoteFileSourceService | null = null;
   private _secretService: ISecretService | null = null;
   private _serverManager: IServerManager | null = null;
@@ -381,6 +386,7 @@ export class ExtensionController implements IDisposable {
 
     this._groovyWorkspace = new FilteredWorkspace(
       GROOVY_FILE_PATTERN,
+      getGroovyTopLevelPackageName,
       GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES,
       this._toaster
     );
@@ -388,6 +394,7 @@ export class ExtensionController implements IDisposable {
 
     this._pythonWorkspace = new FilteredWorkspace(
       PYTHON_FILE_PATTERN,
+      getPythonTopLevelModuleFullname,
       PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
       this._toaster
     );

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -84,6 +84,9 @@ import {
   PYTHON_FILE_PATTERN,
   SecretService,
   ServerManager,
+  PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
+  GROOVY_FILE_PATTERN,
+  GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES,
 } from '../services';
 import type {
   IDisposable,
@@ -189,6 +192,7 @@ export class ExtensionController implements IDisposable {
   private _dhcServiceFactory: IDhcServiceFactory | null = null;
   private _dheJsApiCache: IAsyncCacheService<URL, DheType> | null = null;
   private _dheServiceFactory: IDheServiceFactory | null = null;
+  private _groovyWorkspace: FilteredWorkspace | null = null;
   private _pythonWorkspace: FilteredWorkspace | null = null;
   private _remoteFileSourceService: RemoteFileSourceService | null = null;
   private _secretService: ISecretService | null = null;
@@ -374,13 +378,23 @@ export class ExtensionController implements IDisposable {
    */
   initializeRemoteFileSourcing = (): void => {
     assertDefined(this._toaster, 'toaster');
+
+    this._groovyWorkspace = new FilteredWorkspace(
+      GROOVY_FILE_PATTERN,
+      GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES,
+      this._toaster
+    );
+    this._context.subscriptions.push(this._groovyWorkspace);
+
     this._pythonWorkspace = new FilteredWorkspace(
       PYTHON_FILE_PATTERN,
+      PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
       this._toaster
     );
     this._context.subscriptions.push(this._pythonWorkspace);
 
     this._remoteFileSourceService = new RemoteFileSourceService(
+      this._groovyWorkspace,
       this._pythonWorkspace
     );
     this._context.subscriptions.push(this._remoteFileSourceService);

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -486,9 +486,7 @@ export class ExtensionController implements IDisposable {
     // Clear diagnostics on save
     vscode.workspace.onDidSaveTextDocument(
       doc => {
-        if (doc.languageId === 'groovy') {
-          this._groovyDiagnostics?.set(doc.uri, []);
-        }
+        this._groovyDiagnostics?.set(doc.uri, []);
         this._pythonDiagnostics?.set(doc.uri, []);
       },
       null,

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -27,6 +27,7 @@ import {
   REFRESH_SERVER_TREE_CMD,
   REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD,
   REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD,
+  REVEAL_IN_EXPLORER_CMD,
   RUN_CODE_COMMAND,
   RUN_MARKDOWN_CODEBLOCK_CMD,
   RUN_SELECTION_COMMAND,
@@ -769,6 +770,9 @@ export class ExtensionController implements IDisposable {
   initializeCommands = (): void => {
     assertDefined(this._connectionController, 'connectionController');
 
+    /** Reveal in Explorer */
+    this.registerCommand(REVEAL_IN_EXPLORER_CMD, this.onRevealInExplorer);
+
     /** Clear secret storage */
     this.registerCommand(CLEAR_SECRET_STORAGE_CMD, this.onClearSecretStorage);
 
@@ -1197,6 +1201,22 @@ export class ExtensionController implements IDisposable {
   onRefreshServerStatus = async (): Promise<void> => {
     await this._pipServerController?.syncManagedServers({ forceCheck: true });
     await this._serverManager?.updateStatus();
+  };
+
+  onRevealInExplorer = async (
+    uriOrHasUri: vscode.Uri | { uri: vscode.Uri } | undefined
+  ): Promise<void> => {
+    // Sometimes view/item/context commands pass undefined instead of a value.
+    // Just ignore. microsoft/vscode#283655
+    if (uriOrHasUri == null) {
+      logger.debug('onRevealInExplorer', 'uri is undefined');
+      return;
+    }
+
+    const uri =
+      uriOrHasUri instanceof vscode.Uri ? uriOrHasUri : uriOrHasUri.uri;
+
+    await vscode.commands.executeCommand('revealInExplorer', uri);
   };
 
   /**

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -1036,7 +1036,9 @@ export class ExtensionController implements IDisposable {
 
     assertDefined(workspace, `${languageId}Workspace`);
 
-    await workspace.refresh();
+    // supress notifications since `markFolder` will raise notifications.
+    // this avoids sending data to the server that will change anyway
+    await workspace.refresh(true);
 
     const uris = Array.isArray(folderElementOrUri)
       ? folderElementOrUri
@@ -1070,7 +1072,9 @@ export class ExtensionController implements IDisposable {
 
     assertDefined(workspace, `${languageId}Workspace`);
 
-    await workspace.refresh();
+    // supress notifications since `unmarkFolder` will raise notifications.
+    // this avoids sending data to the server that will change anyway
+    await workspace.refresh(true);
 
     const uris = Array.isArray(folderElementOrUri)
       ? folderElementOrUri

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -12,7 +12,8 @@ import {
 import { NodeHttp2gRPCTransport } from '@deephaven/jsapi-nodejs';
 import { McpController } from './McpController';
 import {
-  ADD_REMOTE_FILE_SOURCE_CMD,
+  ADD_GROOVY_REMOTE_FILE_SOURCE_CMD,
+  ADD_PYTHON_REMOTE_FILE_SOURCE_CMD,
   CLEAR_SECRET_STORAGE_CMD,
   ConnectionNotFoundError,
   CREATE_NEW_TEXT_DOC_CMD,
@@ -24,7 +25,8 @@ import {
   REFRESH_REMOTE_IMPORT_SOURCE_TREE_CMD,
   REFRESH_SERVER_CONNECTION_TREE_CMD,
   REFRESH_SERVER_TREE_CMD,
-  REMOVE_REMOTE_FILE_SOURCE_CMD,
+  REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD,
+  REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD,
   RUN_CODE_COMMAND,
   RUN_MARKDOWN_CODEBLOCK_CMD,
   RUN_SELECTION_COMMAND,
@@ -386,6 +388,7 @@ export class ExtensionController implements IDisposable {
 
     this._groovyWorkspace = new FilteredWorkspace(
       GROOVY_FILE_PATTERN,
+      'groovy',
       getGroovyTopLevelPackageName,
       GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES,
       this._toaster
@@ -394,6 +397,7 @@ export class ExtensionController implements IDisposable {
 
     this._pythonWorkspace = new FilteredWorkspace(
       PYTHON_FILE_PATTERN,
+      'python',
       getPythonTopLevelModuleFullname,
       PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
       this._toaster
@@ -813,12 +817,20 @@ export class ExtensionController implements IDisposable {
       this.onRefreshRemoteImportSourceTree
     );
     this.registerCommand(
-      ADD_REMOTE_FILE_SOURCE_CMD,
-      this.onAddRemoteFileSource
+      ADD_GROOVY_REMOTE_FILE_SOURCE_CMD,
+      this.onAddRemoteFileSource.bind(this, 'groovy')
     );
     this.registerCommand(
-      REMOVE_REMOTE_FILE_SOURCE_CMD,
-      this.onRemoveRemoteFileSource
+      REMOVE_GROOVY_REMOTE_FILE_SOURCE_CMD,
+      this.onRemoveRemoteFileSource.bind(this, 'groovy')
+    );
+    this.registerCommand(
+      ADD_PYTHON_REMOTE_FILE_SOURCE_CMD,
+      this.onAddRemoteFileSource.bind(this, 'python')
+    );
+    this.registerCommand(
+      REMOVE_PYTHON_REMOTE_FILE_SOURCE_CMD,
+      this.onRemoveRemoteFileSource.bind(this, 'python')
     );
 
     /** Search connections */
@@ -849,6 +861,7 @@ export class ExtensionController implements IDisposable {
    */
   initializeWebViews = (): void => {
     assertDefined(this._dheClientCache, 'dheClientCache');
+    assertDefined(this._groovyWorkspace, 'groovyWorkspace');
     assertDefined(this._pythonWorkspace, 'pythonWorkspace');
     assertDefined(this._panelService, 'panelService');
     assertDefined(this._serverManager, 'serverManager');
@@ -910,6 +923,7 @@ export class ExtensionController implements IDisposable {
 
     // Remote import source tree
     this._remoteImportSourceTreeProvider = new RemoteImportSourceTreeProvider(
+      this._groovyWorkspace,
       this._pythonWorkspace
     );
     this._remoteImportSourceTreeView =
@@ -1004,18 +1018,25 @@ export class ExtensionController implements IDisposable {
   onAddRemoteFileSource = async (
     ...args: AddRemoteFileSourceCmdArgs
   ): Promise<void> => {
-    const [folderElementOrUri] = args;
+    const [languageId, folderElementOrUri] = args;
 
     // Sometimes view/item/context commands pass undefined instead of a value.
     // Just ignore. microsoft/vscode#283655
     if (folderElementOrUri == null) {
-      logger.debug('onAddRemoteFileSource', 'folderElementOrUri is undefined');
+      logger.debug(
+        'onAddRemoteFileSource',
+        languageId,
+        'folderElementOrUri is undefined'
+      );
       return;
     }
 
-    assertDefined(this._pythonWorkspace, 'pythonWorkspace');
+    const workspace =
+      languageId === 'groovy' ? this._groovyWorkspace : this._pythonWorkspace;
 
-    await this._pythonWorkspace.refresh();
+    assertDefined(workspace, `${languageId}Workspace`);
+
+    await workspace.refresh();
 
     const uris = Array.isArray(folderElementOrUri)
       ? folderElementOrUri
@@ -1024,28 +1045,32 @@ export class ExtensionController implements IDisposable {
         : [folderElementOrUri.uri];
 
     for (const uri of uris) {
-      this._pythonWorkspace.markFolder(uri);
+      workspace.markFolder(uri);
     }
   };
 
   onRemoveRemoteFileSource = async (
     ...args: RemoveRemoteFileSourceCmdArgs
   ): Promise<void> => {
-    const [folderElementOrUri] = args;
+    const [languageId, folderElementOrUri] = args;
 
     // Sometimes view/item/context commands pass undefined instead of a value.
     // Just ignore. microsoft/vscode#283655
     if (folderElementOrUri == null) {
       logger.debug(
         'onRemoveRemoteFileSource',
+        languageId,
         'folderElementOrUri is undefined'
       );
       return;
     }
 
-    assertDefined(this._pythonWorkspace, 'pythonWorkspace');
+    const workspace =
+      languageId === 'groovy' ? this._groovyWorkspace : this._pythonWorkspace;
 
-    await this._pythonWorkspace.refresh();
+    assertDefined(workspace, `${languageId}Workspace`);
+
+    await workspace.refresh();
 
     const uris = Array.isArray(folderElementOrUri)
       ? folderElementOrUri
@@ -1054,7 +1079,7 @@ export class ExtensionController implements IDisposable {
         : [folderElementOrUri.uri];
 
     for (const uri of uris) {
-      this._pythonWorkspace.unmarkFolder(uri);
+      workspace.unmarkFolder(uri);
     }
   };
 

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -82,6 +82,7 @@ import {
   DheJsApiCache,
   DheService,
   DheServiceCache,
+  DEFAULT_IGNORE_TOP_LEVEL_FOLDER_NAMES,
   FilteredWorkspace,
   RemoteFileSourceService,
   PanelService,
@@ -89,9 +90,7 @@ import {
   PYTHON_FILE_PATTERN,
   SecretService,
   ServerManager,
-  PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
   GROOVY_FILE_PATTERN,
-  GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES,
 } from '../services';
 import type {
   IDisposable,
@@ -392,7 +391,7 @@ export class ExtensionController implements IDisposable {
       GROOVY_FILE_PATTERN,
       'groovy',
       getGroovyTopLevelPackageName,
-      GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES,
+      DEFAULT_IGNORE_TOP_LEVEL_FOLDER_NAMES,
       this._toaster
     );
     this._context.subscriptions.push(this._groovyWorkspace);
@@ -401,7 +400,7 @@ export class ExtensionController implements IDisposable {
       PYTHON_FILE_PATTERN,
       'python',
       getPythonTopLevelModuleFullname,
-      PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
+      DEFAULT_IGNORE_TOP_LEVEL_FOLDER_NAMES,
       this._toaster
     );
     this._context.subscriptions.push(this._pythonWorkspace);

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -450,6 +450,7 @@ export class ExtensionController implements IDisposable {
     assertDefined(this._outputChannelDebug, 'outputChannelDebug');
     assertDefined(this._panelService, 'panelService');
     assertDefined(this._groovyDiagnostics, 'groovyDiagnostics');
+    assertDefined(this._groovyWorkspace, 'groovyWorkspace');
     assertDefined(this._pythonDiagnostics, 'pythonDiagnostics');
     assertDefined(this._pythonWorkspace, 'pythonWorkspace');
     assertDefined(this._serverManager, 'serverManager');
@@ -463,6 +464,7 @@ export class ExtensionController implements IDisposable {
       this._outputChannelDebug,
       this._panelService,
       this._groovyDiagnostics,
+      this._groovyWorkspace,
       this._pythonDiagnostics,
       this._pythonWorkspace,
       this._serverManager

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -227,6 +227,7 @@ export class ExtensionController implements IDisposable {
   // Web views
   private _createQueryViewProvider: CreateQueryViewProvider | null = null;
 
+  private _groovyDiagnostics: vscode.DiagnosticCollection | null = null;
   private _pythonDiagnostics: vscode.DiagnosticCollection | null = null;
   private _outputChannel: OutputChannelWithHistory | null = null;
   private _outputChannelDebug: OutputChannelWithHistory | null = null;
@@ -448,6 +449,7 @@ export class ExtensionController implements IDisposable {
     assertDefined(this._outputChannel, 'outputChannel');
     assertDefined(this._outputChannelDebug, 'outputChannelDebug');
     assertDefined(this._panelService, 'panelService');
+    assertDefined(this._groovyDiagnostics, 'groovyDiagnostics');
     assertDefined(this._pythonDiagnostics, 'pythonDiagnostics');
     assertDefined(this._pythonWorkspace, 'pythonWorkspace');
     assertDefined(this._serverManager, 'serverManager');
@@ -460,6 +462,7 @@ export class ExtensionController implements IDisposable {
       this._outputChannel,
       this._outputChannelDebug,
       this._panelService,
+      this._groovyDiagnostics,
       this._pythonDiagnostics,
       this._pythonWorkspace,
       this._serverManager
@@ -472,12 +475,18 @@ export class ExtensionController implements IDisposable {
    * Initialize diagnostics collections.
    */
   initializeDiagnostics = (): void => {
+    this._groovyDiagnostics =
+      vscode.languages.createDiagnosticCollection('groovy');
+
     this._pythonDiagnostics =
       vscode.languages.createDiagnosticCollection('python');
 
     // Clear diagnostics on save
     vscode.workspace.onDidSaveTextDocument(
       doc => {
+        if (doc.languageId === 'groovy') {
+          this._groovyDiagnostics?.set(doc.uri, []);
+        }
         this._pythonDiagnostics?.set(doc.uri, []);
       },
       null,
@@ -547,6 +556,7 @@ export class ExtensionController implements IDisposable {
   };
 
   initializeServerManager = (): void => {
+    assertDefined(this._groovyDiagnostics, 'groovyDiagnostics');
     assertDefined(this._pythonDiagnostics, 'pythonDiagnostics');
     assertDefined(this._outputChannel, 'outputChannel');
     assertDefined(this._remoteFileSourceService, 'remoteFileSourceService');
@@ -682,6 +692,7 @@ export class ExtensionController implements IDisposable {
 
     this._dhcServiceFactory = DhcService.factory(
       this._coreClientCache,
+      this._groovyDiagnostics,
       this._pythonDiagnostics,
       this._remoteFileSourceService,
       this._outputChannel,

--- a/src/controllers/ExtensionController.ts
+++ b/src/controllers/ExtensionController.ts
@@ -1050,7 +1050,7 @@ export class ExtensionController implements IDisposable {
 
     assertDefined(workspace, `${languageId}Workspace`);
 
-    // supress notifications since `markFolder` will raise notifications.
+    // suppress notifications since `markFolder` will raise notifications.
     // this avoids sending data to the server that will change anyway
     await workspace.refresh(true);
 
@@ -1086,7 +1086,7 @@ export class ExtensionController implements IDisposable {
 
     assertDefined(workspace, `${languageId}Workspace`);
 
-    // supress notifications since `unmarkFolder` will raise notifications.
+    // suppress notifications since `unmarkFolder` will raise notifications.
     // this avoids sending data to the server that will change anyway
     await workspace.refresh(true);
 

--- a/src/controllers/McpController.ts
+++ b/src/controllers/McpController.ts
@@ -9,6 +9,7 @@ import type {
   IPanelService,
   IServerManager,
   McpVersion,
+  GroovyPackageName,
   PythonModuleFullname,
 } from '../types';
 import type { FilteredWorkspace } from '../services';
@@ -47,6 +48,7 @@ export class McpController extends ControllerBase {
     private readonly _outputChannelDebug: OutputChannelWithHistory,
     private readonly _panelService: IPanelService,
     private readonly _groovyDiagnostics: vscode.DiagnosticCollection,
+    private readonly _groovyWorkspace: FilteredWorkspace<GroovyPackageName>,
     private readonly _pythonDiagnostics: vscode.DiagnosticCollection,
     private readonly _pythonWorkspace: FilteredWorkspace<PythonModuleFullname>,
     private readonly _serverManager: IServerManager
@@ -157,6 +159,8 @@ export class McpController extends ControllerBase {
         this._outputChannel,
         this._outputChannelDebug,
         this._panelService,
+        this._groovyDiagnostics,
+        this._groovyWorkspace,
         this._pythonDiagnostics,
         this._pythonWorkspace,
         this._serverManager

--- a/src/controllers/McpController.ts
+++ b/src/controllers/McpController.ts
@@ -9,6 +9,7 @@ import type {
   IPanelService,
   IServerManager,
   McpVersion,
+  PythonModuleFullname,
 } from '../types';
 import type { FilteredWorkspace } from '../services';
 import { isWindsurf, Logger, OutputChannelWithHistory } from '../util';
@@ -46,7 +47,7 @@ export class McpController extends ControllerBase {
     private readonly _outputChannelDebug: OutputChannelWithHistory,
     private readonly _panelService: IPanelService,
     private readonly _pythonDiagnostics: vscode.DiagnosticCollection,
-    private readonly _pythonWorkspace: FilteredWorkspace,
+    private readonly _pythonWorkspace: FilteredWorkspace<PythonModuleFullname>,
     private readonly _serverManager: IServerManager
   ) {
     super();

--- a/src/controllers/McpController.ts
+++ b/src/controllers/McpController.ts
@@ -46,6 +46,7 @@ export class McpController extends ControllerBase {
     private readonly _outputChannel: OutputChannelWithHistory,
     private readonly _outputChannelDebug: OutputChannelWithHistory,
     private readonly _panelService: IPanelService,
+    private readonly _groovyDiagnostics: vscode.DiagnosticCollection,
     private readonly _pythonDiagnostics: vscode.DiagnosticCollection,
     private readonly _pythonWorkspace: FilteredWorkspace<PythonModuleFullname>,
     private readonly _serverManager: IServerManager

--- a/src/dh/__snapshots__/errorUtils.spec.ts.snap
+++ b/src/dh/__snapshots__/errorUtils.spec.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`parseServerError > should parse an error originating from another file > error <string> 1`] = `
+exports[`parsePythonServerError > should parse an error originating from another file > error <string> 1`] = `
 {
   "file": "<string>",
   "java.lang.runtimeexception": "Error in Python interpreter",
@@ -11,7 +11,7 @@ exports[`parseServerError > should parse an error originating from another file 
 }
 `;
 
-exports[`parseServerError > should parse an error originating from another file > error path 1`] = `
+exports[`parsePythonServerError > should parse an error originating from another file > error path 1`] = `
 {
   "file": "/some/path/my_weather/error_test.py",
   "java.lang.runtimeexception": "Error in Python interpreter",
@@ -22,7 +22,7 @@ exports[`parseServerError > should parse an error originating from another file 
 }
 `;
 
-exports[`parseServerError > should parse an error originating from another file > traceback 1`] = `
+exports[`parsePythonServerError > should parse an error originating from another file > traceback 1`] = `
 "
   File "<string>", line 6, in <module>
   File "/some/path/my_weather/__init__.py", line 3, in <module>
@@ -38,7 +38,7 @@ exports[`parseServerError > should parse an error originating from another file 
 "
 `;
 
-exports[`parseServerError > should parse an error originating from the current file > error <string> 1`] = `
+exports[`parsePythonServerError > should parse an error originating from the current file > error <string> 1`] = `
 {
   "file": "<string>",
   "java.lang.runtimeexception": "Error in Python interpreter",
@@ -49,7 +49,7 @@ exports[`parseServerError > should parse an error originating from the current f
 }
 `;
 
-exports[`parseServerError > should parse an error originating from the current file > traceback 1`] = `
+exports[`parsePythonServerError > should parse an error originating from the current file > traceback 1`] = `
 "
   File "<string>", line 5, in <module>
 

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -28,7 +28,8 @@ export const AUTH_HANDLER_TYPE_DHE =
 export type ConnectionAndSession<TConnection, TSession> = {
   cn: TConnection;
   cnId: UniqueID;
-  remoteFileSourcePlugin: DhType.Widget | null;
+  groovyRemoteFileSourcePlugin: DhType.remotefilesource.RemoteFileSourceService | null;
+  pythonRemoteFileSourcePlugin: DhType.Widget | null;
   session: TSession;
 };
 
@@ -152,10 +153,19 @@ export async function initDhcSession(
 
   const session = await cn.startSession(type);
 
-  const remoteFileSourcePlugin =
+  const pythonRemoteFileSourcePlugin =
     type === 'python' ? await getRemoteFileSourcePlugin(cnId, session) : null;
 
-  return { cn, cnId, remoteFileSourcePlugin, session };
+  const groovyRemoteFileSourcePlugin: DhType.remotefilesource.RemoteFileSourceService | null =
+    await client.getRemoteFileSourceService();
+
+  return {
+    cn,
+    cnId,
+    groovyRemoteFileSourcePlugin,
+    pythonRemoteFileSourcePlugin,
+    session,
+  };
 }
 
 /**

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -157,7 +157,9 @@ export async function initDhcSession(
     type === 'python' ? await getRemoteFileSourcePlugin(cnId, session) : null;
 
   const groovyRemoteFileSourcePlugin: DhType.remotefilesource.RemoteFileSourceService | null =
-    type === 'groovy' ? await client.getRemoteFileSourceService() : null;
+    type === 'groovy' && 'getRemoteFileSourceService' in client
+      ? await client.getRemoteFileSourceService()
+      : null;
 
   return {
     cn,

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -157,7 +157,7 @@ export async function initDhcSession(
     type === 'python' ? await getRemoteFileSourcePlugin(cnId, session) : null;
 
   const groovyRemoteFileSourcePlugin: DhType.remotefilesource.RemoteFileSourceService | null =
-    await client.getRemoteFileSourceService();
+    type === 'groovy' ? await client.getRemoteFileSourceService() : null;
 
   return {
     cn,

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -56,7 +56,7 @@ export async function getDhc(
   });
 
   // @ts-ignore TODO: once deephaven/deephaven-core/pull/7451 merges, we can
-  // update to proper jsapi-types and remove this @ts-ignores
+  // update to proper jsapi-types and remove this @ts-ignore
   return coreModule;
 }
 

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -55,6 +55,7 @@ export async function getDhc(
     targetModuleType: 'cjs',
   });
 
+  // @ts-ignore TODO: once we update to proper jsapi-types can remove this
   return coreModule;
 }
 

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -55,7 +55,8 @@ export async function getDhc(
     targetModuleType: 'cjs',
   });
 
-  // @ts-ignore TODO: once we update to proper jsapi-types can remove this
+  // @ts-ignore TODO: once deephaven/deephaven-core/pull/7451 merges, we can
+  // update to proper jsapi-types and remove this @ts-ignores
   return coreModule;
 }
 

--- a/src/dh/dhc.ts
+++ b/src/dh/dhc.ts
@@ -159,6 +159,8 @@ export async function initDhcSession(
     type === 'python' ? await getRemoteFileSourcePlugin(cnId, session) : null;
 
   const groovyRemoteFileSourcePlugin: DhType.remotefilesource.RemoteFileSourceService | null =
+    // The presence of `getRemoteFileSourceService` determines if the Groovy
+    // plugin is available on the server.
     type === 'groovy' && 'getRemoteFileSourceService' in client
       ? await client.getRemoteFileSourceService()
       : null;

--- a/src/dh/errorUtils.spec.ts
+++ b/src/dh/errorUtils.spec.ts
@@ -59,6 +59,36 @@ describe('parseGroovyServerError', () => {
     });
   });
 
+  it('should parse a simple single-level import path', () => {
+    const error =
+      'RuntimeException: Attempting to import a path that does not exist: import MyClass;';
+    const parsed = parseGroovyServerError(error);
+    expect(parsed).toHaveLength(1);
+
+    const [errorObj] = parsed;
+    expect(errorObj).toEqual({
+      type: 'RuntimeException',
+      value:
+        'Attempting to import a path that does not exist: import MyClass;',
+      importPath: 'MyClass',
+    });
+  });
+
+  it('should parse a deep nested import path', () => {
+    const error =
+      'RuntimeException: Attempting to import a path that does not exist: import com.example.subpackage.deep.MyClass;';
+    const parsed = parseGroovyServerError(error);
+    expect(parsed).toHaveLength(1);
+
+    const [errorObj] = parsed;
+    expect(errorObj).toEqual({
+      type: 'RuntimeException',
+      value:
+        'Attempting to import a path that does not exist: import com.example.subpackage.deep.MyClass;',
+      importPath: 'com.example.subpackage.deep.MyClass',
+    });
+  });
+
   it('should return empty array for unrecognized error format', () => {
     const parsed = parseGroovyServerError('Some other error');
     expect(parsed).toHaveLength(0);
@@ -66,6 +96,20 @@ describe('parseGroovyServerError', () => {
 
   it('should return empty array for empty string', () => {
     const parsed = parseGroovyServerError('');
+    expect(parsed).toHaveLength(0);
+  });
+
+  it('should return empty array when error has extra text after semicolon', () => {
+    const error =
+      'RuntimeException: Attempting to import a path that does not exist: import package.MyClass; extra text';
+    const parsed = parseGroovyServerError(error);
+    expect(parsed).toHaveLength(0);
+  });
+
+  it('should return empty array when error has a different prefix', () => {
+    const error =
+      'io.deephaven.RuntimeException: Attempting to import a path that does not exist: import package.MyClass;';
+    const parsed = parseGroovyServerError(error);
     expect(parsed).toHaveLength(0);
   });
 });

--- a/src/dh/errorUtils.spec.ts
+++ b/src/dh/errorUtils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseGroovyServerError, parseServerError } from './errorUtils';
+import { parseGroovyServerError, parsePythonServerError } from './errorUtils';
 
 const mockErrorFromCurrentFile = [
   'java.lang.RuntimeException: Error in Python interpreter:',
@@ -42,81 +42,38 @@ const mockErrorFromAnotherFile = [
   '',
 ].join('\n');
 
-const mockGroovyImportError =
-  'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;';
-
 describe('parseGroovyServerError', () => {
-  it('should parse a Groovy import error', () => {
-    const parsed = parseGroovyServerError(mockGroovyImportError);
-    expect(parsed).toHaveLength(1);
+  it.each([
+    'package3',
+    'package3.subpackage1',
+    'package3.subpackage1.MultiClassTest',
+  ])('should parse RuntimeException', importPath => {
+    const value = `Attempting to import a path that does not exist: import ${importPath}`;
 
-    const [error] = parsed;
-    expect(error).toEqual({
-      type: 'RuntimeException',
-      value:
-        'Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
-      importPath: 'package3.subpackage1.MultiClassTest',
-    });
+    const parsed = parseGroovyServerError(`RuntimeException: ${value};`);
+
+    expect(parsed).toEqual([
+      {
+        type: 'RuntimeException',
+        value: `${value};`,
+        importPath,
+      },
+    ]);
   });
 
-  it('should parse a simple single-level import path', () => {
-    const error =
-      'RuntimeException: Attempting to import a path that does not exist: import MyClass;';
-    const parsed = parseGroovyServerError(error);
-    expect(parsed).toHaveLength(1);
+  it.each(['', 'Some other error'])(
+    'should handle unrecognized error pattern',
+    error => {
+      const parsed = parseGroovyServerError(error);
 
-    const [errorObj] = parsed;
-    expect(errorObj).toEqual({
-      type: 'RuntimeException',
-      value:
-        'Attempting to import a path that does not exist: import MyClass;',
-      importPath: 'MyClass',
-    });
-  });
-
-  it('should parse a deep nested import path', () => {
-    const error =
-      'RuntimeException: Attempting to import a path that does not exist: import com.example.subpackage.deep.MyClass;';
-    const parsed = parseGroovyServerError(error);
-    expect(parsed).toHaveLength(1);
-
-    const [errorObj] = parsed;
-    expect(errorObj).toEqual({
-      type: 'RuntimeException',
-      value:
-        'Attempting to import a path that does not exist: import com.example.subpackage.deep.MyClass;',
-      importPath: 'com.example.subpackage.deep.MyClass',
-    });
-  });
-
-  it('should return empty array for unrecognized error format', () => {
-    const parsed = parseGroovyServerError('Some other error');
-    expect(parsed).toHaveLength(0);
-  });
-
-  it('should return empty array for empty string', () => {
-    const parsed = parseGroovyServerError('');
-    expect(parsed).toHaveLength(0);
-  });
-
-  it('should return empty array when error has extra text after semicolon', () => {
-    const error =
-      'RuntimeException: Attempting to import a path that does not exist: import package.MyClass; extra text';
-    const parsed = parseGroovyServerError(error);
-    expect(parsed).toHaveLength(0);
-  });
-
-  it('should return empty array when error has a different prefix', () => {
-    const error =
-      'io.deephaven.RuntimeException: Attempting to import a path that does not exist: import package.MyClass;';
-    const parsed = parseGroovyServerError(error);
-    expect(parsed).toHaveLength(0);
-  });
+      expect(parsed).toEqual([]);
+    }
+  );
 });
 
-describe('parseServerError', () => {
+describe('parsePythonServerError', () => {
   it('should parse an error originating from the current file', () => {
-    const parsed = parseServerError(mockErrorFromCurrentFile);
+    const parsed = parsePythonServerError(mockErrorFromCurrentFile);
     expect(parsed).toHaveLength(1);
 
     const [error] = parsed;
@@ -127,7 +84,7 @@ describe('parseServerError', () => {
   });
 
   it('should parse an error originating from another file', () => {
-    const parsed = parseServerError(mockErrorFromAnotherFile);
+    const parsed = parsePythonServerError(mockErrorFromAnotherFile);
     expect(parsed).toHaveLength(2);
 
     const [errorA, errorB] = parsed;

--- a/src/dh/errorUtils.spec.ts
+++ b/src/dh/errorUtils.spec.ts
@@ -47,7 +47,7 @@ describe('parseGroovyServerError', () => {
     'package3',
     'package3.subpackage1',
     'package3.subpackage1.MultiClassTest',
-  ])('should parse RuntimeException', importPath => {
+  ])('should parse RuntimeException: "%s"', importPath => {
     const value = `Attempting to import a path that does not exist: import ${importPath}`;
 
     const parsed = parseGroovyServerError(`RuntimeException: ${value};`);
@@ -62,7 +62,7 @@ describe('parseGroovyServerError', () => {
   });
 
   it.each(['', 'Some other error'])(
-    'should handle unrecognized error pattern',
+    'should handle unrecognized error pattern: "%s"',
     error => {
       const parsed = parseGroovyServerError(error);
 

--- a/src/dh/errorUtils.spec.ts
+++ b/src/dh/errorUtils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseServerError } from './errorUtils';
+import { parseGroovyServerError, parseServerError } from './errorUtils';
 
 const mockErrorFromCurrentFile = [
   'java.lang.RuntimeException: Error in Python interpreter:',
@@ -41,6 +41,34 @@ const mockErrorFromAnotherFile = [
   '\tbleh',
   '',
 ].join('\n');
+
+const mockGroovyImportError =
+  'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;';
+
+describe('parseGroovyServerError', () => {
+  it('should parse a Groovy import error', () => {
+    const parsed = parseGroovyServerError(mockGroovyImportError);
+    expect(parsed).toHaveLength(1);
+
+    const [error] = parsed;
+    expect(error).toEqual({
+      type: 'RuntimeException',
+      value:
+        'Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+      importPath: 'package3.subpackage1.MultiClassTest',
+    });
+  });
+
+  it('should return empty array for unrecognized error format', () => {
+    const parsed = parseGroovyServerError('Some other error');
+    expect(parsed).toHaveLength(0);
+  });
+
+  it('should return empty array for empty string', () => {
+    const parsed = parseGroovyServerError('');
+    expect(parsed).toHaveLength(0);
+  });
+});
 
 describe('parseServerError', () => {
   it('should parse an error originating from the current file', () => {

--- a/src/dh/errorUtils.ts
+++ b/src/dh/errorUtils.ts
@@ -103,7 +103,7 @@ export function parseGroovyServerError(
   logger: { debug: (...args: unknown[]) => void } = console
 ): [] | [ParsedError] {
   const importErrorPattern =
-    /^RuntimeException: Attempting to import a path that does not exist: import (.+);$/;
+    /^RuntimeException: Attempting to import a path that does not exist: import (.+);$/m;
   const match = importErrorPattern.exec(error);
 
   if (!match) {

--- a/src/dh/errorUtils.ts
+++ b/src/dh/errorUtils.ts
@@ -89,3 +89,35 @@ export function parseServerError(
 
   return [topLevelError];
 }
+
+/**
+ * Parse a Groovy server error string into an array of `ParsedError` objects.
+ * @param error Error string to parse.
+ * @param logger Optional logger for debugging. Defaults to console.
+ * @returns Array of parsed error objects. This can be one of:
+ * - []: Unrecognized error format.
+ * - [ParsedError]: Recognized Groovy import error with type, value, and importPath fields.
+ */
+export function parseGroovyServerError(
+  error: string,
+  logger: { debug: (...args: unknown[]) => void } = console
+): [] | [ParsedError] {
+  const importErrorPattern =
+    /^RuntimeException: Attempting to import a path that does not exist: import (.+);$/;
+  const match = importErrorPattern.exec(error);
+
+  if (!match) {
+    logger.debug('Unrecognized Groovy error type:', error);
+    return [];
+  }
+
+  const importPath = match[1];
+
+  return [
+    {
+      type: 'RuntimeException',
+      value: `Attempting to import a path that does not exist: import ${importPath};`,
+      importPath,
+    },
+  ];
+}

--- a/src/dh/errorUtils.ts
+++ b/src/dh/errorUtils.ts
@@ -26,7 +26,7 @@ export interface ParsedError {
  *   object is the originating error, second object is an adjusted version that
  *   points to the line in the executed file.
  */
-export function parseServerError(
+export function parsePythonServerError(
   error: string,
   logger: { debug: (...args: unknown[]) => void } = console
 ): [] | [ParsedError] | [ParsedError, ParsedError] {

--- a/src/dh/modules.d.ts
+++ b/src/dh/modules.d.ts
@@ -8,3 +8,35 @@ declare module '@deephaven-enterprise/jsapi-types' {
 }
 
 export {};
+
+/**
+ * TODO: These types were copied from core until deephaven/deephaven-core#7451
+ * merges / is released. Then we can do a version bump of jsapi-types and remove
+ * this module augmentation.
+ */
+declare module '@deephaven/jsapi-types' {
+  namespace dh {
+    interface CoreClient {
+      getRemoteFileSourceService(): Promise<dh.remotefilesource.RemoteFileSourceService>;
+    }
+  }
+
+  namespace dh.remotefilesource {
+    interface ResourceRequestEvent {
+      respond(content: string | Uint8Array | undefined | null): void;
+      get resourceName(): string;
+    }
+
+    class RemoteFileSourceService {
+      static readonly EVENT_REQUEST_SOURCE: string;
+
+      addEventListener<T>(
+        name: string,
+        callback: (e: dh.Event<T>) => void
+      ): () => void;
+
+      setExecutionContext(resourcePaths?: string[]): Promise<boolean>;
+      close(): void;
+    }
+  }
+}

--- a/src/dh/modules.d.ts
+++ b/src/dh/modules.d.ts
@@ -35,7 +35,10 @@ declare module '@deephaven/jsapi-types' {
         callback: (e: dh.Event<T>) => void
       ): () => void;
 
-      setExecutionContext(resourcePaths?: string[]): Promise<boolean>;
+      setExecutionContext(
+        isDirty: boolean,
+        resourcePaths?: string[]
+      ): Promise<boolean>;
       close(): void;
     }
   }

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -75,15 +75,7 @@ export class McpServer extends DisposableBase {
     this.registerTool(createOpenFilesInEditorTool());
     this.registerTool(createOpenVariablePanelsTool(this));
     this.registerTool(createRemoveRemoteFileSourcesTool());
-    this.registerTool(
-      createRunCodeFromUriTool({
-        groovyDiagnostics: this.groovyDiagnostics,
-        groovyWorkspace: this.groovyWorkspace,
-        pythonDiagnostics: this.pythonDiagnostics,
-        pythonWorkspace: this.pythonWorkspace,
-        serverManager: this.serverManager,
-      })
-    );
+    this.registerTool(createRunCodeFromUriTool(this));
     this.registerTool(createRunCodeTool(this));
     this.registerTool(createShowOutputPanelTool(this));
   }

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -9,6 +9,7 @@ import type {
   IServerManager,
   McpTool,
   McpToolSpec,
+  PythonModuleFullname,
 } from '../types';
 import { MCP_SERVER_NAME } from '../common';
 import {
@@ -47,7 +48,7 @@ export class McpServer extends DisposableBase {
     readonly outputChannelDebug: OutputChannelWithHistory,
     readonly panelService: IPanelService,
     readonly pythonDiagnostics: vscode.DiagnosticCollection,
-    readonly pythonWorkspace: FilteredWorkspace,
+    readonly pythonWorkspace: FilteredWorkspace<PythonModuleFullname>,
     readonly serverManager: IServerManager
   ) {
     super();

--- a/src/mcp/McpServer.ts
+++ b/src/mcp/McpServer.ts
@@ -9,6 +9,7 @@ import type {
   IServerManager,
   McpTool,
   McpToolSpec,
+  GroovyPackageName,
   PythonModuleFullname,
 } from '../types';
 import { MCP_SERVER_NAME } from '../common';
@@ -47,6 +48,8 @@ export class McpServer extends DisposableBase {
     readonly outputChannel: OutputChannelWithHistory,
     readonly outputChannelDebug: OutputChannelWithHistory,
     readonly panelService: IPanelService,
+    readonly groovyDiagnostics: vscode.DiagnosticCollection,
+    readonly groovyWorkspace: FilteredWorkspace<GroovyPackageName>,
     readonly pythonDiagnostics: vscode.DiagnosticCollection,
     readonly pythonWorkspace: FilteredWorkspace<PythonModuleFullname>,
     readonly serverManager: IServerManager
@@ -72,7 +75,15 @@ export class McpServer extends DisposableBase {
     this.registerTool(createOpenFilesInEditorTool());
     this.registerTool(createOpenVariablePanelsTool(this));
     this.registerTool(createRemoveRemoteFileSourcesTool());
-    this.registerTool(createRunCodeFromUriTool(this));
+    this.registerTool(
+      createRunCodeFromUriTool({
+        groovyDiagnostics: this.groovyDiagnostics,
+        groovyWorkspace: this.groovyWorkspace,
+        pythonDiagnostics: this.pythonDiagnostics,
+        pythonWorkspace: this.pythonWorkspace,
+        serverManager: this.serverManager,
+      })
+    );
     this.registerTool(createRunCodeTool(this));
     this.registerTool(createShowOutputPanelTool(this));
   }

--- a/src/mcp/tools/addRemoteFileSources.spec.ts
+++ b/src/mcp/tools/addRemoteFileSources.spec.ts
@@ -71,6 +71,7 @@ describe('addRemoteFileSources', () => {
     const result = await tool.handler({ folderUris });
 
     expect(commands.execAddRemoteFileSource).toHaveBeenCalledWith(
+      'python',
       expectedParsedUris.map(uri => vscode.Uri.parse(uri))
     );
 

--- a/src/mcp/tools/addRemoteFileSources.spec.ts
+++ b/src/mcp/tools/addRemoteFileSources.spec.ts
@@ -35,27 +35,33 @@ describe('addRemoteFileSources', () => {
 
   it.each([
     {
-      scenario: 'multiple URIs',
+      scenario: 'multiple URIs (python)',
       folderUris: [
         'file:///server1/path/to/folder1',
         'file:///server2/path/to/folder2/',
         'file:///local/path/',
       ],
+      languageId: 'python' as const,
       expectedParsedUris: [
         'file:///server1/path/to/folder1',
         'file:///server2/path/to/folder2',
         'file:///local/path',
       ],
+      expectedLanguageId: 'python',
     },
     {
-      scenario: 'single folder URI',
+      scenario: 'single folder URI (python)',
       folderUris: ['file:///server/folder'],
+      languageId: 'python' as const,
       expectedParsedUris: ['file:///server/folder'],
+      expectedLanguageId: 'python',
     },
     {
       scenario: 'empty array',
       folderUris: [],
+      languageId: 'python' as const,
       expectedParsedUris: [],
+      expectedLanguageId: 'python',
     },
     {
       scenario: 'duplicate URIs with mixed trailing slashes',
@@ -64,23 +70,34 @@ describe('addRemoteFileSources', () => {
         'file:///server/folder',
         'file:///server/folder/',
       ],
+      languageId: 'python' as const,
       expectedParsedUris: ['file:///server/folder'],
+      expectedLanguageId: 'python',
     },
-  ])('should handle $scenario', async ({ folderUris, expectedParsedUris }) => {
-    const tool = createAddRemoteFileSourcesTool();
-    const result = await tool.handler({ folderUris });
+    {
+      scenario: 'groovy language ID',
+      folderUris: ['file:///server/groovy/package3'],
+      languageId: 'groovy' as const,
+      expectedParsedUris: ['file:///server/groovy/package3'],
+      expectedLanguageId: 'groovy',
+    },
+  ])(
+    'should handle $scenario',
+    async ({ folderUris, languageId, expectedParsedUris, expectedLanguageId }) => {
+      const tool = createAddRemoteFileSourcesTool();
+      const result = await tool.handler({ folderUris, languageId });
 
-    expect(commands.execAddRemoteFileSource).toHaveBeenCalledWith(
-      'python',
-      expectedParsedUris.map(uri => vscode.Uri.parse(uri))
-    );
-
-    expect(result.structuredContent).toEqual(
-      mcpSuccessResult('Remote file sources added successfully', {
-        foldersAdded: expectedParsedUris.length,
-      })
-    );
-  });
+      expect(commands.execAddRemoteFileSource).toHaveBeenCalledWith(
+        expectedLanguageId,
+        expectedParsedUris.map(uri => vscode.Uri.parse(uri))
+      );
+      expect(result.structuredContent).toEqual(
+        mcpSuccessResult('Remote file sources added successfully', {
+          foldersAdded: expectedParsedUris.length,
+        })
+      );
+    }
+  );
 
   it.each([
     {
@@ -91,6 +108,7 @@ describe('addRemoteFileSources', () => {
         );
       },
       folderUris: ['file:///server/folder'],
+      languageId: 'python' as const,
       expectedMessage: 'Failed to add remote file sources: Command failed',
     },
     {
@@ -101,15 +119,16 @@ describe('addRemoteFileSources', () => {
         });
       },
       folderUris: ['invalid-uri'],
+      languageId: 'python' as const,
       expectedMessage: 'Failed to add remote file sources: Invalid URI',
     },
   ])(
     'should handle $scenario',
-    async ({ mockSetup, folderUris, expectedMessage }) => {
+    async ({ mockSetup, folderUris, languageId, expectedMessage }) => {
       mockSetup();
 
       const tool = createAddRemoteFileSourcesTool();
-      const result = await tool.handler({ folderUris });
+      const result = await tool.handler({ folderUris, languageId });
 
       expect(result.structuredContent).toEqual(
         mcpErrorResult(expectedMessage, { folderUris })

--- a/src/mcp/tools/addRemoteFileSources.ts
+++ b/src/mcp/tools/addRemoteFileSources.ts
@@ -44,7 +44,7 @@ export function createAddRemoteFileSourcesTool(): AddRemoteFileSourcesTool {
         // Deduplicate URIs using URISet
         const uniqueUris = Array.from(new URISet(uris).values());
 
-        await execAddRemoteFileSource(uniqueUris);
+        await execAddRemoteFileSource('python', uniqueUris);
 
         return response.success('Remote file sources added successfully', {
           foldersAdded: uniqueUris.length,

--- a/src/mcp/tools/addRemoteFileSources.ts
+++ b/src/mcp/tools/addRemoteFileSources.ts
@@ -17,7 +17,7 @@ const spec = {
     languageId: z
       .string()
       .describe(
-        'The language of the remote file sources to add: "python" or "groovy". Use "groovy" when adding Groovy package folders.'
+        'Language of the source files in the folders: "python" or "groovy".'
       ),
     folderUris: z
       .array(z.string())

--- a/src/mcp/tools/addRemoteFileSources.ts
+++ b/src/mcp/tools/addRemoteFileSources.ts
@@ -14,6 +14,11 @@ const spec = {
   description:
     'Add folder(s) as remote file sources (allows server to fetch source files on-demand during script execution).',
   inputSchema: {
+    languageId: z
+      .string()
+      .describe(
+        'The language of the remote file sources to add: "python" or "groovy". Use "groovy" when adding Groovy package folders.'
+      ),
     folderUris: z
       .array(z.string())
       .describe('List of folder URIs to add as remote file sources.'),
@@ -33,8 +38,18 @@ export function createAddRemoteFileSourcesTool(): AddRemoteFileSourcesTool {
   return {
     name: 'addRemoteFileSources',
     spec,
-    handler: async ({ folderUris }: HandlerArg): Promise<HandlerResult> => {
+    handler: async ({
+      folderUris,
+      languageId,
+    }: HandlerArg): Promise<HandlerResult> => {
       const response = new McpToolResponse();
+
+      // Validate languageId
+      if (languageId !== 'python' && languageId !== 'groovy') {
+        return response.error(
+          `Invalid languageId: '${languageId}'. Must be "python" or "groovy".`
+        );
+      }
 
       try {
         const uris = folderUris.map(uri =>
@@ -44,7 +59,7 @@ export function createAddRemoteFileSourcesTool(): AddRemoteFileSourcesTool {
         // Deduplicate URIs using URISet
         const uniqueUris = Array.from(new URISet(uris).values());
 
-        await execAddRemoteFileSource('python', uniqueUris);
+        await execAddRemoteFileSource(languageId, uniqueUris);
 
         return response.success('Remote file sources added successfully', {
           foldersAdded: uniqueUris.length,

--- a/src/mcp/tools/listRemoteFileSources.spec.ts
+++ b/src/mcp/tools/listRemoteFileSources.spec.ts
@@ -27,8 +27,6 @@ function createMockWorkspace<
   } as unknown as FilteredWorkspace<T>;
 }
 
-const emptyGroovyWorkspace = createMockWorkspace<GroovyPackageName>([]);
-
 describe('listRemoteFileSources', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,10 +34,12 @@ describe('listRemoteFileSources', () => {
   });
 
   it('should return correct tool spec', () => {
-    const mockWorkspace = createMockWorkspace<PythonModuleFullname>([]);
+    const groovyWorkspace = createMockWorkspace<GroovyPackageName>([]);
+    const pythonWorkspace = createMockWorkspace<PythonModuleFullname>([]);
+
     const tool = createListRemoteFileSourcesTool({
-      groovyWorkspace: emptyGroovyWorkspace,
-      pythonWorkspace: mockWorkspace,
+      groovyWorkspace,
+      pythonWorkspace,
     });
 
     expect(tool.name).toBe('listRemoteFileSources');
@@ -49,59 +49,95 @@ describe('listRemoteFileSources', () => {
     );
   });
 
-  it.each([
-    {
-      scenario: 'no remote file sources',
-      folderUris: [],
-      expectedMessage: 'Found 0 remote file sources',
-    },
-    {
-      scenario: 'single remote file source',
-      folderUris: ['file:///server/folder'],
-      expectedMessage: 'Found 1 remote file source',
-    },
-    {
-      scenario: 'multiple remote file sources',
-      folderUris: [
-        'file:///server1/path/to/folder1',
-        'file:///server2/path/to/folder2',
-      ],
-      expectedMessage: 'Found 2 remote file sources',
-    },
-    {
-      scenario: 'large number of folders',
-      folderUris: Array.from(
-        { length: 50 },
-        (_, i) => `file:///server/folder${i}`
-      ),
-      expectedMessage: 'Found 50 remote file sources',
-    },
-  ])(
-    'should handle $scenario (python only)',
-    async ({ folderUris, expectedMessage }) => {
-      const mockWorkspace = createMockWorkspace<PythonModuleFullname>(
-        folderUris.map(uri => vscode.Uri.parse(uri))
+  describe.each(['groovy', 'python'] as const)('single source', languageId => {
+    it.each([
+      {
+        scenario: 'no remote file sources',
+        folderUriStrings: [],
+        expectedMessage: 'Found 0 remote file sources',
+      },
+      {
+        scenario: 'single remote file source',
+        folderUriStrings: ['file:///server/folder'],
+        expectedMessage: 'Found 1 remote file source',
+      },
+      {
+        scenario: 'multiple remote file sources',
+        folderUriStrings: [
+          'file:///server1/path/to/folder1',
+          'file:///server2/path/to/folder2',
+        ],
+        expectedMessage: 'Found 2 remote file sources',
+      },
+      {
+        scenario: 'large number of folders',
+        folderUriStrings: Array.from(
+          { length: 50 },
+          (_, i) => `file:///server/folder${i}`
+        ),
+        expectedMessage: 'Found 50 remote file sources',
+      },
+    ])(
+      `should handle ${languageId} $scenario`,
+      async ({ folderUriStrings, expectedMessage }) => {
+        const folderUris = folderUriStrings.map(uri => vscode.Uri.parse(uri));
+
+        const pythonWorkspace = createMockWorkspace<PythonModuleFullname>(
+          languageId === 'python' ? folderUris : []
+        );
+        const groovyWorkspace = createMockWorkspace<GroovyPackageName>(
+          languageId === 'groovy' ? folderUris : []
+        );
+
+        const tool = createListRemoteFileSourcesTool({
+          groovyWorkspace,
+          pythonWorkspace,
+        });
+        const result = await tool.handler({ languageId });
+
+        const [yesWorkspace, noWorkspace] =
+          languageId === 'groovy'
+            ? [groovyWorkspace, pythonWorkspace]
+            : [pythonWorkspace, groovyWorkspace];
+
+        expect(yesWorkspace.getTopLevelMarkedFolders).toHaveBeenCalledOnce();
+        expect(noWorkspace.getTopLevelMarkedFolders).not.toHaveBeenCalled();
+
+        expect(result.structuredContent).toEqual(
+          mcpSuccessResult(expectedMessage, { folderUris: folderUriStrings })
+        );
+      }
+    );
+
+    it(`should handle ${languageId} error from getTopLevelMarkedFolders`, async () => {
+      const error = new Error('Test error');
+
+      const groovyWorkspace = createMockWorkspace<GroovyPackageName>(
+        languageId === 'groovy' ? error : []
       );
+      const pythonWorkspace = createMockWorkspace<PythonModuleFullname>(
+        languageId === 'python' ? error : []
+      );
+
       const tool = createListRemoteFileSourcesTool({
-        groovyWorkspace: emptyGroovyWorkspace,
-        pythonWorkspace: mockWorkspace,
+        groovyWorkspace,
+        pythonWorkspace,
       });
       const result = await tool.handler({});
 
-      expect(mockWorkspace.getTopLevelMarkedFolders).toHaveBeenCalledOnce();
       expect(result.structuredContent).toEqual(
-        mcpSuccessResult(expectedMessage, { folderUris })
+        mcpErrorResult('Failed to list remote file sources: Test error')
       );
-    }
-  );
+    });
+  });
 
   it('should include Groovy and Python sources together', async () => {
-    const groovyUris = ['file:///workspace/package3'].map(uri =>
-      vscode.Uri.parse(uri)
-    );
-    const pythonUris = ['file:///workspace/mymodule'].map(uri =>
-      vscode.Uri.parse(uri)
-    );
+    const groovyFolder = 'file:///workspace/package3';
+    const groovyUris = [groovyFolder].map(uri => vscode.Uri.parse(uri));
+
+    const pythonFolder = 'file:///workspace/mymodule';
+    const pythonUris = [pythonFolder].map(uri => vscode.Uri.parse(uri));
+
     const groovyWorkspace = createMockWorkspace<GroovyPackageName>(groovyUris);
     const pythonWorkspace =
       createMockWorkspace<PythonModuleFullname>(pythonUris);
@@ -114,25 +150,8 @@ describe('listRemoteFileSources', () => {
 
     expect(result.structuredContent).toEqual(
       mcpSuccessResult('Found 2 remote file sources', {
-        folderUris: [
-          'file:///workspace/package3',
-          'file:///workspace/mymodule',
-        ],
+        folderUris: [groovyFolder, pythonFolder],
       })
-    );
-  });
-
-  it('should handle error from getTopLevelMarkedFolders', async () => {
-    const error = new Error('Test error');
-    const mockWorkspace = createMockWorkspace<PythonModuleFullname>(error);
-    const tool = createListRemoteFileSourcesTool({
-      groovyWorkspace: emptyGroovyWorkspace,
-      pythonWorkspace: mockWorkspace,
-    });
-    const result = await tool.handler({});
-
-    expect(result.structuredContent).toEqual(
-      mcpErrorResult('Failed to list remote file sources: Test error')
     );
   });
 });

--- a/src/mcp/tools/listRemoteFileSources.spec.ts
+++ b/src/mcp/tools/listRemoteFileSources.spec.ts
@@ -7,13 +7,13 @@ import {
   mcpErrorResult,
   mcpSuccessResult,
 } from '../utils/mcpTestUtils';
-import type { PythonModuleFullname } from '../../types';
+import type { GroovyPackageName, PythonModuleFullname } from '../../types';
 
 vi.mock('vscode');
 
-const createMockWorkspace = (
+function createMockWorkspace<T>(
   folderUris: vscode.Uri[] | Error
-): FilteredWorkspace<PythonModuleFullname> => {
+): FilteredWorkspace<T> {
   const folders =
     folderUris instanceof Error ? folderUris : folderUris.map(uri => ({ uri }));
 
@@ -24,8 +24,10 @@ const createMockWorkspace = (
             throw folders;
           })
         : vi.fn().mockReturnValue(folders),
-  } as unknown as FilteredWorkspace<PythonModuleFullname>;
-};
+  } as unknown as FilteredWorkspace<T>;
+}
+
+const emptyGroovyWorkspace = createMockWorkspace<GroovyPackageName>([]);
 
 describe('listRemoteFileSources', () => {
   beforeEach(() => {
@@ -34,8 +36,9 @@ describe('listRemoteFileSources', () => {
   });
 
   it('should return correct tool spec', () => {
-    const mockWorkspace = createMockWorkspace([]);
+    const mockWorkspace = createMockWorkspace<PythonModuleFullname>([]);
     const tool = createListRemoteFileSourcesTool({
+      groovyWorkspace: emptyGroovyWorkspace,
       pythonWorkspace: mockWorkspace,
     });
 
@@ -73,11 +76,12 @@ describe('listRemoteFileSources', () => {
       ),
       expectedMessage: 'Found 50 remote file sources',
     },
-  ])('should handle $scenario', async ({ folderUris, expectedMessage }) => {
-    const mockWorkspace = createMockWorkspace(
+  ])('should handle $scenario (python only)', async ({ folderUris, expectedMessage }) => {
+    const mockWorkspace = createMockWorkspace<PythonModuleFullname>(
       folderUris.map(uri => vscode.Uri.parse(uri))
     );
     const tool = createListRemoteFileSourcesTool({
+      groovyWorkspace: emptyGroovyWorkspace,
       pythonWorkspace: mockWorkspace,
     });
     const result = await tool.handler({});
@@ -88,10 +92,38 @@ describe('listRemoteFileSources', () => {
     );
   });
 
+  it('should include Groovy and Python sources together', async () => {
+    const groovyUris = ['file:///workspace/package3'].map(uri =>
+      vscode.Uri.parse(uri)
+    );
+    const pythonUris = ['file:///workspace/mymodule'].map(uri =>
+      vscode.Uri.parse(uri)
+    );
+    const groovyWorkspace = createMockWorkspace<GroovyPackageName>(groovyUris);
+    const pythonWorkspace =
+      createMockWorkspace<PythonModuleFullname>(pythonUris);
+
+    const tool = createListRemoteFileSourcesTool({
+      groovyWorkspace,
+      pythonWorkspace,
+    });
+    const result = await tool.handler({});
+
+    expect(result.structuredContent).toEqual(
+      mcpSuccessResult('Found 2 remote file sources', {
+        folderUris: [
+          'file:///workspace/package3',
+          'file:///workspace/mymodule',
+        ],
+      })
+    );
+  });
+
   it('should handle error from getTopLevelMarkedFolders', async () => {
     const error = new Error('Test error');
-    const mockWorkspace = createMockWorkspace(error);
+    const mockWorkspace = createMockWorkspace<PythonModuleFullname>(error);
     const tool = createListRemoteFileSourcesTool({
+      groovyWorkspace: emptyGroovyWorkspace,
       pythonWorkspace: mockWorkspace,
     });
     const result = await tool.handler({});

--- a/src/mcp/tools/listRemoteFileSources.spec.ts
+++ b/src/mcp/tools/listRemoteFileSources.spec.ts
@@ -7,12 +7,13 @@ import {
   mcpErrorResult,
   mcpSuccessResult,
 } from '../utils/mcpTestUtils';
+import type { PythonModuleFullname } from '../../types';
 
 vi.mock('vscode');
 
 const createMockWorkspace = (
   folderUris: vscode.Uri[] | Error
-): FilteredWorkspace => {
+): FilteredWorkspace<PythonModuleFullname> => {
   const folders =
     folderUris instanceof Error ? folderUris : folderUris.map(uri => ({ uri }));
 
@@ -23,7 +24,7 @@ const createMockWorkspace = (
             throw folders;
           })
         : vi.fn().mockReturnValue(folders),
-  } as unknown as FilteredWorkspace;
+  } as unknown as FilteredWorkspace<PythonModuleFullname>;
 };
 
 describe('listRemoteFileSources', () => {

--- a/src/mcp/tools/listRemoteFileSources.spec.ts
+++ b/src/mcp/tools/listRemoteFileSources.spec.ts
@@ -11,9 +11,9 @@ import type { GroovyPackageName, PythonModuleFullname } from '../../types';
 
 vi.mock('vscode');
 
-function createMockWorkspace<T>(
-  folderUris: vscode.Uri[] | Error
-): FilteredWorkspace<T> {
+function createMockWorkspace<
+  T extends GroovyPackageName | PythonModuleFullname,
+>(folderUris: vscode.Uri[] | Error): FilteredWorkspace<T> {
   const folders =
     folderUris instanceof Error ? folderUris : folderUris.map(uri => ({ uri }));
 
@@ -76,21 +76,24 @@ describe('listRemoteFileSources', () => {
       ),
       expectedMessage: 'Found 50 remote file sources',
     },
-  ])('should handle $scenario (python only)', async ({ folderUris, expectedMessage }) => {
-    const mockWorkspace = createMockWorkspace<PythonModuleFullname>(
-      folderUris.map(uri => vscode.Uri.parse(uri))
-    );
-    const tool = createListRemoteFileSourcesTool({
-      groovyWorkspace: emptyGroovyWorkspace,
-      pythonWorkspace: mockWorkspace,
-    });
-    const result = await tool.handler({});
+  ])(
+    'should handle $scenario (python only)',
+    async ({ folderUris, expectedMessage }) => {
+      const mockWorkspace = createMockWorkspace<PythonModuleFullname>(
+        folderUris.map(uri => vscode.Uri.parse(uri))
+      );
+      const tool = createListRemoteFileSourcesTool({
+        groovyWorkspace: emptyGroovyWorkspace,
+        pythonWorkspace: mockWorkspace,
+      });
+      const result = await tool.handler({});
 
-    expect(mockWorkspace.getTopLevelMarkedFolders).toHaveBeenCalledOnce();
-    expect(result.structuredContent).toEqual(
-      mcpSuccessResult(expectedMessage, { folderUris })
-    );
-  });
+      expect(mockWorkspace.getTopLevelMarkedFolders).toHaveBeenCalledOnce();
+      expect(result.structuredContent).toEqual(
+        mcpSuccessResult(expectedMessage, { folderUris })
+      );
+    }
+  );
 
   it('should include Groovy and Python sources together', async () => {
     const groovyUris = ['file:///workspace/package3'].map(uri =>

--- a/src/mcp/tools/listRemoteFileSources.spec.ts
+++ b/src/mcp/tools/listRemoteFileSources.spec.ts
@@ -103,8 +103,13 @@ describe('listRemoteFileSources', () => {
         expect(yesWorkspace.getTopLevelMarkedFolders).toHaveBeenCalledOnce();
         expect(noWorkspace.getTopLevelMarkedFolders).not.toHaveBeenCalled();
 
+        const expectedFolders = folderUriStrings.map(uri => ({
+          uri,
+          languageId,
+        }));
+
         expect(result.structuredContent).toEqual(
-          mcpSuccessResult(expectedMessage, { folderUris: folderUriStrings })
+          mcpSuccessResult(expectedMessage, { folders: expectedFolders })
         );
       }
     );
@@ -150,8 +155,31 @@ describe('listRemoteFileSources', () => {
 
     expect(result.structuredContent).toEqual(
       mcpSuccessResult('Found 2 remote file sources', {
-        folderUris: [groovyFolder, pythonFolder],
+        folders: [
+          { uri: groovyFolder, languageId: 'groovy' },
+          { uri: pythonFolder, languageId: 'python' },
+        ],
       })
+    );
+  });
+
+  it('should return error for unsupported languageId', async () => {
+    const groovyWorkspace = createMockWorkspace<GroovyPackageName>([]);
+    const pythonWorkspace = createMockWorkspace<PythonModuleFullname>([]);
+
+    const tool = createListRemoteFileSourcesTool({
+      groovyWorkspace,
+      pythonWorkspace,
+    });
+    const result = await tool.handler({ languageId: 'java' });
+
+    expect(groovyWorkspace.getTopLevelMarkedFolders).not.toHaveBeenCalled();
+    expect(pythonWorkspace.getTopLevelMarkedFolders).not.toHaveBeenCalled();
+
+    expect(result.structuredContent).toEqual(
+      mcpErrorResult(
+        'Unsupported languageId: "java". Must be "groovy" or "python".'
+      )
     );
   });
 });

--- a/src/mcp/tools/listRemoteFileSources.ts
+++ b/src/mcp/tools/listRemoteFileSources.ts
@@ -3,6 +3,7 @@ import type {
   McpTool,
   McpToolHandlerArg,
   McpToolHandlerResult,
+  GroovyPackageName,
   PythonModuleFullname,
 } from '../../types';
 import { createMcpToolOutputSchema, McpToolResponse } from '../utils';
@@ -11,7 +12,14 @@ import type { FilteredWorkspace } from '../../services';
 const spec = {
   title: 'List Remote File Sources',
   description: 'List all remote file source folders in the workspace.',
-  inputSchema: {},
+  inputSchema: {
+    languageId: z
+      .string()
+      .optional()
+      .describe(
+        'The language of the remote file sources to list: "python" or "groovy". If not specified, lists both.'
+      ),
+  },
   outputSchema: createMcpToolOutputSchema({
     folderUris: z.array(z.string()).optional(),
   }),
@@ -23,20 +31,36 @@ type HandlerResult = McpToolHandlerResult<Spec>;
 type ListRemoteFileSourcesTool = McpTool<Spec>;
 
 export function createListRemoteFileSourcesTool({
+  groovyWorkspace,
   pythonWorkspace,
 }: {
+  groovyWorkspace: FilteredWorkspace<GroovyPackageName>;
   pythonWorkspace: FilteredWorkspace<PythonModuleFullname>;
 }): ListRemoteFileSourcesTool {
   return {
     name: 'listRemoteFileSources',
     spec,
-    handler: async (_arg: HandlerArg): Promise<HandlerResult> => {
+    handler: async ({ languageId }: HandlerArg): Promise<HandlerResult> => {
       const response = new McpToolResponse();
 
       try {
-        const folderUris = pythonWorkspace
-          .getTopLevelMarkedFolders()
-          .map(folder => folder.uri.toString());
+        const folderUris: string[] = [];
+
+        if (!languageId || languageId === 'groovy') {
+          folderUris.push(
+            ...groovyWorkspace
+              .getTopLevelMarkedFolders()
+              .map(folder => folder.uri.toString())
+          );
+        }
+
+        if (!languageId || languageId === 'python') {
+          folderUris.push(
+            ...pythonWorkspace
+              .getTopLevelMarkedFolders()
+              .map(folder => folder.uri.toString())
+          );
+        }
 
         return response.success(
           `Found ${folderUris.length} remote file source${folderUris.length === 1 ? '' : 's'}`,

--- a/src/mcp/tools/listRemoteFileSources.ts
+++ b/src/mcp/tools/listRemoteFileSources.ts
@@ -3,6 +3,7 @@ import type {
   McpTool,
   McpToolHandlerArg,
   McpToolHandlerResult,
+  PythonModuleFullname,
 } from '../../types';
 import { createMcpToolOutputSchema, McpToolResponse } from '../utils';
 import type { FilteredWorkspace } from '../../services';
@@ -24,7 +25,7 @@ type ListRemoteFileSourcesTool = McpTool<Spec>;
 export function createListRemoteFileSourcesTool({
   pythonWorkspace,
 }: {
-  pythonWorkspace: FilteredWorkspace;
+  pythonWorkspace: FilteredWorkspace<PythonModuleFullname>;
 }): ListRemoteFileSourcesTool {
   return {
     name: 'listRemoteFileSources',

--- a/src/mcp/tools/listRemoteFileSources.ts
+++ b/src/mcp/tools/listRemoteFileSources.ts
@@ -21,7 +21,14 @@ const spec = {
       ),
   },
   outputSchema: createMcpToolOutputSchema({
-    folderUris: z.array(z.string()).optional(),
+    folders: z
+      .array(
+        z.object({
+          uri: z.string(),
+          languageId: z.enum(['groovy', 'python']),
+        })
+      )
+      .optional(),
   }),
 } as const;
 
@@ -44,28 +51,38 @@ export function createListRemoteFileSourcesTool({
       const response = new McpToolResponse();
 
       try {
-        const folderUris: string[] = [];
+        // Validate languageId if provided
+        if (languageId && languageId !== 'groovy' && languageId !== 'python') {
+          return response.error(
+            `Unsupported languageId: "${languageId}". Must be "groovy" or "python".`
+          );
+        }
+
+        const folders: Array<{ uri: string; languageId: 'groovy' | 'python' }> =
+          [];
 
         if (!languageId || languageId === 'groovy') {
-          folderUris.push(
-            ...groovyWorkspace
-              .getTopLevelMarkedFolders()
-              .map(folder => folder.uri.toString())
+          folders.push(
+            ...groovyWorkspace.getTopLevelMarkedFolders().map(folder => ({
+              uri: folder.uri.toString(),
+              languageId: 'groovy' as const,
+            }))
           );
         }
 
         if (!languageId || languageId === 'python') {
-          folderUris.push(
-            ...pythonWorkspace
-              .getTopLevelMarkedFolders()
-              .map(folder => folder.uri.toString())
+          folders.push(
+            ...pythonWorkspace.getTopLevelMarkedFolders().map(folder => ({
+              uri: folder.uri.toString(),
+              languageId: 'python' as const,
+            }))
           );
         }
 
         return response.success(
-          `Found ${folderUris.length} remote file source${folderUris.length === 1 ? '' : 's'}`,
+          `Found ${folders.length} remote file source${folders.length === 1 ? '' : 's'}`,
           {
-            folderUris,
+            folders,
           }
         );
       } catch (error) {

--- a/src/mcp/tools/removeRemoteFileSources.spec.ts
+++ b/src/mcp/tools/removeRemoteFileSources.spec.ts
@@ -13,7 +13,7 @@ vi.mock('../../common/commands', async () => {
   const actual = await vi.importActual('../../common/commands');
   return {
     ...actual,
-    execRemoveRemoteFileSource: vi.fn().mockResolvedValue(undefined),
+    execRemoveRemoteFileSource: vi.fn(),
   };
 });
 
@@ -33,105 +33,109 @@ describe('removeRemoteFileSources', () => {
     );
   });
 
-  it.each([
-    {
-      scenario: 'multiple URIs (python)',
-      folderUris: [
-        'file:///server1/path/to/folder1',
-        'file:///server2/path/to/folder2/',
-        'file:///local/path/',
-      ],
-      languageId: 'python' as const,
-      expectedParsedUris: [
-        'file:///server1/path/to/folder1',
-        'file:///server2/path/to/folder2',
-        'file:///local/path',
-      ],
-      expectedLanguageId: 'python',
-    },
-    {
-      scenario: 'single folder URI (python)',
-      folderUris: ['file:///server/folder'],
-      languageId: 'python' as const,
-      expectedParsedUris: ['file:///server/folder'],
-      expectedLanguageId: 'python',
-    },
-    {
-      scenario: 'empty array',
-      folderUris: [],
-      languageId: 'python' as const,
-      expectedParsedUris: [],
-      expectedLanguageId: 'python',
-    },
-    {
-      scenario: 'duplicate URIs with mixed trailing slashes',
-      folderUris: [
-        'file:///server/folder',
-        'file:///server/folder',
-        'file:///server/folder/',
-      ],
-      languageId: 'python' as const,
-      expectedParsedUris: ['file:///server/folder'],
-      expectedLanguageId: 'python',
-    },
-    {
-      scenario: 'groovy language ID',
-      folderUris: ['file:///server/groovy/package3'],
-      languageId: 'groovy' as const,
-      expectedParsedUris: ['file:///server/groovy/package3'],
-      expectedLanguageId: 'groovy',
-    },
-  ])(
-    'should handle $scenario',
-    async ({ folderUris, languageId, expectedParsedUris, expectedLanguageId }) => {
-      const tool = createRemoveRemoteFileSourcesTool();
-      const result = await tool.handler({ folderUris, languageId });
+  describe.each(['groovy', 'python'] as const)(
+    'handler with languageId "%s"',
+    languageId => {
+      it.each([
+        {
+          scenario: 'multiple URIs',
+          folderUris: [
+            'file:///server1/path/to/folder1',
+            'file:///server2/path/to/folder2/',
+            'file:///local/path/',
+          ],
+          languageId,
+          expectedParsedUris: [
+            'file:///server1/path/to/folder1',
+            'file:///server2/path/to/folder2',
+            'file:///local/path',
+          ],
+          expectedLanguageId: languageId,
+        },
+        {
+          scenario: 'single folder URI',
+          folderUris: ['file:///server/folder'],
+          languageId,
+          expectedParsedUris: ['file:///server/folder'],
+          expectedLanguageId: languageId,
+        },
+        {
+          scenario: 'empty array',
+          folderUris: [],
+          languageId,
+          expectedParsedUris: [],
+          expectedLanguageId: languageId,
+        },
+        {
+          scenario: 'duplicate URIs with mixed trailing slashes',
+          folderUris: [
+            'file:///server/folder',
+            'file:///server/folder',
+            'file:///server/folder/',
+          ],
+          languageId,
+          expectedParsedUris: ['file:///server/folder'],
+          expectedLanguageId: languageId,
+        },
+      ])(
+        'should handle $scenario',
+        async ({
+          folderUris,
+          languageId,
+          expectedParsedUris,
+          expectedLanguageId,
+        }) => {
+          const tool = createRemoveRemoteFileSourcesTool();
+          const result = await tool.handler({ folderUris, languageId });
 
-      expect(commands.execRemoveRemoteFileSource).toHaveBeenCalledWith(
-        expectedLanguageId,
-        expectedParsedUris.map(uri => vscode.Uri.parse(uri))
+          expect(commands.execRemoveRemoteFileSource).toHaveBeenCalledWith(
+            expectedLanguageId,
+            expectedParsedUris.map(uri => vscode.Uri.parse(uri))
+          );
+          expect(result.structuredContent).toEqual(
+            mcpSuccessResult('Remote file sources removed successfully', {
+              foldersRemoved: expectedParsedUris.length,
+            })
+          );
+        }
       );
-      expect(result.structuredContent).toEqual(
-        mcpSuccessResult('Remote file sources removed successfully', {
-          foldersRemoved: expectedParsedUris.length,
-        })
-      );
-    }
-  );
 
-  it.each([
-    {
-      scenario: 'command execution error',
-      mockSetup: (): void => {
-        vi.mocked(commands.execRemoveRemoteFileSource).mockRejectedValue(
-          new Error('Command failed')
-        );
-      },
-      folderUris: ['file:///server/folder'],
-      languageId: 'python' as const,
-      expectedMessage: 'Failed to remove remote file sources: Command failed',
-    },
-    {
-      scenario: 'URI parsing error',
-      mockSetup: (): void => {
-        vi.mocked(vscode.Uri.parse).mockImplementation(() => {
-          throw new Error('Invalid URI');
-        });
-      },
-      folderUris: ['invalid-uri'],
-      languageId: 'python' as const,
-      expectedMessage: 'Failed to remove remote file sources: Invalid URI',
-    },
-  ])(
-    'should handle $scenario',
-    async ({ mockSetup, folderUris, languageId, expectedMessage }) => {
-      mockSetup();
+      it.each([
+        {
+          scenario: 'command execution error',
+          mockSetup: (): void => {
+            vi.mocked(
+              commands.execRemoveRemoteFileSource
+            ).mockRejectedValueOnce(new Error('Command failed'));
+          },
+          folderUris: ['file:///server/folder'],
+          languageId,
+          expectedMessage:
+            'Failed to remove remote file sources: Command failed',
+        },
+        {
+          scenario: 'URI parsing error',
+          mockSetup: (): void => {
+            vi.mocked(vscode.Uri.parse).mockImplementationOnce(() => {
+              throw new Error('Invalid URI');
+            });
+          },
+          folderUris: ['invalid-uri'],
+          languageId,
+          expectedMessage: 'Failed to remove remote file sources: Invalid URI',
+        },
+      ])(
+        'should handle $scenario',
+        async ({ mockSetup, folderUris, languageId, expectedMessage }) => {
+          mockSetup();
 
-      const tool = createRemoveRemoteFileSourcesTool();
-      const result = await tool.handler({ folderUris, languageId });
+          const tool = createRemoveRemoteFileSourcesTool();
+          const result = await tool.handler({ folderUris, languageId });
 
-      expect(result.structuredContent).toEqual(
-        mcpErrorResult(expectedMessage, { folderUris })
+          expect(result.structuredContent).toEqual(
+            mcpErrorResult(expectedMessage, { folderUris })
+          );
+        }
       );
     }
   );

--- a/src/mcp/tools/removeRemoteFileSources.spec.ts
+++ b/src/mcp/tools/removeRemoteFileSources.spec.ts
@@ -35,27 +35,33 @@ describe('removeRemoteFileSources', () => {
 
   it.each([
     {
-      scenario: 'multiple URIs',
+      scenario: 'multiple URIs (python)',
       folderUris: [
         'file:///server1/path/to/folder1',
         'file:///server2/path/to/folder2/',
         'file:///local/path/',
       ],
+      languageId: 'python' as const,
       expectedParsedUris: [
         'file:///server1/path/to/folder1',
         'file:///server2/path/to/folder2',
         'file:///local/path',
       ],
+      expectedLanguageId: 'python',
     },
     {
-      scenario: 'single folder URI',
+      scenario: 'single folder URI (python)',
       folderUris: ['file:///server/folder'],
+      languageId: 'python' as const,
       expectedParsedUris: ['file:///server/folder'],
+      expectedLanguageId: 'python',
     },
     {
       scenario: 'empty array',
       folderUris: [],
+      languageId: 'python' as const,
       expectedParsedUris: [],
+      expectedLanguageId: 'python',
     },
     {
       scenario: 'duplicate URIs with mixed trailing slashes',
@@ -64,23 +70,34 @@ describe('removeRemoteFileSources', () => {
         'file:///server/folder',
         'file:///server/folder/',
       ],
+      languageId: 'python' as const,
       expectedParsedUris: ['file:///server/folder'],
+      expectedLanguageId: 'python',
     },
-  ])('should handle $scenario', async ({ folderUris, expectedParsedUris }) => {
-    const tool = createRemoveRemoteFileSourcesTool();
-    const result = await tool.handler({ folderUris });
+    {
+      scenario: 'groovy language ID',
+      folderUris: ['file:///server/groovy/package3'],
+      languageId: 'groovy' as const,
+      expectedParsedUris: ['file:///server/groovy/package3'],
+      expectedLanguageId: 'groovy',
+    },
+  ])(
+    'should handle $scenario',
+    async ({ folderUris, languageId, expectedParsedUris, expectedLanguageId }) => {
+      const tool = createRemoveRemoteFileSourcesTool();
+      const result = await tool.handler({ folderUris, languageId });
 
-    expect(commands.execRemoveRemoteFileSource).toHaveBeenCalledWith(
-      'python',
-      expectedParsedUris.map(uri => vscode.Uri.parse(uri))
-    );
-
-    expect(result.structuredContent).toEqual(
-      mcpSuccessResult('Remote file sources removed successfully', {
-        foldersRemoved: expectedParsedUris.length,
-      })
-    );
-  });
+      expect(commands.execRemoveRemoteFileSource).toHaveBeenCalledWith(
+        expectedLanguageId,
+        expectedParsedUris.map(uri => vscode.Uri.parse(uri))
+      );
+      expect(result.structuredContent).toEqual(
+        mcpSuccessResult('Remote file sources removed successfully', {
+          foldersRemoved: expectedParsedUris.length,
+        })
+      );
+    }
+  );
 
   it.each([
     {
@@ -91,6 +108,7 @@ describe('removeRemoteFileSources', () => {
         );
       },
       folderUris: ['file:///server/folder'],
+      languageId: 'python' as const,
       expectedMessage: 'Failed to remove remote file sources: Command failed',
     },
     {
@@ -101,15 +119,16 @@ describe('removeRemoteFileSources', () => {
         });
       },
       folderUris: ['invalid-uri'],
+      languageId: 'python' as const,
       expectedMessage: 'Failed to remove remote file sources: Invalid URI',
     },
   ])(
     'should handle $scenario',
-    async ({ mockSetup, folderUris, expectedMessage }) => {
+    async ({ mockSetup, folderUris, languageId, expectedMessage }) => {
       mockSetup();
 
       const tool = createRemoveRemoteFileSourcesTool();
-      const result = await tool.handler({ folderUris });
+      const result = await tool.handler({ folderUris, languageId });
 
       expect(result.structuredContent).toEqual(
         mcpErrorResult(expectedMessage, { folderUris })

--- a/src/mcp/tools/removeRemoteFileSources.spec.ts
+++ b/src/mcp/tools/removeRemoteFileSources.spec.ts
@@ -71,6 +71,7 @@ describe('removeRemoteFileSources', () => {
     const result = await tool.handler({ folderUris });
 
     expect(commands.execRemoveRemoteFileSource).toHaveBeenCalledWith(
+      'python',
       expectedParsedUris.map(uri => vscode.Uri.parse(uri))
     );
 

--- a/src/mcp/tools/removeRemoteFileSources.ts
+++ b/src/mcp/tools/removeRemoteFileSources.ts
@@ -44,7 +44,7 @@ export function createRemoveRemoteFileSourcesTool(): RemoveRemoteFileSourcesTool
         // Deduplicate URIs using URISet
         const uniqueUris = Array.from(new URISet(uris).values());
 
-        await execRemoveRemoteFileSource(uniqueUris);
+        await execRemoveRemoteFileSource('python', uniqueUris);
 
         return response.success('Remote file sources removed successfully', {
           foldersRemoved: uniqueUris.length,

--- a/src/mcp/tools/removeRemoteFileSources.ts
+++ b/src/mcp/tools/removeRemoteFileSources.ts
@@ -14,6 +14,11 @@ const spec = {
   description:
     'Remove one or more remote file source folders from the workspace.',
   inputSchema: {
+    languageId: z
+      .string()
+      .describe(
+        'The language of the remote file sources to remove: "python" or "groovy".'
+      ),
     folderUris: z
       .array(z.string())
       .describe('List of folder URIs to remove as remote file sources.'),
@@ -33,8 +38,18 @@ export function createRemoveRemoteFileSourcesTool(): RemoveRemoteFileSourcesTool
   return {
     name: 'removeRemoteFileSources',
     spec,
-    handler: async ({ folderUris }: HandlerArg): Promise<HandlerResult> => {
+    handler: async ({
+      folderUris,
+      languageId,
+    }: HandlerArg): Promise<HandlerResult> => {
       const response = new McpToolResponse();
+
+      // Validate languageId
+      if (languageId !== 'python' && languageId !== 'groovy') {
+        return response.error(
+          `Invalid languageId: '${languageId}'. Must be "python" or "groovy".`
+        );
+      }
 
       try {
         const uris = folderUris.map(uri =>
@@ -44,7 +59,7 @@ export function createRemoveRemoteFileSourcesTool(): RemoveRemoteFileSourcesTool
         // Deduplicate URIs using URISet
         const uniqueUris = Array.from(new URISet(uris).values());
 
-        await execRemoveRemoteFileSource('python', uniqueUris);
+        await execRemoveRemoteFileSource(languageId, uniqueUris);
 
         return response.success('Remote file sources removed successfully', {
           foldersRemoved: uniqueUris.length,

--- a/src/mcp/tools/runCodeFromUri.spec.ts
+++ b/src/mcp/tools/runCodeFromUri.spec.ts
@@ -6,6 +6,7 @@ import { createRunCodeFromUriTool } from './runCodeFromUri';
 import type {
   IDhcService,
   IServerManager,
+  GroovyPackageName,
   PythonModuleFullname,
   VariableDefintion,
 } from '../../types';
@@ -21,6 +22,7 @@ import { ConnectionNotFoundError } from '../../common';
 import { execRunCode } from '../../common/commands';
 import {
   createConnectionNotFoundHint,
+  createGroovyImportErrorHint,
   createPythonModuleImportErrorHint,
   getDiagnosticsErrors,
   type DiagnosticsError,
@@ -46,6 +48,7 @@ vi.mock('../utils/runCodeUtils', async () => {
   return {
     ...actual,
     createConnectionNotFoundHint: vi.fn(),
+    createGroovyImportErrorHint: vi.fn(),
     createPythonModuleImportErrorHint: vi.fn(),
     getDiagnosticsErrors: vi.fn(),
   };
@@ -57,6 +60,7 @@ const MOCK_HINT = {
 };
 
 const MOCK_URI_STRING = 'file:///path/to/file.py' as const;
+const MOCK_GROOVY_URI_STRING = 'file:///path/to/file.groovy' as const;
 
 const MOCK_DIAGNOSTIC_ERRORS: DiagnosticsError[] = [
   {
@@ -71,6 +75,19 @@ const MOCK_PANEL_URL_FORMAT = 'mock.panelUrlFormat' as const;
 const MOCK_DOCUMENT = {
   languageId: 'python',
 } as vscode.TextDocument;
+
+const MOCK_GROOVY_DOCUMENT = {
+  languageId: 'groovy',
+} as vscode.TextDocument;
+
+const MOCK_GROOVY_DIAGNOSTIC_ERRORS: DiagnosticsError[] = [
+  {
+    uri: MOCK_GROOVY_URI_STRING,
+    message:
+      'Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+    range: new vscode.Range(0, 0, 0, 0),
+  },
+];
 
 const MOCK_FILE_STAT = {
   type: vscode.FileType.File,
@@ -106,13 +123,30 @@ const MOCK_RUN_CODE_ERROR = {
   },
 } as unknown as DhcType.ide.CommandResult;
 
+const MOCK_GROOVY_RUN_CODE_ERROR = {
+  error: 'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+  changes: {
+    created: [MOCK_STR_VARIABLE],
+    updated: [],
+    removed: [],
+  },
+} as unknown as DhcType.ide.CommandResult;
+
 describe('runCodeFromUri tool', () => {
   const pythonDiagnostics: vscode.DiagnosticCollection =
     vscode.languages.createDiagnosticCollection('python');
 
+  const groovyDiagnostics: vscode.DiagnosticCollection =
+    vscode.languages.createDiagnosticCollection('groovy');
+
   const pythonWorkspace = {
     getUserFiles: vi.fn(),
   } as unknown as FilteredWorkspace<PythonModuleFullname>;
+
+  const groovyWorkspace = {
+    getChildNodes: vi.fn(),
+    iterateNodeTree: vi.fn(),
+  } as unknown as FilteredWorkspace<GroovyPackageName>;
 
   const serverManager = {
     getUriConnection: vi.fn(),
@@ -122,6 +156,7 @@ describe('runCodeFromUri tool', () => {
     // clear diagnostics before `clearAllMocks` since `clear` is actually a mock
     // and we also want to reset its call count
     pythonDiagnostics.clear();
+    groovyDiagnostics.clear();
 
     vi.clearAllMocks();
     fakeMcpToolTimings();
@@ -129,6 +164,8 @@ describe('runCodeFromUri tool', () => {
 
   it('should return correct tool spec', () => {
     const tool = createRunCodeFromUriTool({
+      groovyDiagnostics,
+      groovyWorkspace,
       pythonDiagnostics,
       pythonWorkspace,
       serverManager,
@@ -160,6 +197,8 @@ describe('runCodeFromUri tool', () => {
       });
 
       const tool = createRunCodeFromUriTool({
+        groovyDiagnostics,
+        groovyWorkspace,
         pythonDiagnostics,
         pythonWorkspace,
         serverManager,
@@ -223,6 +262,8 @@ describe('runCodeFromUri tool', () => {
         }
 
         const tool = createRunCodeFromUriTool({
+          groovyDiagnostics,
+          groovyWorkspace,
           pythonDiagnostics,
           pythonWorkspace,
           serverManager,
@@ -344,6 +385,8 @@ describe('runCodeFromUri tool', () => {
         );
 
         const tool = createRunCodeFromUriTool({
+          groovyDiagnostics,
+          groovyWorkspace,
           pythonDiagnostics,
           pythonWorkspace,
           serverManager,
@@ -358,6 +401,136 @@ describe('runCodeFromUri tool', () => {
           serverManager,
           connectionUrl: MOCK_CONNECTION_URL,
           languageId: 'python',
+        });
+        expect(result.structuredContent).toEqual(expected);
+      }
+    );
+  });
+
+  describe('groovy code execution', () => {
+    const mockGroovyConnection: IDhcService = createMockDhcService({
+      serverUrl: new URL('http://localhost:10000'),
+    });
+
+    beforeEach(() => {
+      vi.mocked(vscode.workspace.fs.stat).mockResolvedValue(MOCK_FILE_STAT);
+      vi.mocked(vscode.workspace.openTextDocument).mockResolvedValue(
+        MOCK_GROOVY_DOCUMENT
+      );
+      vi.mocked(serverManager.getUriConnection).mockReturnValue(
+        mockGroovyConnection
+      );
+      vi.mocked(getDiagnosticsErrors).mockReturnValue(
+        MOCK_GROOVY_DIAGNOSTIC_ERRORS
+      );
+
+      vi.mocked(getFirstConnectionOrCreate).mockResolvedValue({
+        success: true,
+        connection: mockGroovyConnection,
+        panelUrlFormat: MOCK_PANEL_URL_FORMAT,
+      });
+
+      vi.mocked(execRunCode).mockResolvedValue(null);
+    });
+
+    it.each([
+      {
+        name: 'execute Groovy code successfully',
+        cmdResult: MOCK_RUN_CODE_SUCCESS,
+        connectionUrl: MOCK_CONNECTION_URL.href,
+        expected: mcpSuccessResult('Code executed successfully', {
+          variables: [{ id: 'x', title: 'x', type: 'int', isNew: true }],
+          panelUrlFormat: MOCK_PANEL_URL_FORMAT,
+        }),
+      },
+      {
+        name: 'handle code execution failure with Groovy diagnostics and hint',
+        cmdResult: MOCK_GROOVY_RUN_CODE_ERROR,
+        connectionUrl: MOCK_CONNECTION_URL.href,
+        groovyHint: MOCK_HINT,
+        expected: mcpErrorResult(
+          `Code execution failed: ${MOCK_GROOVY_URI_STRING}: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest; [0:0]`,
+          {
+            languageId: 'groovy',
+            variables: [{ id: 'y', title: 'y', type: 'str', isNew: true }],
+            foundMatchingFolderUris: MOCK_HINT.foundMatchingFolderUris,
+          },
+          MOCK_HINT.hint
+        ),
+      },
+      {
+        name: 'handle code execution failure with Groovy diagnostics without hint',
+        cmdResult: MOCK_GROOVY_RUN_CODE_ERROR,
+        connectionUrl: MOCK_CONNECTION_URL.href,
+        groovyHint: undefined,
+        expected: mcpErrorResult(
+          `Code execution failed: ${MOCK_GROOVY_URI_STRING}: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest; [0:0]`,
+          {
+            languageId: 'groovy',
+            variables: [{ id: 'y', title: 'y', type: 'str', isNew: true }],
+          }
+        ),
+      },
+      {
+        name: 'handle ConnectionNotFoundError during Groovy code execution',
+        cmdResult: new ConnectionNotFoundError(MOCK_CONNECTION_URL),
+        connectionUrl: MOCK_CONNECTION_URL.href,
+        connectionNotFoundHint:
+          'No available connections supporting languageId groovy.',
+        expected: mcpErrorResult(
+          'Failed to execute code: No connection found for URL: http://localhost:10000/',
+          { languageId: 'groovy' },
+          'No available connections supporting languageId groovy.'
+        ),
+      },
+      {
+        name: 'handle general exceptions during Groovy execution',
+        cmdResult: new Error('Unexpected Groovy error'),
+        connectionUrl: MOCK_CONNECTION_URL.href,
+        expected: mcpErrorResult(
+          'Failed to execute code: Unexpected Groovy error',
+          { languageId: 'groovy' }
+        ),
+      },
+    ])(
+      'should $name',
+      async ({
+        cmdResult,
+        connectionUrl,
+        groovyHint,
+        connectionNotFoundHint,
+        expected,
+      }) => {
+        if (cmdResult instanceof Error) {
+          vi.mocked(execRunCode).mockRejectedValue(cmdResult);
+          if (connectionNotFoundHint) {
+            vi.mocked(createConnectionNotFoundHint).mockResolvedValue(
+              connectionNotFoundHint
+            );
+          }
+        } else {
+          vi.mocked(execRunCode).mockResolvedValue(cmdResult);
+        }
+
+        vi.mocked(createGroovyImportErrorHint).mockReturnValue(groovyHint);
+
+        const tool = createRunCodeFromUriTool({
+          groovyDiagnostics,
+          groovyWorkspace,
+          pythonDiagnostics,
+          pythonWorkspace,
+          serverManager,
+        });
+
+        const result = await tool.handler({
+          uri: MOCK_GROOVY_URI_STRING,
+          connectionUrl,
+        });
+
+        expect(getFirstConnectionOrCreate).toHaveBeenCalledWith({
+          serverManager,
+          connectionUrl: MOCK_CONNECTION_URL,
+          languageId: 'groovy',
         });
         expect(result.structuredContent).toEqual(expected);
       }

--- a/src/mcp/tools/runCodeFromUri.spec.ts
+++ b/src/mcp/tools/runCodeFromUri.spec.ts
@@ -123,8 +123,18 @@ const MOCK_RUN_CODE_ERROR = {
   },
 } as unknown as DhcType.ide.CommandResult;
 
+const MOCK_PYTHON_IMPORT_ERROR = {
+  error: "ModuleNotFoundError: No module named 'mypackage'",
+  changes: {
+    created: [MOCK_STR_VARIABLE],
+    updated: [],
+    removed: [],
+  },
+} as unknown as DhcType.ide.CommandResult;
+
 const MOCK_GROOVY_RUN_CODE_ERROR = {
-  error: 'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+  error:
+    'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
   changes: {
     created: [MOCK_STR_VARIABLE],
     updated: [],
@@ -341,6 +351,22 @@ describe('runCodeFromUri tool', () => {
         ),
       },
       {
+        name: 'handle code execution failure without Python diagnostics',
+        cmdResult: MOCK_PYTHON_IMPORT_ERROR,
+        connectionUrl: MOCK_CONNECTION_URL.href,
+        emptyDiagnostics: true,
+        pythonHint: MOCK_HINT,
+        expected: mcpErrorResult(
+          "Code execution failed: ModuleNotFoundError: No module named 'mypackage'",
+          {
+            languageId: 'python',
+            variables: [{ id: 'y', title: 'y', type: 'str', isNew: true }],
+            foundMatchingFolderUris: MOCK_HINT.foundMatchingFolderUris,
+          },
+          MOCK_HINT.hint
+        ),
+      },
+      {
         name: 'handle ConnectionNotFoundError during code execution',
         cmdResult: new ConnectionNotFoundError(MOCK_CONNECTION_URL),
         connectionUrl: MOCK_CONNECTION_URL.href,
@@ -366,6 +392,7 @@ describe('runCodeFromUri tool', () => {
         cmdResult,
         connectionUrl,
         pythonHint,
+        emptyDiagnostics,
         connectionNotFoundHint,
         expected,
       }) => {
@@ -378,6 +405,10 @@ describe('runCodeFromUri tool', () => {
           }
         } else {
           vi.mocked(execRunCode).mockResolvedValue(cmdResult);
+        }
+
+        if (emptyDiagnostics) {
+          vi.mocked(getDiagnosticsErrors).mockReturnValue([]);
         }
 
         vi.mocked(createPythonModuleImportErrorHint).mockReturnValue(
@@ -472,6 +503,22 @@ describe('runCodeFromUri tool', () => {
         ),
       },
       {
+        name: 'handle code execution failure without Groovy diagnostics',
+        cmdResult: MOCK_GROOVY_RUN_CODE_ERROR,
+        connectionUrl: MOCK_CONNECTION_URL.href,
+        emptyDiagnostics: true,
+        groovyHint: MOCK_HINT,
+        expected: mcpErrorResult(
+          'Code execution failed: RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+          {
+            languageId: 'groovy',
+            variables: [{ id: 'y', title: 'y', type: 'str', isNew: true }],
+            foundMatchingFolderUris: MOCK_HINT.foundMatchingFolderUris,
+          },
+          MOCK_HINT.hint
+        ),
+      },
+      {
         name: 'handle ConnectionNotFoundError during Groovy code execution',
         cmdResult: new ConnectionNotFoundError(MOCK_CONNECTION_URL),
         connectionUrl: MOCK_CONNECTION_URL.href,
@@ -498,6 +545,7 @@ describe('runCodeFromUri tool', () => {
         cmdResult,
         connectionUrl,
         groovyHint,
+        emptyDiagnostics,
         connectionNotFoundHint,
         expected,
       }) => {
@@ -510,6 +558,10 @@ describe('runCodeFromUri tool', () => {
           }
         } else {
           vi.mocked(execRunCode).mockResolvedValue(cmdResult);
+        }
+
+        if (emptyDiagnostics) {
+          vi.mocked(getDiagnosticsErrors).mockReturnValue([]);
         }
 
         vi.mocked(createGroovyImportErrorHint).mockReturnValue(groovyHint);

--- a/src/mcp/tools/runCodeFromUri.spec.ts
+++ b/src/mcp/tools/runCodeFromUri.spec.ts
@@ -6,6 +6,7 @@ import { createRunCodeFromUriTool } from './runCodeFromUri';
 import type {
   IDhcService,
   IServerManager,
+  PythonModuleFullname,
   VariableDefintion,
 } from '../../types';
 import type { FilteredWorkspace } from '../../services';
@@ -111,7 +112,7 @@ describe('runCodeFromUri tool', () => {
 
   const pythonWorkspace = {
     getUserFiles: vi.fn(),
-  } as unknown as FilteredWorkspace;
+  } as unknown as FilteredWorkspace<PythonModuleFullname>;
 
   const serverManager = {
     getUriConnection: vi.fn(),

--- a/src/mcp/tools/runCodeFromUri.ts
+++ b/src/mcp/tools/runCodeFromUri.ts
@@ -5,6 +5,7 @@ import type {
   McpTool,
   McpToolHandlerArg,
   McpToolHandlerResult,
+  PythonModuleFullname,
 } from '../../types';
 
 import type { IServerManager } from '../../types';
@@ -53,7 +54,7 @@ export function createRunCodeFromUriTool({
   serverManager,
 }: {
   pythonDiagnostics: vscode.DiagnosticCollection;
-  pythonWorkspace: FilteredWorkspace;
+  pythonWorkspace: FilteredWorkspace<PythonModuleFullname>;
   serverManager: IServerManager;
 }): RunCodeFromUriTool {
   return {

--- a/src/mcp/tools/runCodeFromUri.ts
+++ b/src/mcp/tools/runCodeFromUri.ts
@@ -5,6 +5,7 @@ import type {
   McpTool,
   McpToolHandlerArg,
   McpToolHandlerResult,
+  GroovyPackageName,
   PythonModuleFullname,
 } from '../../types';
 
@@ -49,10 +50,14 @@ type HandlerResult = McpToolHandlerResult<Spec>;
 type RunCodeFromUriTool = McpTool<Spec>;
 
 export function createRunCodeFromUriTool({
+  groovyDiagnostics,
+  groovyWorkspace,
   pythonDiagnostics,
   pythonWorkspace,
   serverManager,
 }: {
+  groovyDiagnostics: vscode.DiagnosticCollection;
+  groovyWorkspace: FilteredWorkspace<GroovyPackageName>;
   pythonDiagnostics: vscode.DiagnosticCollection;
   pythonWorkspace: FilteredWorkspace<PythonModuleFullname>;
   serverManager: IServerManager;

--- a/src/mcp/tools/runCodeFromUri.ts
+++ b/src/mcp/tools/runCodeFromUri.ts
@@ -16,6 +16,7 @@ import {
   runCodeOutputSchema,
   extractVariables,
   getDiagnosticsErrors,
+  createGroovyImportErrorHint,
   createPythonModuleImportErrorHint,
   formatDiagnosticError,
   createConnectionNotFoundHint,
@@ -132,9 +133,6 @@ export function createRunCodeFromUriTool({
             | { hint: string; foundMatchingFolderUris: string[] }
             | undefined;
 
-          // TODO: We currently only parse Python errors into a
-          // `vscode.DiagnosticsCollection`, but we should be able to improve
-          // error hints for Groovy once DH-21363 is implemented.
           if (languageId === 'python') {
             const executedConnection = serverManager.getUriConnection(
               parsedUriResult.value
@@ -149,6 +147,21 @@ export function createRunCodeFromUriTool({
               pythonErrors,
               executedConnection,
               pythonWorkspace
+            );
+          } else if (languageId === 'groovy') {
+            const executedConnection = serverManager.getUriConnection(
+              parsedUriResult.value
+            );
+            assertDefined(executedConnection, 'executedConnection');
+
+            const groovyErrors = getDiagnosticsErrors(groovyDiagnostics);
+
+            errorMsg = groovyErrors.map(formatDiagnosticError).join('\n');
+
+            hintResult = createGroovyImportErrorHint(
+              groovyErrors,
+              executedConnection,
+              groovyWorkspace
             );
           }
 

--- a/src/mcp/tools/runCodeFromUri.ts
+++ b/src/mcp/tools/runCodeFromUri.ts
@@ -130,7 +130,7 @@ export function createRunCodeFromUriTool({
         if (result?.error) {
           let errorMsg = result.error;
           let hintResult:
-            | { hint: string; foundMatchingFolderUris: string[] }
+            | { hint: string; foundMatchingFolderUris?: string[] }
             | undefined;
 
           if (languageId === 'python' || languageId === 'groovy') {

--- a/src/mcp/tools/runCodeFromUri.ts
+++ b/src/mcp/tools/runCodeFromUri.ts
@@ -133,42 +133,34 @@ export function createRunCodeFromUriTool({
             | { hint: string; foundMatchingFolderUris: string[] }
             | undefined;
 
-          if (languageId === 'python') {
+          if (languageId === 'python' || languageId === 'groovy') {
             const executedConnection = serverManager.getUriConnection(
               parsedUriResult.value
             );
             assertDefined(executedConnection, 'executedConnection');
 
-            const pythonErrors = getDiagnosticsErrors(pythonDiagnostics);
+            const errors = getDiagnosticsErrors(
+              languageId === 'python' ? pythonDiagnostics : groovyDiagnostics
+            );
 
-            if (pythonErrors.length > 0) {
-              errorMsg = pythonErrors.map(formatDiagnosticError).join('\n');
+            if (errors.length > 0) {
+              errorMsg = errors.map(formatDiagnosticError).join('\n');
             }
 
-            hintResult = createPythonModuleImportErrorHint(
-              pythonErrors,
-              executedConnection,
-              pythonWorkspace,
-              result.error
-            );
-          } else if (languageId === 'groovy') {
-            const executedConnection = serverManager.getUriConnection(
-              parsedUriResult.value
-            );
-            assertDefined(executedConnection, 'executedConnection');
-
-            const groovyErrors = getDiagnosticsErrors(groovyDiagnostics);
-
-            if (groovyErrors.length > 0) {
-              errorMsg = groovyErrors.map(formatDiagnosticError).join('\n');
-            }
-
-            hintResult = createGroovyImportErrorHint(
-              groovyErrors,
-              executedConnection,
-              groovyWorkspace,
-              result.error
-            );
+            hintResult =
+              languageId === 'python'
+                ? createPythonModuleImportErrorHint(
+                    errors,
+                    executedConnection,
+                    pythonWorkspace,
+                    result.error
+                  )
+                : createGroovyImportErrorHint(
+                    errors,
+                    executedConnection,
+                    groovyWorkspace,
+                    result.error
+                  );
           }
 
           const { hint, foundMatchingFolderUris } = hintResult ?? {};

--- a/src/mcp/tools/runCodeFromUri.ts
+++ b/src/mcp/tools/runCodeFromUri.ts
@@ -141,12 +141,15 @@ export function createRunCodeFromUriTool({
 
             const pythonErrors = getDiagnosticsErrors(pythonDiagnostics);
 
-            errorMsg = pythonErrors.map(formatDiagnosticError).join('\n');
+            if (pythonErrors.length > 0) {
+              errorMsg = pythonErrors.map(formatDiagnosticError).join('\n');
+            }
 
             hintResult = createPythonModuleImportErrorHint(
               pythonErrors,
               executedConnection,
-              pythonWorkspace
+              pythonWorkspace,
+              result.error
             );
           } else if (languageId === 'groovy') {
             const executedConnection = serverManager.getUriConnection(
@@ -156,12 +159,15 @@ export function createRunCodeFromUriTool({
 
             const groovyErrors = getDiagnosticsErrors(groovyDiagnostics);
 
-            errorMsg = groovyErrors.map(formatDiagnosticError).join('\n');
+            if (groovyErrors.length > 0) {
+              errorMsg = groovyErrors.map(formatDiagnosticError).join('\n');
+            }
 
             hintResult = createGroovyImportErrorHint(
               groovyErrors,
               executedConnection,
-              groovyWorkspace
+              groovyWorkspace,
+              result.error
             );
           }
 

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -530,7 +530,6 @@ describe('createPythonModuleImportErrorHint', () => {
       workspaces: [{ nodes: [wkspRoot, pandasFolder] }],
       expected: {
         hint: `The Python remote file source plugin is not installed. Install it with 'pip install deephaven-plugin-python-remote-file-source' to enable importing workspace packages.`,
-        foundMatchingFolderUris: [],
       },
     },
     {
@@ -740,7 +739,6 @@ describe('createGroovyImportErrorHint', () => {
       workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
       expected: {
         hint: `The Groovy remote file source plugin is not installed. Install it to enable importing workspace packages.`,
-        foundMatchingFolderUris: [],
       },
     },
     {

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -126,7 +126,9 @@ function createGroovyWorkspace(
 
   vi.mocked(workspace.getChildNodes).mockImplementation(
     (parentUri: vscode.Uri | null) => {
-      if (parentUri == null) return roots;
+      if (parentUri == null) {
+        return roots;
+      }
       return childMap.get(parentUri) ?? [];
     }
   );

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -680,6 +680,10 @@ describe('createGroovyImportErrorHint', () => {
     'file:///workspace/other'
   );
 
+  const wksp2OtherFolder: RemoteImportSourceTreeFolderElement = groovyFolder(
+    'file:///workspace2/other'
+  );
+
   const wksp2Root: FilteredWorkspaceRootNode = {
     uri: vscode.Uri.parse('file:///workspace2'),
     name: 'workspace2',
@@ -687,21 +691,21 @@ describe('createGroovyImportErrorHint', () => {
     type: 'workspaceRootFolder',
   };
 
-  const wksp2OtherFolder: RemoteImportSourceTreeFolderElement = groovyFolder(
-    'file:///workspace2/other'
-  );
-
-  const mockWkspSpec: MockWorkspaceSpec = {
-    nodes: [wkspRoot, package3Folder, subpackage1Folder],
-    nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
-      vscode.Uri,
-      FilteredWorkspaceNode[],
-    ][],
+  const WKSP_PACKAGE3: MockWorkspaceSpec = {
+    nodes: [wkspRoot, package3Folder],
   };
 
-  const mockWkspOtherSpec: MockWorkspaceSpec = {
+  const WKSP_OTHER: MockWorkspaceSpec = {
+    nodes: [wkspRoot, otherFolder],
+  };
+
+  const WKSP_PACKAGE3_SUBPACKAGE1: MockWorkspaceSpec = {
+    nodes: [wkspRoot, package3Folder, subpackage1Folder],
+    nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
+  };
+
+  const WKSP2_OTHER: MockWorkspaceSpec = {
     nodes: [wksp2Root, wksp2OtherFolder],
-    nodeChildren: [],
   };
 
   const PACKAGE3_SUBPACKAGE1_MULTICLASSTEST =
@@ -717,29 +721,23 @@ describe('createGroovyImportErrorHint', () => {
   it.each([
     {
       name: 'return undefined when no import errors exist',
-      errors: diagnosticError('Some non-import related error'),
+      errors: diagnosticError('non-import related error'),
       hasPlugin: false,
-      workspaces: {
-        nodes: [wkspRoot, package3Folder],
-        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
-      },
+      workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
       expected: undefined,
     },
     {
       name: 'return undefined when no import errors exist even with plugin',
-      errors: diagnosticError('Some non-import related error'),
+      errors: diagnosticError('non-import related error'),
       hasPlugin: true,
-      workspaces: {
-        nodes: [wkspRoot, package3Folder],
-        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
-      },
+      workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
       expected: undefined,
     },
     {
       name: 'suggest installing plugin when not installed',
       errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: false,
-      workspaces: mockWkspSpec,
+      workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
       expected: {
         hint: `The Groovy remote file source plugin is not installed. Install it to enable importing workspace packages.`,
         foundMatchingFolderUris: [],
@@ -749,7 +747,7 @@ describe('createGroovyImportErrorHint', () => {
       name: 'return matching folder when plugin installed and subpackage folder exists',
       errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: true,
-      workspaces: mockWkspSpec,
+      workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
       expected: {
         hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [package3Folder.uri.toString()],
@@ -759,13 +757,7 @@ describe('createGroovyImportErrorHint', () => {
       name: 'not include folder when subpackage folder does not exist',
       errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: true,
-      workspaces: {
-        nodes: [wkspRoot, package3Folder],
-        nodeChildren: [[package3Folder.uri, []]] as [
-          vscode.Uri,
-          FilteredWorkspaceNode[],
-        ][],
-      },
+      workspaces: WKSP_PACKAGE3,
       expected: {
         hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [],
@@ -775,10 +767,7 @@ describe('createGroovyImportErrorHint', () => {
       name: 'include folder when import has only 2 parts (no subpackage verification needed)',
       errors: missingImportError(PACKAGE3_MYCLASS),
       hasPlugin: true,
-      workspaces: {
-        nodes: [wkspRoot, package3Folder],
-        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
-      },
+      workspaces: WKSP_PACKAGE3,
       expected: {
         hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [package3Folder.uri.toString()],
@@ -788,10 +777,7 @@ describe('createGroovyImportErrorHint', () => {
       name: 'return empty foundMatchingFolderUris when no matching folder exists in workspace',
       errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: true,
-      workspaces: {
-        nodes: [wkspRoot, otherFolder],
-        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
-      },
+      workspaces: WKSP_OTHER,
       expected: {
         hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [],
@@ -801,7 +787,7 @@ describe('createGroovyImportErrorHint', () => {
       name: 'handle "unable to resolve class" error format',
       errors: unableToResolveClassError('package3.subpackage1.MultiClassTest'),
       hasPlugin: true,
-      workspaces: mockWkspSpec,
+      workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
       expected: {
         hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [package3Folder.uri.toString()],
@@ -814,7 +800,7 @@ describe('createGroovyImportErrorHint', () => {
         missingImportError(OTHER_SOMECLASS),
       ],
       hasPlugin: true,
-      workspaces: [mockWkspSpec, mockWkspOtherSpec],
+      workspaces: [WKSP_PACKAGE3_SUBPACKAGE1, WKSP2_OTHER],
       expected: {
         hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [
@@ -823,77 +809,51 @@ describe('createGroovyImportErrorHint', () => {
         ],
       },
     },
-  ])('should $name', ({ errors, hasPlugin, workspaces, expected }) => {
-    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>(
-      ...(Array.isArray(workspaces) ? workspaces : [workspaces])
-    );
+    {
+      name: 'parse raw error message when diagnostics are empty',
+      errors: [],
+      rawErrorMessage:
+        'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+      hasPlugin: true,
+      workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
+      expected: {
+        hint: ADD_FOLDER_HINT,
+        foundMatchingFolderUris: [package3Folder.uri.toString()],
+      },
+    },
+    {
+      name: 'parse "unable to resolve class" raw error message when diagnostics are empty',
+      errors: [],
+      rawErrorMessage:
+        'GroovyExceptionWrapper: startup failed:\nScript_1: 42: unable to resolve class package3.subpackage1.MultiClassTest\n @ line 42, column 1.\n   import package3.subpackage1.MultiClassTest',
+      hasPlugin: true,
+      workspaces: WKSP_PACKAGE3_SUBPACKAGE1,
+      expected: {
+        hint: ADD_FOLDER_HINT,
+        foundMatchingFolderUris: [package3Folder.uri.toString()],
+      },
+    },
+  ])(
+    'should $name',
+    ({ errors, rawErrorMessage, hasPlugin, workspaces, expected }) => {
+      const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>(
+        ...(Array.isArray(workspaces) ? workspaces : [workspaces])
+      );
 
-    vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
+      vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
 
-    const connection = {
-      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(hasPlugin),
-    } as unknown as ConnectionState;
+      const connection = {
+        hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(hasPlugin),
+      } as unknown as ConnectionState;
 
-    const hint = createGroovyImportErrorHint(
-      Array.isArray(errors) ? errors : [errors],
-      connection,
-      groovyWorkspace
-    );
+      const hint = createGroovyImportErrorHint(
+        Array.isArray(errors) ? errors : [errors],
+        connection,
+        groovyWorkspace,
+        rawErrorMessage
+      );
 
-    expect(hint).toEqual(expected);
-  });
-
-  it('should parse raw error message when diagnostics are empty', () => {
-    const groovyWorkspace =
-      mockFilteredWorkspace<GroovyPackageName>(mockWkspSpec);
-
-    vi.mocked(isInstanceOf).mockReturnValue(true);
-
-    const connection = {
-      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
-    } as unknown as ConnectionState;
-
-    const rawErrorMessage =
-      'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;';
-
-    const hint = createGroovyImportErrorHint(
-      [], // empty diagnostics
-      connection,
-      groovyWorkspace,
-      rawErrorMessage
-    );
-
-    expect(hint).toEqual({
-      hint: ADD_FOLDER_HINT,
-      foundMatchingFolderUris: [package3Folder.uri.toString()],
-    });
-  });
-
-  it('should parse "unable to resolve class" raw error message when diagnostics are empty', () => {
-    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>({
-      nodes: [wkspRoot, package3Folder, subpackage1Folder],
-      nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
-    });
-
-    vi.mocked(isInstanceOf).mockReturnValue(true);
-
-    const connection = {
-      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
-    } as unknown as ConnectionState;
-
-    const rawErrorMessage =
-      'GroovyExceptionWrapper: startup failed:\nScript_1: 42: unable to resolve class package3.subpackage1.MultiClassTest\n @ line 42, column 1.\n   import package3.subpackage1.MultiClassTest';
-
-    const hint = createGroovyImportErrorHint(
-      [], // empty diagnostics
-      connection,
-      groovyWorkspace,
-      rawErrorMessage
-    );
-
-    expect(hint).toEqual({
-      hint: ADD_FOLDER_HINT,
-      foundMatchingFolderUris: [package3Folder.uri.toString()],
-    });
-  });
+      expect(hint).toEqual(expected);
+    }
+  );
 });

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -107,22 +107,24 @@ function createDiagnosticCollection(
  *     entries when parentUri matches a key, otherwise empty array
  *   - iterateNodeTree: Returns all nodes for the matching root
  */
-function createGroovyWorkspace(
+function mockFilteredWorkspace<
+  TModuleName extends PythonModuleFullname | GroovyPackageName,
+>(
   ...workspaces: Array<{
     nodes: (FilteredWorkspaceRootNode | FilteredWorkspaceNode)[];
     nodeChildren?: [vscode.Uri, FilteredWorkspaceNode[]][];
   }>
-): FilteredWorkspace<GroovyPackageName> {
+): FilteredWorkspace<TModuleName> {
   const roots = workspaces.map(ws => ws.nodes[0] as FilteredWorkspaceRootNode);
 
   const nodeMap = new URIMap(workspaces.map(ws => [ws.nodes[0].uri, ws.nodes]));
 
   const childMap = new URIMap(workspaces.flatMap(ws => ws.nodeChildren ?? []));
 
-  const workspace: FilteredWorkspace<GroovyPackageName> = {
+  const workspace: FilteredWorkspace<TModuleName> = {
     getChildNodes: vi.fn(),
     iterateNodeTree: vi.fn(),
-  } as unknown as FilteredWorkspace<GroovyPackageName>;
+  } as unknown as FilteredWorkspace<TModuleName>;
 
   vi.mocked(workspace.getChildNodes).mockImplementation(
     (parentUri: vscode.Uri | null) => {
@@ -131,28 +133,6 @@ function createGroovyWorkspace(
       }
       return childMap.get(parentUri) ?? [];
     }
-  );
-  vi.mocked(workspace.iterateNodeTree).mockImplementation(
-    (rootUri: vscode.Uri) => nodeMap.get(rootUri) ?? []
-  );
-
-  return workspace;
-}
-
-function createPythonWorkspace(
-  ...workspaces: Array<(FilteredWorkspaceRootNode | FilteredWorkspaceNode)[]>
-): FilteredWorkspace<PythonModuleFullname> {
-  const roots = workspaces.map(nodes => nodes[0] as FilteredWorkspaceRootNode);
-
-  const nodeMap = new URIMap(workspaces.map(nodes => [nodes[0].uri, nodes]));
-
-  const workspace: FilteredWorkspace<PythonModuleFullname> = {
-    getChildNodes: vi.fn(),
-    iterateNodeTree: vi.fn(),
-  } as unknown as FilteredWorkspace<PythonModuleFullname>;
-
-  vi.mocked(workspace.getChildNodes).mockImplementation(
-    (parentUri: vscode.Uri | null) => (parentUri == null ? roots : [])
   );
   vi.mocked(workspace.iterateNodeTree).mockImplementation(
     (rootUri: vscode.Uri) => nodeMap.get(rootUri) ?? []
@@ -540,21 +520,21 @@ describe('createPythonModuleImportErrorHint', () => {
       name: 'return undefined when no import errors exist',
       errors: DIAGNOSTIC_ERRORS_WITHOUT_MODULE_IMPORT,
       hasPlugin: false,
-      workspaces: [[wkspRoot, pandasFolder]],
+      workspaces: [{ nodes: [wkspRoot, pandasFolder] }],
       expected: undefined,
     },
     {
       name: 'return undefined when no import errors exist even with plugin',
       errors: DIAGNOSTIC_ERRORS_WITHOUT_MODULE_IMPORT,
       hasPlugin: true,
-      workspaces: [[wkspRoot, pandasFolder]],
+      workspaces: [{ nodes: [wkspRoot, pandasFolder] }],
       expected: undefined,
     },
     {
       name: 'suggest installing plugin when not installed',
       errors: DIAGNOSTIC_ERRORS_WITH_MODULE_IMPORT,
       hasPlugin: false,
-      workspaces: [[wkspRoot, pandasFolder]],
+      workspaces: [{ nodes: [wkspRoot, pandasFolder] }],
       expected: {
         hint: `The Python remote file source plugin is not installed. Install it with 'pip install deephaven-plugin-python-remote-file-source' to enable importing workspace packages.`,
         foundMatchingFolderUris: [],
@@ -564,7 +544,7 @@ describe('createPythonModuleImportErrorHint', () => {
       name: 'suggest workspace folders when plugin is installed and folders exist',
       errors: DIAGNOSTIC_ERRORS_WITH_MODULE_IMPORT,
       hasPlugin: true,
-      workspaces: [[wkspRoot, pandasFolder]],
+      workspaces: [{ nodes: [wkspRoot, pandasFolder] }],
       expected: {
         hint: `If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris. DO NOT create __init__.py files without first attempting to configure remote file sources.`,
         foundMatchingFolderUris: [pandasFolder.uri.toString()],
@@ -574,7 +554,7 @@ describe('createPythonModuleImportErrorHint', () => {
       name: 'handle multiple import errors and find matching folders',
       errors: DIAGNOSTIC_ERRORS_WITH_MULTIPLE_MODULE_IMPORTS,
       hasPlugin: true,
-      workspaces: [[wkspRoot, pandasFolder, numpyFolder]],
+      workspaces: [{ nodes: [wkspRoot, pandasFolder, numpyFolder] }],
       expected: {
         hint: `If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris. DO NOT create __init__.py files without first attempting to configure remote file sources.`,
         foundMatchingFolderUris: [
@@ -587,7 +567,7 @@ describe('createPythonModuleImportErrorHint', () => {
       name: 'not include file nodes, only folders',
       errors: DIAGNOSTIC_ERRORS_WITH_MODULE_IMPORT,
       hasPlugin: true,
-      workspaces: [[wkspRoot, pandasFile]],
+      workspaces: [{ nodes: [wkspRoot, pandasFile] }],
       expected: {
         hint: `If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris. DO NOT create __init__.py files without first attempting to configure remote file sources.`,
         foundMatchingFolderUris: [],
@@ -598,8 +578,8 @@ describe('createPythonModuleImportErrorHint', () => {
       errors: DIAGNOSTIC_ERRORS_WITH_MULTIPLE_MODULE_IMPORTS,
       hasPlugin: true,
       workspaces: [
-        [wkspRoot, pandasFolder],
-        [wksp2Root, wksp2NumpyFolder],
+        { nodes: [wkspRoot, pandasFolder] },
+        { nodes: [wksp2Root, wksp2NumpyFolder] },
       ],
       expected: {
         hint: `If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris. DO NOT create __init__.py files without first attempting to configure remote file sources.`,
@@ -610,7 +590,9 @@ describe('createPythonModuleImportErrorHint', () => {
       },
     },
   ])('should $name', async ({ errors, hasPlugin, workspaces, expected }) => {
-    const pythonWorkspace = createPythonWorkspace(...workspaces);
+    const pythonWorkspace = mockFilteredWorkspace<PythonModuleFullname>(
+      ...workspaces
+    );
 
     vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
 
@@ -628,7 +610,9 @@ describe('createPythonModuleImportErrorHint', () => {
   });
 
   it('should parse raw error message when diagnostics are empty', () => {
-    const pythonWorkspace = createPythonWorkspace([wkspRoot, pandasFolder]);
+    const pythonWorkspace = mockFilteredWorkspace<PythonModuleFullname>({
+      nodes: [wkspRoot, pandasFolder],
+    });
 
     vi.mocked(isInstanceOf).mockReturnValue(true);
 
@@ -862,7 +846,7 @@ describe('createGroovyImportErrorHint', () => {
       },
     },
   ])('should $name', ({ errors, hasPlugin, workspace, expected }) => {
-    const groovyWorkspace = createGroovyWorkspace(workspace);
+    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>(workspace);
 
     vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
 
@@ -880,7 +864,7 @@ describe('createGroovyImportErrorHint', () => {
   });
 
   it('should handle multiple workspace roots with matching folders', () => {
-    const groovyWorkspace = createGroovyWorkspace(
+    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>(
       {
         nodes: [wkspRoot, package3Folder, subpackage1Folder],
         nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
@@ -913,7 +897,7 @@ describe('createGroovyImportErrorHint', () => {
   });
 
   it('should parse raw error message when diagnostics are empty', () => {
-    const groovyWorkspace = createGroovyWorkspace({
+    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>({
       nodes: [wkspRoot, package3Folder, subpackage1Folder],
       nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
     });
@@ -941,7 +925,7 @@ describe('createGroovyImportErrorHint', () => {
   });
 
   it('should parse "unable to resolve class" raw error message when diagnostics are empty', () => {
-    const groovyWorkspace = createGroovyWorkspace({
+    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>({
       nodes: [wkspRoot, package3Folder, subpackage1Folder],
       nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
     });

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -711,21 +711,13 @@ describe('createGroovyImportErrorHint', () => {
 
   const OTHER_SOMECLASS = 'other.SomeClass' as const;
 
-  const GROOVY_NON_IMPORT_ERROR: DiagnosticsError[] = [
-    diagnosticError('Some unrelated Groovy error'),
-  ];
-
-  const GROOVY_UNABLE_TO_RESOLVE_CLASS_ERROR: DiagnosticsError[] = [
-    unableToResolveClassError('package3.subpackage1.MultiClassTest'),
-  ];
-
   const ADD_FOLDER_HINT =
     'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.' as const;
 
   it.each([
     {
       name: 'return undefined when no import errors exist',
-      errors: GROOVY_NON_IMPORT_ERROR,
+      errors: diagnosticError('Some unrelated Groovy error'),
       hasPlugin: false,
       workspaces: {
         nodes: [wkspRoot, package3Folder],
@@ -735,7 +727,7 @@ describe('createGroovyImportErrorHint', () => {
     },
     {
       name: 'return undefined when no import errors exist even with plugin',
-      errors: GROOVY_NON_IMPORT_ERROR,
+      errors: diagnosticError('Some unrelated Groovy error'),
       hasPlugin: true,
       workspaces: {
         nodes: [wkspRoot, package3Folder],
@@ -807,7 +799,7 @@ describe('createGroovyImportErrorHint', () => {
     },
     {
       name: 'handle "unable to resolve class" error format',
-      errors: GROOVY_UNABLE_TO_RESOLVE_CLASS_ERROR,
+      errors: unableToResolveClassError('package3.subpackage1.MultiClassTest'),
       hasPlugin: true,
       workspaces: mockWkspSpec,
       expected: {

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -113,17 +113,11 @@ function createGroovyWorkspace(
     nodeChildren?: [vscode.Uri, FilteredWorkspaceNode[]][];
   }>
 ): FilteredWorkspace<GroovyPackageName> {
-  const roots = workspaces.map(
-    ws => ws.nodes[0] as FilteredWorkspaceRootNode
-  );
+  const roots = workspaces.map(ws => ws.nodes[0] as FilteredWorkspaceRootNode);
 
-  const nodeMap = new URIMap(
-    workspaces.map(ws => [ws.nodes[0].uri, ws.nodes])
-  );
+  const nodeMap = new URIMap(workspaces.map(ws => [ws.nodes[0].uri, ws.nodes]));
 
-  const childMap = new URIMap(
-    workspaces.flatMap(ws => ws.nodeChildren ?? [])
-  );
+  const childMap = new URIMap(workspaces.flatMap(ws => ws.nodeChildren ?? []));
 
   const workspace: FilteredWorkspace<GroovyPackageName> = {
     getChildNodes: vi.fn(),
@@ -630,6 +624,31 @@ describe('createPythonModuleImportErrorHint', () => {
 
     expect(hint).toEqual(expected);
   });
+
+  it('should parse raw error message when diagnostics are empty', () => {
+    const pythonWorkspace = createPythonWorkspace([wkspRoot, pandasFolder]);
+
+    vi.mocked(isInstanceOf).mockReturnValue(true);
+
+    const connection = {
+      hasRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
+      hasPythonRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
+    } as unknown as ConnectionState;
+
+    const rawErrorMessage = "ModuleNotFoundError: No module named 'pandas'";
+
+    const hint = createPythonModuleImportErrorHint(
+      [], // empty diagnostics
+      connection,
+      pythonWorkspace,
+      rawErrorMessage
+    );
+
+    expect(hint).toEqual({
+      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris. DO NOT create __init__.py files without first attempting to configure remote file sources.',
+      foundMatchingFolderUris: [pandasFolder.uri.toString()],
+    });
+  });
 });
 
 describe('createGroovyImportErrorHint', () => {
@@ -720,6 +739,15 @@ describe('createGroovyImportErrorHint', () => {
     },
   ];
 
+  const GROOVY_UNABLE_TO_RESOLVE_CLASS_ERROR: DiagnosticsError[] = [
+    {
+      uri: MOCK_URI_STRING,
+      message:
+        'unable to resolve class package3.subpackage1.MultiClassTest\n @ line 42, column 1.\n   import package3.subpackage1.MultiClassTest',
+      range: new vscode.Range(0, 0, 0, 0),
+    },
+  ];
+
   it.each([
     {
       name: 'return undefined when no import errors exist',
@@ -747,9 +775,10 @@ describe('createGroovyImportErrorHint', () => {
       hasPlugin: false,
       workspace: {
         nodes: [wkspRoot, package3Folder, subpackage1Folder],
-        nodeChildren: [
-          [package3Folder.uri, [subpackage1Folder]],
-        ] as [vscode.Uri, FilteredWorkspaceNode[]][],
+        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
+          vscode.Uri,
+          FilteredWorkspaceNode[],
+        ][],
       },
       expected: {
         hint: `The Groovy remote file source plugin is not installed. Install it to enable importing workspace packages.`,
@@ -762,12 +791,13 @@ describe('createGroovyImportErrorHint', () => {
       hasPlugin: true,
       workspace: {
         nodes: [wkspRoot, package3Folder, subpackage1Folder],
-        nodeChildren: [
-          [package3Folder.uri, [subpackage1Folder]],
-        ] as [vscode.Uri, FilteredWorkspaceNode[]][],
+        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
+          vscode.Uri,
+          FilteredWorkspaceNode[],
+        ][],
       },
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
         foundMatchingFolderUris: [package3Folder.uri.toString()],
       },
     },
@@ -777,12 +807,13 @@ describe('createGroovyImportErrorHint', () => {
       hasPlugin: true,
       workspace: {
         nodes: [wkspRoot, package3Folder],
-        nodeChildren: [
-          [package3Folder.uri, []],
-        ] as [vscode.Uri, FilteredWorkspaceNode[]][],
+        nodeChildren: [[package3Folder.uri, []]] as [
+          vscode.Uri,
+          FilteredWorkspaceNode[],
+        ][],
       },
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
         foundMatchingFolderUris: [],
       },
     },
@@ -795,7 +826,7 @@ describe('createGroovyImportErrorHint', () => {
         nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
       },
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
         foundMatchingFolderUris: [package3Folder.uri.toString()],
       },
     },
@@ -808,30 +839,43 @@ describe('createGroovyImportErrorHint', () => {
         nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
       },
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
         foundMatchingFolderUris: [],
       },
     },
-  ])(
-    'should $name',
-    ({ errors, hasPlugin, workspace, expected }) => {
-      const groovyWorkspace = createGroovyWorkspace(workspace);
+    {
+      name: 'handle "unable to resolve class" error format',
+      errors: GROOVY_UNABLE_TO_RESOLVE_CLASS_ERROR,
+      hasPlugin: true,
+      workspace: {
+        nodes: [wkspRoot, package3Folder, subpackage1Folder],
+        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
+          vscode.Uri,
+          FilteredWorkspaceNode[],
+        ][],
+      },
+      expected: {
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        foundMatchingFolderUris: [package3Folder.uri.toString()],
+      },
+    },
+  ])('should $name', ({ errors, hasPlugin, workspace, expected }) => {
+    const groovyWorkspace = createGroovyWorkspace(workspace);
 
-      vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
+    vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
 
-      const connection = {
-        hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(hasPlugin),
-      } as unknown as ConnectionState;
+    const connection = {
+      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(hasPlugin),
+    } as unknown as ConnectionState;
 
-      const hint = createGroovyImportErrorHint(
-        errors,
-        connection,
-        groovyWorkspace
-      );
+    const hint = createGroovyImportErrorHint(
+      errors,
+      connection,
+      groovyWorkspace
+    );
 
-      expect(hint).toEqual(expected);
-    }
-  );
+    expect(hint).toEqual(expected);
+  });
 
   it('should handle multiple workspace roots with matching folders', () => {
     const groovyWorkspace = createGroovyWorkspace(
@@ -858,11 +902,67 @@ describe('createGroovyImportErrorHint', () => {
     );
 
     expect(hint).toEqual({
-      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
       foundMatchingFolderUris: [
         package3Folder.uri.toString(),
         wksp2NumpyFolder.uri.toString(),
       ],
+    });
+  });
+
+  it('should parse raw error message when diagnostics are empty', () => {
+    const groovyWorkspace = createGroovyWorkspace({
+      nodes: [wkspRoot, package3Folder, subpackage1Folder],
+      nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
+    });
+
+    vi.mocked(isInstanceOf).mockReturnValue(true);
+
+    const connection = {
+      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
+    } as unknown as ConnectionState;
+
+    const rawErrorMessage =
+      'RuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;';
+
+    const hint = createGroovyImportErrorHint(
+      [], // empty diagnostics
+      connection,
+      groovyWorkspace,
+      rawErrorMessage
+    );
+
+    expect(hint).toEqual({
+      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+      foundMatchingFolderUris: [package3Folder.uri.toString()],
+    });
+  });
+
+  it('should parse "unable to resolve class" raw error message when diagnostics are empty', () => {
+    const groovyWorkspace = createGroovyWorkspace({
+      nodes: [wkspRoot, package3Folder, subpackage1Folder],
+      nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
+    });
+
+    vi.mocked(isInstanceOf).mockReturnValue(true);
+
+    const connection = {
+      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
+    } as unknown as ConnectionState;
+
+    const rawErrorMessage =
+      'GroovyExceptionWrapper: startup failed:\nScript_1: 42: unable to resolve class package3.subpackage1.MultiClassTest\n @ line 42, column 1.\n   import package3.subpackage1.MultiClassTest';
+
+    const hint = createGroovyImportErrorHint(
+      [], // empty diagnostics
+      connection,
+      groovyWorkspace,
+      rawErrorMessage
+    );
+
+    expect(hint).toEqual({
+      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+      foundMatchingFolderUris: [package3Folder.uri.toString()],
     });
   });
 });

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -85,23 +85,21 @@ function createDiagnosticCollection(
 }
 
 /**
- * Creates a mock FilteredWorkspace for testing with support for multiple root nodes.
- * Each workspace argument represents a root node and its children.
- *
- * @param workspaces - Rest parameter where each array contains [root, ...children].
- *   The first element is the root node, remaining elements are its children.
- * @returns A mocked FilteredWorkspace with:
- *   - getChildNodes: Returns roots when parentUri is null, empty array otherwise
- *   - iterateNodeTree: Returns children for the matching root, empty array if not found
+ * Type representing a mock workspace specification for testing.
+ * Each workspace represents a root node and its descendants.
  */
+type MockWorkspaceSpec = {
+  /** Array of [root, ...allNodes] for iterateNodeTree */
+  nodes: (FilteredWorkspaceRootNode | FilteredWorkspaceNode)[];
+  /** Optional map of folder URI strings to their direct children */
+  nodeChildren?: [vscode.Uri, FilteredWorkspaceNode[]][];
+};
+
 /**
- * Creates a mock FilteredWorkspace<GroovyPackageName> for testing.
+ * Creates a mock FilteredWorkspace for testing.
  * Each workspace argument represents a root node and its descendants.
  *
- * @param workspaces - Rest parameter where each element is:
- *   - nodes: Array of [root, ...allDescendants] for iterateNodeTree
- *   - nodeChildren: Optional map of folder URI strings to their direct children
- *     (used for getChildNodes(uri) calls during subpackage verification)
+ * @param workspaces - Array of mock workspace specifications
  * @returns A mocked FilteredWorkspace with:
  *   - getChildNodes: Returns roots when parentUri is null, returns nodeChildren
  *     entries when parentUri matches a key, otherwise empty array
@@ -109,12 +107,7 @@ function createDiagnosticCollection(
  */
 function mockFilteredWorkspace<
   TModuleName extends PythonModuleFullname | GroovyPackageName,
->(
-  ...workspaces: Array<{
-    nodes: (FilteredWorkspaceRootNode | FilteredWorkspaceNode)[];
-    nodeChildren?: [vscode.Uri, FilteredWorkspaceNode[]][];
-  }>
-): FilteredWorkspace<TModuleName> {
+>(...workspaces: MockWorkspaceSpec[]): FilteredWorkspace<TModuleName> {
   const roots = workspaces.map(ws => ws.nodes[0] as FilteredWorkspaceRootNode);
 
   const nodeMap = new URIMap(workspaces.map(ws => [ws.nodes[0].uri, ws.nodes]));

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -12,6 +12,7 @@ import {
 import type {
   ConnectionState,
   IServerManager,
+  PythonModuleFullname,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
 } from '../../types';
@@ -93,15 +94,15 @@ function createDiagnosticCollection(
  */
 function createPythonWorkspace(
   ...workspaces: Array<(FilteredWorkspaceRootNode | FilteredWorkspaceNode)[]>
-): FilteredWorkspace {
+): FilteredWorkspace<PythonModuleFullname> {
   const roots = workspaces.map(nodes => nodes[0] as FilteredWorkspaceRootNode);
 
   const nodeMap = new URIMap(workspaces.map(nodes => [nodes[0].uri, nodes]));
 
-  const workspace: FilteredWorkspace = {
+  const workspace: FilteredWorkspace<PythonModuleFullname> = {
     getChildNodes: vi.fn(),
     iterateNodeTree: vi.fn(),
-  } as unknown as FilteredWorkspace;
+  } as unknown as FilteredWorkspace<PythonModuleFullname>;
 
   vi.mocked(workspace.getChildNodes).mockImplementation(
     (parentUri: vscode.Uri | null) => (parentUri == null ? roots : [])
@@ -442,6 +443,7 @@ describe('createPythonModuleImportErrorHint', () => {
   const wkspRoot: RemoteImportSourceTreeFolderElement = {
     uri: vscode.Uri.parse('file:///workspace'),
     name: 'workspace',
+    languageId: 'python',
     type: 'folder',
     isMarked: false,
   };
@@ -449,6 +451,7 @@ describe('createPythonModuleImportErrorHint', () => {
   const pandasFolder: RemoteImportSourceTreeFolderElement = {
     uri: vscode.Uri.parse('file:///workspace/pandas'),
     name: 'pandas',
+    languageId: 'python',
     type: 'folder',
     isMarked: false,
   };
@@ -456,6 +459,7 @@ describe('createPythonModuleImportErrorHint', () => {
   const pandasFile: RemoteImportSourceTreeFileElement = {
     uri: vscode.Uri.parse('file:///workspace/pandas.py'),
     name: 'pandas',
+    languageId: 'python',
     type: 'file',
     isMarked: false,
   };
@@ -463,6 +467,7 @@ describe('createPythonModuleImportErrorHint', () => {
   const numpyFolder: RemoteImportSourceTreeFolderElement = {
     uri: vscode.Uri.parse('file:///workspace/numpy'),
     name: 'numpy',
+    languageId: 'python',
     type: 'folder',
     isMarked: false,
   };
@@ -470,6 +475,7 @@ describe('createPythonModuleImportErrorHint', () => {
   const wksp2Root: RemoteImportSourceTreeFolderElement = {
     uri: vscode.Uri.parse('file:///workspace2'),
     name: 'workspace2',
+    languageId: 'python',
     type: 'folder',
     isMarked: false,
   };
@@ -477,6 +483,7 @@ describe('createPythonModuleImportErrorHint', () => {
   const wksp2NumpyFolder: RemoteImportSourceTreeFolderElement = {
     uri: vscode.Uri.parse('file:///workspace2/numpy'),
     name: 'numpy',
+    languageId: 'python',
     type: 'folder',
     isMarked: false,
   };
@@ -562,6 +569,7 @@ describe('createPythonModuleImportErrorHint', () => {
 
     const connection = {
       hasRemoteFileSourcePlugin: vi.fn().mockReturnValue(hasPlugin),
+      hasPythonRemoteFileSourcePlugin: vi.fn().mockReturnValue(hasPlugin),
     } as unknown as ConnectionState;
     const hint = createPythonModuleImportErrorHint(
       errors,

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -631,6 +631,36 @@ describe('createPythonModuleImportErrorHint', () => {
 });
 
 describe('createGroovyImportErrorHint', () => {
+  function diagnosticError(message: string): DiagnosticsError {
+    return {
+      uri: MOCK_URI_STRING,
+      message,
+      range: new vscode.Range(0, 0, 0, 0),
+    };
+  }
+
+  function missingImportError(importPath: string): DiagnosticsError {
+    return diagnosticError(
+      `Attempting to import a path that does not exist: import ${importPath};\nRuntimeException: Attempting to import a path that does not exist: import ${importPath};`
+    );
+  }
+
+  function unableToResolveClassError(importPath: string): DiagnosticsError {
+    return diagnosticError(
+      `unable to resolve class ${importPath}\n @ line 42, column 1.\n   import ${importPath}`
+    );
+  }
+
+  function groovyFolder(uriStr: string): RemoteImportSourceTreeFolderElement {
+    return {
+      uri: vscode.Uri.parse(uriStr),
+      name: uriStr.split('/').at(-1) ?? '',
+      languageId: 'groovy',
+      type: 'folder',
+      isMarked: false,
+    };
+  }
+
   const wkspRoot: FilteredWorkspaceRootNode = {
     uri: vscode.Uri.parse('file:///workspace'),
     name: 'workspace',
@@ -638,29 +668,17 @@ describe('createGroovyImportErrorHint', () => {
     type: 'workspaceRootFolder',
   };
 
-  const package3Folder: RemoteImportSourceTreeFolderElement = {
-    uri: vscode.Uri.parse('file:///workspace/package3'),
-    name: 'package3',
-    languageId: 'groovy',
-    type: 'folder',
-    isMarked: false,
-  };
+  const package3Folder: RemoteImportSourceTreeFolderElement = groovyFolder(
+    'file:///workspace/package3'
+  );
 
-  const subpackage1Folder: RemoteImportSourceTreeFolderElement = {
-    uri: vscode.Uri.parse('file:///workspace/package3/subpackage1'),
-    name: 'subpackage1',
-    languageId: 'groovy',
-    type: 'folder',
-    isMarked: false,
-  };
+  const subpackage1Folder: RemoteImportSourceTreeFolderElement = groovyFolder(
+    'file:///workspace/package3/subpackage1'
+  );
 
-  const numpyFolder: RemoteImportSourceTreeFolderElement = {
-    uri: vscode.Uri.parse('file:///workspace/numpy'),
-    name: 'numpy',
-    languageId: 'groovy',
-    type: 'folder',
-    isMarked: false,
-  };
+  const otherFolder: RemoteImportSourceTreeFolderElement = groovyFolder(
+    'file:///workspace/other'
+  );
 
   const wksp2Root: FilteredWorkspaceRootNode = {
     uri: vscode.Uri.parse('file:///workspace2'),
@@ -669,70 +687,47 @@ describe('createGroovyImportErrorHint', () => {
     type: 'workspaceRootFolder',
   };
 
-  const wksp2NumpyFolder: RemoteImportSourceTreeFolderElement = {
-    uri: vscode.Uri.parse('file:///workspace2/numpy'),
-    name: 'numpy',
-    languageId: 'groovy',
-    type: 'folder',
-    isMarked: false,
+  const wksp2OtherFolder: RemoteImportSourceTreeFolderElement = groovyFolder(
+    'file:///workspace2/other'
+  );
+
+  const mockWkspSpec: MockWorkspaceSpec = {
+    nodes: [wkspRoot, package3Folder, subpackage1Folder],
+    nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
+      vscode.Uri,
+      FilteredWorkspaceNode[],
+    ][],
   };
 
-  const GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE: DiagnosticsError[] = [
-    {
-      uri: MOCK_URI_STRING,
-      message:
-        'Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;\nRuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
-      range: new vscode.Range(0, 0, 0, 0),
-    },
-  ];
+  const mockWkspOtherSpec: MockWorkspaceSpec = {
+    nodes: [wksp2Root, wksp2OtherFolder],
+    nodeChildren: [],
+  };
 
-  const GROOVY_IMPORT_ERROR_WITHOUT_SUBPACKAGE: DiagnosticsError[] = [
-    {
-      uri: MOCK_URI_STRING,
-      message:
-        'Attempting to import a path that does not exist: import package3.MyClass;\nRuntimeException: Attempting to import a path that does not exist: import package3.MyClass;',
-      range: new vscode.Range(0, 0, 0, 0),
-    },
-  ];
+  const PACKAGE3_SUBPACKAGE1_MULTICLASSTEST =
+    'package3.subpackage1.MultiClassTest' as const;
 
-  const GROOVY_IMPORT_ERRORS_MULTIPLE: DiagnosticsError[] = [
-    {
-      uri: MOCK_URI_STRING,
-      message:
-        'Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;\nRuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
-      range: new vscode.Range(0, 0, 0, 0),
-    },
-    {
-      uri: MOCK_URI_STRING,
-      message:
-        'Attempting to import a path that does not exist: import numpy.SomeClass;\nRuntimeException: Attempting to import a path that does not exist: import numpy.SomeClass;',
-      range: new vscode.Range(0, 0, 0, 0),
-    },
-  ];
+  const PACKAGE3_MYCLASS = 'package3.MyClass' as const;
 
-  const NON_GROOVY_IMPORT_ERROR: DiagnosticsError[] = [
-    {
-      uri: MOCK_URI_STRING,
-      message: 'Some unrelated Groovy error',
-      range: new vscode.Range(0, 0, 0, 0),
-    },
+  const OTHER_SOMECLASS = 'other.SomeClass' as const;
+
+  const GROOVY_NON_IMPORT_ERROR: DiagnosticsError[] = [
+    diagnosticError('Some unrelated Groovy error'),
   ];
 
   const GROOVY_UNABLE_TO_RESOLVE_CLASS_ERROR: DiagnosticsError[] = [
-    {
-      uri: MOCK_URI_STRING,
-      message:
-        'unable to resolve class package3.subpackage1.MultiClassTest\n @ line 42, column 1.\n   import package3.subpackage1.MultiClassTest',
-      range: new vscode.Range(0, 0, 0, 0),
-    },
+    unableToResolveClassError('package3.subpackage1.MultiClassTest'),
   ];
+
+  const ADD_FOLDER_HINT =
+    'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.' as const;
 
   it.each([
     {
       name: 'return undefined when no import errors exist',
-      errors: NON_GROOVY_IMPORT_ERROR,
+      errors: GROOVY_NON_IMPORT_ERROR,
       hasPlugin: false,
-      workspace: {
+      workspaces: {
         nodes: [wkspRoot, package3Folder],
         nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
       },
@@ -740,9 +735,9 @@ describe('createGroovyImportErrorHint', () => {
     },
     {
       name: 'return undefined when no import errors exist even with plugin',
-      errors: NON_GROOVY_IMPORT_ERROR,
+      errors: GROOVY_NON_IMPORT_ERROR,
       hasPlugin: true,
-      workspace: {
+      workspaces: {
         nodes: [wkspRoot, package3Folder],
         nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
       },
@@ -750,15 +745,9 @@ describe('createGroovyImportErrorHint', () => {
     },
     {
       name: 'suggest installing plugin when not installed',
-      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: false,
-      workspace: {
-        nodes: [wkspRoot, package3Folder, subpackage1Folder],
-        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
-          vscode.Uri,
-          FilteredWorkspaceNode[],
-        ][],
-      },
+      workspaces: mockWkspSpec,
       expected: {
         hint: `The Groovy remote file source plugin is not installed. Install it to enable importing workspace packages.`,
         foundMatchingFolderUris: [],
@@ -766,25 +755,19 @@ describe('createGroovyImportErrorHint', () => {
     },
     {
       name: 'return matching folder when plugin installed and subpackage folder exists',
-      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: true,
-      workspace: {
-        nodes: [wkspRoot, package3Folder, subpackage1Folder],
-        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
-          vscode.Uri,
-          FilteredWorkspaceNode[],
-        ][],
-      },
+      workspaces: mockWkspSpec,
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [package3Folder.uri.toString()],
       },
     },
     {
       name: 'not include folder when subpackage folder does not exist',
-      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: true,
-      workspace: {
+      workspaces: {
         nodes: [wkspRoot, package3Folder],
         nodeChildren: [[package3Folder.uri, []]] as [
           vscode.Uri,
@@ -792,33 +775,33 @@ describe('createGroovyImportErrorHint', () => {
         ][],
       },
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [],
       },
     },
     {
       name: 'include folder when import has only 2 parts (no subpackage verification needed)',
-      errors: GROOVY_IMPORT_ERROR_WITHOUT_SUBPACKAGE,
+      errors: missingImportError(PACKAGE3_MYCLASS),
       hasPlugin: true,
-      workspace: {
+      workspaces: {
         nodes: [wkspRoot, package3Folder],
         nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
       },
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [package3Folder.uri.toString()],
       },
     },
     {
       name: 'return empty foundMatchingFolderUris when no matching folder exists in workspace',
-      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      errors: missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
       hasPlugin: true,
-      workspace: {
-        nodes: [wkspRoot, numpyFolder],
+      workspaces: {
+        nodes: [wkspRoot, otherFolder],
         nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
       },
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [],
       },
     },
@@ -826,20 +809,32 @@ describe('createGroovyImportErrorHint', () => {
       name: 'handle "unable to resolve class" error format',
       errors: GROOVY_UNABLE_TO_RESOLVE_CLASS_ERROR,
       hasPlugin: true,
-      workspace: {
-        nodes: [wkspRoot, package3Folder, subpackage1Folder],
-        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]] as [
-          vscode.Uri,
-          FilteredWorkspaceNode[],
-        ][],
-      },
+      workspaces: mockWkspSpec,
       expected: {
-        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        hint: ADD_FOLDER_HINT,
         foundMatchingFolderUris: [package3Folder.uri.toString()],
       },
     },
-  ])('should $name', ({ errors, hasPlugin, workspace, expected }) => {
-    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>(workspace);
+    {
+      name: 'handle multiple workspace roots with matching folders',
+      errors: [
+        missingImportError(PACKAGE3_SUBPACKAGE1_MULTICLASSTEST),
+        missingImportError(OTHER_SOMECLASS),
+      ],
+      hasPlugin: true,
+      workspaces: [mockWkspSpec, mockWkspOtherSpec],
+      expected: {
+        hint: ADD_FOLDER_HINT,
+        foundMatchingFolderUris: [
+          package3Folder.uri.toString(),
+          wksp2OtherFolder.uri.toString(),
+        ],
+      },
+    },
+  ])('should $name', ({ errors, hasPlugin, workspaces, expected }) => {
+    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>(
+      ...(Array.isArray(workspaces) ? workspaces : [workspaces])
+    );
 
     vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
 
@@ -848,7 +843,7 @@ describe('createGroovyImportErrorHint', () => {
     } as unknown as ConnectionState;
 
     const hint = createGroovyImportErrorHint(
-      errors,
+      Array.isArray(errors) ? errors : [errors],
       connection,
       groovyWorkspace
     );
@@ -856,44 +851,9 @@ describe('createGroovyImportErrorHint', () => {
     expect(hint).toEqual(expected);
   });
 
-  it('should handle multiple workspace roots with matching folders', () => {
-    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>(
-      {
-        nodes: [wkspRoot, package3Folder, subpackage1Folder],
-        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
-      },
-      {
-        nodes: [wksp2Root, wksp2NumpyFolder],
-        nodeChildren: [],
-      }
-    );
-
-    vi.mocked(isInstanceOf).mockReturnValue(true);
-
-    const connection = {
-      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
-    } as unknown as ConnectionState;
-
-    const hint = createGroovyImportErrorHint(
-      GROOVY_IMPORT_ERRORS_MULTIPLE,
-      connection,
-      groovyWorkspace
-    );
-
-    expect(hint).toEqual({
-      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
-      foundMatchingFolderUris: [
-        package3Folder.uri.toString(),
-        wksp2NumpyFolder.uri.toString(),
-      ],
-    });
-  });
-
   it('should parse raw error message when diagnostics are empty', () => {
-    const groovyWorkspace = mockFilteredWorkspace<GroovyPackageName>({
-      nodes: [wkspRoot, package3Folder, subpackage1Folder],
-      nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
-    });
+    const groovyWorkspace =
+      mockFilteredWorkspace<GroovyPackageName>(mockWkspSpec);
 
     vi.mocked(isInstanceOf).mockReturnValue(true);
 
@@ -912,7 +872,7 @@ describe('createGroovyImportErrorHint', () => {
     );
 
     expect(hint).toEqual({
-      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+      hint: ADD_FOLDER_HINT,
       foundMatchingFolderUris: [package3Folder.uri.toString()],
     });
   });
@@ -940,7 +900,7 @@ describe('createGroovyImportErrorHint', () => {
     );
 
     expect(hint).toEqual({
-      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+      hint: ADD_FOLDER_HINT,
       foundMatchingFolderUris: [package3Folder.uri.toString()],
     });
   });

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { dh as DhcType } from '@deephaven/jsapi-types';
 import {
   createConnectionNotFoundHint,
+  createGroovyImportErrorHint,
   createPythonModuleImportErrorHint,
   extractVariables,
   formatDiagnosticError,
@@ -11,6 +12,7 @@ import {
 } from './runCodeUtils';
 import type {
   ConnectionState,
+  GroovyPackageName,
   IServerManager,
   PythonModuleFullname,
   RemoteImportSourceTreeFileElement,
@@ -92,6 +94,55 @@ function createDiagnosticCollection(
  *   - getChildNodes: Returns roots when parentUri is null, empty array otherwise
  *   - iterateNodeTree: Returns children for the matching root, empty array if not found
  */
+/**
+ * Creates a mock FilteredWorkspace<GroovyPackageName> for testing.
+ * Each workspace argument represents a root node and its descendants.
+ *
+ * @param workspaces - Rest parameter where each element is:
+ *   - nodes: Array of [root, ...allDescendants] for iterateNodeTree
+ *   - nodeChildren: Optional map of folder URI strings to their direct children
+ *     (used for getChildNodes(uri) calls during subpackage verification)
+ * @returns A mocked FilteredWorkspace with:
+ *   - getChildNodes: Returns roots when parentUri is null, returns nodeChildren
+ *     entries when parentUri matches a key, otherwise empty array
+ *   - iterateNodeTree: Returns all nodes for the matching root
+ */
+function createGroovyWorkspace(
+  ...workspaces: Array<{
+    nodes: (FilteredWorkspaceRootNode | FilteredWorkspaceNode)[];
+    nodeChildren?: [vscode.Uri, FilteredWorkspaceNode[]][];
+  }>
+): FilteredWorkspace<GroovyPackageName> {
+  const roots = workspaces.map(
+    ws => ws.nodes[0] as FilteredWorkspaceRootNode
+  );
+
+  const nodeMap = new URIMap(
+    workspaces.map(ws => [ws.nodes[0].uri, ws.nodes])
+  );
+
+  const childMap = new URIMap(
+    workspaces.flatMap(ws => ws.nodeChildren ?? [])
+  );
+
+  const workspace: FilteredWorkspace<GroovyPackageName> = {
+    getChildNodes: vi.fn(),
+    iterateNodeTree: vi.fn(),
+  } as unknown as FilteredWorkspace<GroovyPackageName>;
+
+  vi.mocked(workspace.getChildNodes).mockImplementation(
+    (parentUri: vscode.Uri | null) => {
+      if (parentUri == null) return roots;
+      return childMap.get(parentUri) ?? [];
+    }
+  );
+  vi.mocked(workspace.iterateNodeTree).mockImplementation(
+    (rootUri: vscode.Uri) => nodeMap.get(rootUri) ?? []
+  );
+
+  return workspace;
+}
+
 function createPythonWorkspace(
   ...workspaces: Array<(FilteredWorkspaceRootNode | FilteredWorkspaceNode)[]>
 ): FilteredWorkspace<PythonModuleFullname> {
@@ -578,5 +629,240 @@ describe('createPythonModuleImportErrorHint', () => {
     );
 
     expect(hint).toEqual(expected);
+  });
+});
+
+describe('createGroovyImportErrorHint', () => {
+  const wkspRoot: FilteredWorkspaceRootNode = {
+    uri: vscode.Uri.parse('file:///workspace'),
+    name: 'workspace',
+    languageId: 'groovy',
+    type: 'workspaceRootFolder',
+  };
+
+  const package3Folder: RemoteImportSourceTreeFolderElement = {
+    uri: vscode.Uri.parse('file:///workspace/package3'),
+    name: 'package3',
+    languageId: 'groovy',
+    type: 'folder',
+    isMarked: false,
+  };
+
+  const subpackage1Folder: RemoteImportSourceTreeFolderElement = {
+    uri: vscode.Uri.parse('file:///workspace/package3/subpackage1'),
+    name: 'subpackage1',
+    languageId: 'groovy',
+    type: 'folder',
+    isMarked: false,
+  };
+
+  const numpyFolder: RemoteImportSourceTreeFolderElement = {
+    uri: vscode.Uri.parse('file:///workspace/numpy'),
+    name: 'numpy',
+    languageId: 'groovy',
+    type: 'folder',
+    isMarked: false,
+  };
+
+  const wksp2Root: FilteredWorkspaceRootNode = {
+    uri: vscode.Uri.parse('file:///workspace2'),
+    name: 'workspace2',
+    languageId: 'groovy',
+    type: 'workspaceRootFolder',
+  };
+
+  const wksp2NumpyFolder: RemoteImportSourceTreeFolderElement = {
+    uri: vscode.Uri.parse('file:///workspace2/numpy'),
+    name: 'numpy',
+    languageId: 'groovy',
+    type: 'folder',
+    isMarked: false,
+  };
+
+  const GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE: DiagnosticsError[] = [
+    {
+      uri: MOCK_URI_STRING,
+      message:
+        'Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;\nRuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+      range: new vscode.Range(0, 0, 0, 0),
+    },
+  ];
+
+  const GROOVY_IMPORT_ERROR_WITHOUT_SUBPACKAGE: DiagnosticsError[] = [
+    {
+      uri: MOCK_URI_STRING,
+      message:
+        'Attempting to import a path that does not exist: import package3.MyClass;\nRuntimeException: Attempting to import a path that does not exist: import package3.MyClass;',
+      range: new vscode.Range(0, 0, 0, 0),
+    },
+  ];
+
+  const GROOVY_IMPORT_ERRORS_MULTIPLE: DiagnosticsError[] = [
+    {
+      uri: MOCK_URI_STRING,
+      message:
+        'Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;\nRuntimeException: Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;',
+      range: new vscode.Range(0, 0, 0, 0),
+    },
+    {
+      uri: MOCK_URI_STRING,
+      message:
+        'Attempting to import a path that does not exist: import numpy.SomeClass;\nRuntimeException: Attempting to import a path that does not exist: import numpy.SomeClass;',
+      range: new vscode.Range(0, 0, 0, 0),
+    },
+  ];
+
+  const NON_GROOVY_IMPORT_ERROR: DiagnosticsError[] = [
+    {
+      uri: MOCK_URI_STRING,
+      message: 'Some unrelated Groovy error',
+      range: new vscode.Range(0, 0, 0, 0),
+    },
+  ];
+
+  it.each([
+    {
+      name: 'return undefined when no import errors exist',
+      errors: NON_GROOVY_IMPORT_ERROR,
+      hasPlugin: false,
+      workspace: {
+        nodes: [wkspRoot, package3Folder],
+        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
+      },
+      expected: undefined,
+    },
+    {
+      name: 'return undefined when no import errors exist even with plugin',
+      errors: NON_GROOVY_IMPORT_ERROR,
+      hasPlugin: true,
+      workspace: {
+        nodes: [wkspRoot, package3Folder],
+        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
+      },
+      expected: undefined,
+    },
+    {
+      name: 'suggest installing plugin when not installed',
+      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      hasPlugin: false,
+      workspace: {
+        nodes: [wkspRoot, package3Folder, subpackage1Folder],
+        nodeChildren: [
+          [package3Folder.uri, [subpackage1Folder]],
+        ] as [vscode.Uri, FilteredWorkspaceNode[]][],
+      },
+      expected: {
+        hint: `The Groovy remote file source plugin is not installed. Install it to enable importing workspace packages.`,
+        foundMatchingFolderUris: [],
+      },
+    },
+    {
+      name: 'return matching folder when plugin installed and subpackage folder exists',
+      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      hasPlugin: true,
+      workspace: {
+        nodes: [wkspRoot, package3Folder, subpackage1Folder],
+        nodeChildren: [
+          [package3Folder.uri, [subpackage1Folder]],
+        ] as [vscode.Uri, FilteredWorkspaceNode[]][],
+      },
+      expected: {
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        foundMatchingFolderUris: [package3Folder.uri.toString()],
+      },
+    },
+    {
+      name: 'not include folder when subpackage folder does not exist',
+      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      hasPlugin: true,
+      workspace: {
+        nodes: [wkspRoot, package3Folder],
+        nodeChildren: [
+          [package3Folder.uri, []],
+        ] as [vscode.Uri, FilteredWorkspaceNode[]][],
+      },
+      expected: {
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        foundMatchingFolderUris: [],
+      },
+    },
+    {
+      name: 'include folder when import has only 2 parts (no subpackage verification needed)',
+      errors: GROOVY_IMPORT_ERROR_WITHOUT_SUBPACKAGE,
+      hasPlugin: true,
+      workspace: {
+        nodes: [wkspRoot, package3Folder],
+        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
+      },
+      expected: {
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        foundMatchingFolderUris: [package3Folder.uri.toString()],
+      },
+    },
+    {
+      name: 'return empty foundMatchingFolderUris when no matching folder exists in workspace',
+      errors: GROOVY_IMPORT_ERROR_WITH_SUBPACKAGE,
+      hasPlugin: true,
+      workspace: {
+        nodes: [wkspRoot, numpyFolder],
+        nodeChildren: [] as [vscode.Uri, FilteredWorkspaceNode[]][],
+      },
+      expected: {
+        hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+        foundMatchingFolderUris: [],
+      },
+    },
+  ])(
+    'should $name',
+    ({ errors, hasPlugin, workspace, expected }) => {
+      const groovyWorkspace = createGroovyWorkspace(workspace);
+
+      vi.mocked(isInstanceOf).mockReturnValue(hasPlugin);
+
+      const connection = {
+        hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(hasPlugin),
+      } as unknown as ConnectionState;
+
+      const hint = createGroovyImportErrorHint(
+        errors,
+        connection,
+        groovyWorkspace
+      );
+
+      expect(hint).toEqual(expected);
+    }
+  );
+
+  it('should handle multiple workspace roots with matching folders', () => {
+    const groovyWorkspace = createGroovyWorkspace(
+      {
+        nodes: [wkspRoot, package3Folder, subpackage1Folder],
+        nodeChildren: [[package3Folder.uri, [subpackage1Folder]]],
+      },
+      {
+        nodes: [wksp2Root, wksp2NumpyFolder],
+        nodeChildren: [],
+      }
+    );
+
+    vi.mocked(isInstanceOf).mockReturnValue(true);
+
+    const connection = {
+      hasGroovyRemoteFileSourcePlugin: vi.fn().mockReturnValue(true),
+    } as unknown as ConnectionState;
+
+    const hint = createGroovyImportErrorHint(
+      GROOVY_IMPORT_ERRORS_MULTIPLE,
+      connection,
+      groovyWorkspace
+    );
+
+    expect(hint).toEqual({
+      hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+      foundMatchingFolderUris: [
+        package3Folder.uri.toString(),
+        wksp2NumpyFolder.uri.toString(),
+      ],
+    });
   });
 });

--- a/src/mcp/utils/runCodeUtils.spec.ts
+++ b/src/mcp/utils/runCodeUtils.spec.ts
@@ -717,7 +717,7 @@ describe('createGroovyImportErrorHint', () => {
   it.each([
     {
       name: 'return undefined when no import errors exist',
-      errors: diagnosticError('Some unrelated Groovy error'),
+      errors: diagnosticError('Some non-import related error'),
       hasPlugin: false,
       workspaces: {
         nodes: [wkspRoot, package3Folder],
@@ -727,7 +727,7 @@ describe('createGroovyImportErrorHint', () => {
     },
     {
       name: 'return undefined when no import errors exist even with plugin',
-      errors: diagnosticError('Some unrelated Groovy error'),
+      errors: diagnosticError('Some non-import related error'),
       hasPlugin: true,
       workspaces: {
         nodes: [wkspRoot, package3Folder],

--- a/src/mcp/utils/runCodeUtils.ts
+++ b/src/mcp/utils/runCodeUtils.ts
@@ -235,20 +235,22 @@ export function createGroovyImportErrorHint(
         message
       ) || /unable to resolve class ([^\s\n]+)/.exec(message);
 
-    if (match) {
-      const importPath = match[1].trim();
-      const parts = importPath.split('.');
-      const topLevelPackage = parts[0];
+    if (match == null) {
+      return;
+    }
 
-      if (!importErrors.has(topLevelPackage)) {
-        importErrors.set(topLevelPackage, new Set());
-      }
+    const importPath = match[1].trim();
+    const parts = importPath.split('.');
+    const topLevelPackage = parts[0];
 
-      // If there are 3+ parts (package.subpackage.ClassName), the second part
-      // is a subpackage that must exist as a child folder
-      if (parts.length >= 3) {
-        importErrors.get(topLevelPackage)!.add(parts[1]);
-      }
+    if (!importErrors.has(topLevelPackage)) {
+      importErrors.set(topLevelPackage, new Set());
+    }
+
+    // If there are 3+ parts (package.subpackage.ClassName), the second part
+    // is a subpackage that must exist as a child folder
+    if (parts.length >= 3) {
+      importErrors.get(topLevelPackage)!.add(parts[1]);
     }
   };
 
@@ -278,7 +280,7 @@ export function createGroovyImportErrorHint(
 
   for (const rootNode of rootNodes) {
     for (const node of groovyWorkspace.iterateNodeTree(rootNode.uri)) {
-      if (node.type === 'folder' && importErrors.has(node.name) && node.uri) {
+      if (node.type === 'folder' && importErrors.has(node.name)) {
         const requiredSubpackages = importErrors.get(node.name)!;
 
         if (requiredSubpackages.size === 0) {

--- a/src/mcp/utils/runCodeUtils.ts
+++ b/src/mcp/utils/runCodeUtils.ts
@@ -132,7 +132,7 @@ export function createPythonModuleImportErrorHint(
   connection: ConnectionState,
   pythonWorkspace: FilteredWorkspace<PythonModuleFullname>,
   rawErrorMessage?: string
-): { hint: string; foundMatchingFolderUris: string[] } | undefined {
+): { hint: string; foundMatchingFolderUris?: string[] } | undefined {
   // Look for 'No module named' errors and extract the module names
   const noModuleErrors = new Set(
     errors
@@ -155,7 +155,6 @@ export function createPythonModuleImportErrorHint(
   if (!hasPythonRemoteFileSourcePlugin(connection)) {
     return {
       hint: `The Python remote file source plugin is not installed. Install it with 'pip install deephaven-plugin-python-remote-file-source' to enable importing workspace packages.`,
-      foundMatchingFolderUris: [],
     };
   }
 
@@ -220,7 +219,7 @@ export function createGroovyImportErrorHint(
   connection: ConnectionState,
   groovyWorkspace: FilteredWorkspace<GroovyPackageName>,
   rawErrorMessage?: string
-): { hint: string; foundMatchingFolderUris: string[] } | undefined {
+): { hint: string; foundMatchingFolderUris?: string[] } | undefined {
   // Look for 'Attempting to import a path that does not exist' errors and
   // extract the top-level package and required subpackage (if any)
   const importErrors = new Map<string, Set<string>>();
@@ -271,7 +270,6 @@ export function createGroovyImportErrorHint(
   if (!hasGroovyRemoteFileSourcePlugin(connection)) {
     return {
       hint: `The Groovy remote file source plugin is not installed. Install it to enable importing workspace packages.`,
-      foundMatchingFolderUris: [],
     };
   }
 

--- a/src/mcp/utils/runCodeUtils.ts
+++ b/src/mcp/utils/runCodeUtils.ts
@@ -7,7 +7,12 @@ import {
   type FilteredWorkspace,
 } from '../../services';
 import { isInstanceOf } from '../../util';
-import type { ConnectionState, ConsoleType, IServerManager } from '../../types';
+import type {
+  ConnectionState,
+  ConsoleType,
+  IServerManager,
+  PythonModuleFullname,
+} from '../../types';
 
 export interface DiagnosticsError {
   uri: string;
@@ -120,7 +125,7 @@ export async function createConnectionNotFoundHint(
 export function createPythonModuleImportErrorHint(
   errors: Array<{ message: string; uri: string; range: vscode.Range }>,
   connection: ConnectionState,
-  pythonWorkspace: FilteredWorkspace
+  pythonWorkspace: FilteredWorkspace<PythonModuleFullname>
 ): { hint: string; foundMatchingFolderUris: string[] } | undefined {
   // Look for 'No module named' errors and extract the module names
   const noModuleErrors = new Set(
@@ -165,7 +170,7 @@ export function createPythonModuleImportErrorHint(
 function hasPythonRemoteFileSourcePlugin(connection: ConnectionState): boolean {
   return (
     isInstanceOf(connection, DhcService) &&
-    connection.hasRemoteFileSourcePlugin()
+    connection.hasPythonRemoteFileSourcePlugin()
   );
 }
 

--- a/src/mcp/utils/runCodeUtils.ts
+++ b/src/mcp/utils/runCodeUtils.ts
@@ -27,7 +27,11 @@ export type VariableResult = z.infer<typeof variableResultSchema>;
  * Schema for variable results returned after code execution.
  */
 export const variableResultSchema = z.object({
-  id: z.string().describe('Variable ID. Pass as variableId to data tools. Only valid for variables with type "Table".'),
+  id: z
+    .string()
+    .describe(
+      'Variable ID. Pass as variableId to data tools. Only valid for variables with type "Table".'
+    ),
   title: z
     .string()
     .optional()
@@ -126,7 +130,8 @@ export async function createConnectionNotFoundHint(
 export function createPythonModuleImportErrorHint(
   errors: Array<{ message: string; uri: string; range: vscode.Range }>,
   connection: ConnectionState,
-  pythonWorkspace: FilteredWorkspace<PythonModuleFullname>
+  pythonWorkspace: FilteredWorkspace<PythonModuleFullname>,
+  rawErrorMessage?: string
 ): { hint: string; foundMatchingFolderUris: string[] } | undefined {
   // Look for 'No module named' errors and extract the module names
   const noModuleErrors = new Set(
@@ -134,6 +139,14 @@ export function createPythonModuleImportErrorHint(
       .map(e => /^No module named '([^']+)'/.exec(e.message)?.[1])
       .filter(e => e != null)
   );
+
+  // If no diagnostic errors but we have a raw error message, parse it
+  if (noModuleErrors.size === 0 && rawErrorMessage) {
+    const match = /No module named '([^']+)'/.exec(rawErrorMessage);
+    if (match?.[1]) {
+      noModuleErrors.add(match[1]);
+    }
+  }
 
   if (noModuleErrors.size === 0) {
     return;
@@ -205,17 +218,23 @@ export function hasGroovyRemoteFileSourcePlugin(
 export function createGroovyImportErrorHint(
   errors: Array<{ message: string; uri: string; range: vscode.Range }>,
   connection: ConnectionState,
-  groovyWorkspace: FilteredWorkspace<GroovyPackageName>
+  groovyWorkspace: FilteredWorkspace<GroovyPackageName>,
+  rawErrorMessage?: string
 ): { hint: string; foundMatchingFolderUris: string[] } | undefined {
   // Look for 'Attempting to import a path that does not exist' errors and
   // extract the top-level package and required subpackage (if any)
   const importErrors = new Map<string, Set<string>>();
 
-  for (const e of errors) {
+  // Helper function to parse import errors
+  const parseImportError = (message: string) => {
+    // Match either:
+    // 1. "Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;"
+    // 2. "unable to resolve class package3.subpackage1.MultiClassTest"
     const match =
       /Attempting to import a path that does not exist: import ([^;]+);/.exec(
-        e.message
-      );
+        message
+      ) || /unable to resolve class ([^\s\n]+)/.exec(message);
+
     if (match) {
       const importPath = match[1].trim();
       const parts = importPath.split('.');
@@ -231,6 +250,16 @@ export function createGroovyImportErrorHint(
         importErrors.get(topLevelPackage)!.add(parts[1]);
       }
     }
+  };
+
+  // Parse diagnostic errors
+  for (const e of errors) {
+    parseImportError(e.message);
+  }
+
+  // If no diagnostic errors but we have a raw error message, parse it
+  if (importErrors.size === 0 && rawErrorMessage) {
+    parseImportError(rawErrorMessage);
   }
 
   if (importErrors.size === 0) {
@@ -273,7 +302,7 @@ export function createGroovyImportErrorHint(
   }
 
   return {
-    hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+    hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources with languageId "groovy". DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
     foundMatchingFolderUris: foundUris,
   };
 }

--- a/src/mcp/utils/runCodeUtils.ts
+++ b/src/mcp/utils/runCodeUtils.ts
@@ -10,6 +10,7 @@ import { isInstanceOf } from '../../util';
 import type {
   ConnectionState,
   ConsoleType,
+  GroovyPackageName,
   IServerManager,
   PythonModuleFullname,
 } from '../../types';
@@ -172,6 +173,109 @@ function hasPythonRemoteFileSourcePlugin(connection: ConnectionState): boolean {
     isInstanceOf(connection, DhcService) &&
     connection.hasPythonRemoteFileSourcePlugin()
   );
+}
+
+/**
+ * Checks if the Groovy remote file source plugin is installed for the given connection.
+ * @param connection The connection state to check.
+ * @returns True if the Groovy remote file source plugin is installed, false otherwise.
+ */
+export function hasGroovyRemoteFileSourcePlugin(
+  connection: ConnectionState
+): boolean {
+  return (
+    isInstanceOf(connection, DhcService) &&
+    connection.hasGroovyRemoteFileSourcePlugin()
+  );
+}
+
+/**
+ * Creates a hint for Groovy import errors.
+ * - If no import errors are found, returns undefined.
+ * - If import errors are found, and remote file source plugin is not installed,
+ * suggests installing it.
+ * - If import errors are found, and remote file source plugin is installed,
+ * determines a list of folder URIs in the workspace that may satisfy the missing
+ * imports by verifying the subpackage folder structure.
+ * @param errors The list of diagnostic errors.
+ * @param connection The connection state to check for Groovy remote file source plugin.
+ * @param groovyWorkspace The filtered Groovy workspace.
+ * @returns An object with hint and foundMatchingFolderUris, or undefined if no hint is applicable.
+ */
+export function createGroovyImportErrorHint(
+  errors: Array<{ message: string; uri: string; range: vscode.Range }>,
+  connection: ConnectionState,
+  groovyWorkspace: FilteredWorkspace<GroovyPackageName>
+): { hint: string; foundMatchingFolderUris: string[] } | undefined {
+  // Look for 'Attempting to import a path that does not exist' errors and
+  // extract the top-level package and required subpackage (if any)
+  const importErrors = new Map<string, Set<string>>();
+
+  for (const e of errors) {
+    const match =
+      /Attempting to import a path that does not exist: import ([^;]+);/.exec(
+        e.message
+      );
+    if (match) {
+      const importPath = match[1].trim();
+      const parts = importPath.split('.');
+      const topLevelPackage = parts[0];
+
+      if (!importErrors.has(topLevelPackage)) {
+        importErrors.set(topLevelPackage, new Set());
+      }
+
+      // If there are 3+ parts (package.subpackage.ClassName), the second part
+      // is a subpackage that must exist as a child folder
+      if (parts.length >= 3) {
+        importErrors.get(topLevelPackage)!.add(parts[1]);
+      }
+    }
+  }
+
+  if (importErrors.size === 0) {
+    return;
+  }
+
+  if (!hasGroovyRemoteFileSourcePlugin(connection)) {
+    return {
+      hint: `The Groovy remote file source plugin is not installed. Install it to enable importing workspace packages.`,
+      foundMatchingFolderUris: [],
+    };
+  }
+
+  const foundUris: string[] = [];
+  const rootNodes = groovyWorkspace.getChildNodes(null);
+
+  for (const rootNode of rootNodes) {
+    for (const node of groovyWorkspace.iterateNodeTree(rootNode.uri)) {
+      if (node.type === 'folder' && importErrors.has(node.name) && node.uri) {
+        const requiredSubpackages = importErrors.get(node.name)!;
+
+        if (requiredSubpackages.size === 0) {
+          // No subpackage verification needed
+          foundUris.push(node.uri.toString());
+        } else {
+          // Verify at least one required subpackage exists as a child folder
+          const childNodes = groovyWorkspace.getChildNodes(node.uri);
+          const hasMatchingSubpackage = [...requiredSubpackages].some(sub =>
+            childNodes.some(
+              child => child.type === 'folder' && child.name === sub
+            )
+          );
+
+          if (hasMatchingSubpackage) {
+            foundUris.push(node.uri.toString());
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    hint: 'If this is a package in your workspace, add its folder as a remote file source using addRemoteFileSources. DO NOT guess folder URIs - use the exact URIs provided in details.foundMatchingFolderUris.',
+    foundMatchingFolderUris: foundUris,
+  };
 }
 
 /**

--- a/src/mcp/utils/runCodeUtils.ts
+++ b/src/mcp/utils/runCodeUtils.ts
@@ -226,7 +226,7 @@ export function createGroovyImportErrorHint(
   const importErrors = new Map<string, Set<string>>();
 
   // Helper function to parse import errors
-  const parseImportError = (message: string) => {
+  const parseImportError = (message: string): void => {
     // Match either:
     // 1. "Attempting to import a path that does not exist: import package3.subpackage1.MultiClassTest;"
     // 2. "unable to resolve class package3.subpackage1.MultiClassTest"

--- a/src/providers/RemoteImportSourceTreeProvider.ts
+++ b/src/providers/RemoteImportSourceTreeProvider.ts
@@ -1,23 +1,37 @@
 import * as vscode from 'vscode';
 import { TreeDataProviderBase } from './TreeDataProviderBase';
 import type { FilteredWorkspace } from '../services';
-import type { RemoteImportSourceTreeElement } from '../types';
+import type {
+  GroovyPackageName,
+  PythonModuleFullname,
+  RemoteImportSourceTreeElement,
+} from '../types';
 import {
   getFileTreeItem,
   getFolderTreeItem,
   getTopLevelMarkedFolderTreeItem,
   sortByStringProp,
 } from '../util';
+import { ICON_ID } from '../common';
 
 const ACTIVE_SOURCES_LABEL = 'Active Sources';
-const WORKSPACE_LABEL = 'Workspace';
+// const WORKSPACE_LABEL = 'Workspace';
+const GROOVY_LABEL = 'Groovy';
+const PYTHON_LABEL = 'Python';
 
 /**
  * Tree data provider that shows the Python modules in the workspace.
  */
 export class RemoteImportSourceTreeProvider extends TreeDataProviderBase<RemoteImportSourceTreeElement> {
-  constructor(private readonly _pythonWorkspace: FilteredWorkspace) {
+  constructor(
+    private readonly _groovyWorkspace: FilteredWorkspace<GroovyPackageName>,
+    private readonly _pythonWorkspace: FilteredWorkspace<PythonModuleFullname>
+  ) {
     super();
+
+    this.disposables.add(
+      this._groovyWorkspace.onDidUpdate(() => this.refresh())
+    );
 
     this.disposables.add(
       this._pythonWorkspace.onDidUpdate(() => this.refresh())
@@ -35,21 +49,32 @@ export class RemoteImportSourceTreeProvider extends TreeDataProviderBase<RemoteI
     if (node == null) {
       return [
         { type: 'root', name: ACTIVE_SOURCES_LABEL },
-        { type: 'root', name: WORKSPACE_LABEL },
+        { type: 'root', name: GROOVY_LABEL },
+        { type: 'root', name: PYTHON_LABEL },
       ];
     }
 
     if (node.type === 'root') {
       if (node.name === ACTIVE_SOURCES_LABEL) {
-        return this._pythonWorkspace
-          .getTopLevelMarkedFolders()
-          .sort(sortByStringProp('name'));
+        return [
+          ...this._groovyWorkspace.getTopLevelMarkedFolders(),
+          ...this._pythonWorkspace.getTopLevelMarkedFolders(),
+        ].sort(sortByStringProp('name'));
+      }
+
+      if (node.name === GROOVY_LABEL) {
+        return this._groovyWorkspace.getChildNodes(null);
       }
 
       return this._pythonWorkspace.getChildNodes(null);
     }
 
-    return this._pythonWorkspace.getChildNodes(node.uri).sort(
+    const workspace =
+      node.languageId === 'groovy'
+        ? this._groovyWorkspace
+        : this._pythonWorkspace;
+
+    return workspace.getChildNodes(node.uri).sort(
       (nodeA, nodeB) =>
         // Sort folders before files, then by name
         nodeB.type.localeCompare(nodeA.type) ||
@@ -78,9 +103,15 @@ export class RemoteImportSourceTreeProvider extends TreeDataProviderBase<RemoteI
     return {
       label: element.name,
       collapsibleState:
-        element.type === 'root'
+        element.type === 'root' && element.name === ACTIVE_SOURCES_LABEL
           ? vscode.TreeItemCollapsibleState.Expanded
           : vscode.TreeItemCollapsibleState.Collapsed,
+      iconPath:
+        element.name === PYTHON_LABEL
+          ? new vscode.ThemeIcon(ICON_ID.python)
+          : element.name === GROOVY_LABEL
+            ? new vscode.ThemeIcon(ICON_ID.groovy)
+            : undefined,
     };
   }
 }

--- a/src/providers/RemoteImportSourceTreeProvider.ts
+++ b/src/providers/RemoteImportSourceTreeProvider.ts
@@ -15,7 +15,7 @@ import {
 import { ICON_ID } from '../common';
 
 const ACTIVE_SOURCES_LABEL = 'Active Sources';
-// const WORKSPACE_LABEL = 'Workspace';
+const WORKSPACE_LABEL = 'Workspace';
 const GROOVY_LABEL = 'Groovy';
 const PYTHON_LABEL = 'Python';
 
@@ -49,8 +49,7 @@ export class RemoteImportSourceTreeProvider extends TreeDataProviderBase<RemoteI
     if (node == null) {
       return [
         { type: 'root', name: ACTIVE_SOURCES_LABEL },
-        { type: 'root', name: GROOVY_LABEL },
-        { type: 'root', name: PYTHON_LABEL },
+        { type: 'root', name: WORKSPACE_LABEL },
       ];
     }
 
@@ -60,6 +59,13 @@ export class RemoteImportSourceTreeProvider extends TreeDataProviderBase<RemoteI
           ...this._groovyWorkspace.getTopLevelMarkedFolders(),
           ...this._pythonWorkspace.getTopLevelMarkedFolders(),
         ].sort(sortByStringProp('name'));
+      }
+
+      if (node.name === WORKSPACE_LABEL) {
+        return [
+          { type: 'root', name: GROOVY_LABEL },
+          { type: 'root', name: PYTHON_LABEL },
+        ];
       }
 
       if (node.name === GROOVY_LABEL) {
@@ -103,7 +109,8 @@ export class RemoteImportSourceTreeProvider extends TreeDataProviderBase<RemoteI
     return {
       label: element.name,
       collapsibleState:
-        element.type === 'root' && element.name === ACTIVE_SOURCES_LABEL
+        element.type === 'root' &&
+        [ACTIVE_SOURCES_LABEL, WORKSPACE_LABEL].includes(element.name)
           ? vscode.TreeItemCollapsibleState.Expanded
           : vscode.TreeItemCollapsibleState.Collapsed,
       iconPath:

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -35,7 +35,11 @@ import {
   UnsupportedConsoleTypeError,
   VARIABLE_UNICODE_ICONS,
 } from '../common';
-import { NoConsoleTypesError, parseServerError } from '../dh/errorUtils';
+import {
+  NoConsoleTypesError,
+  parseGroovyServerError,
+  parseServerError,
+} from '../dh/errorUtils';
 import { hasErrorCode } from '../util/typeUtils';
 import { DisposableBase } from './DisposableBase';
 import { assertDefined } from '../shared';
@@ -474,6 +478,7 @@ export class DhcService extends DisposableBase implements IDhcService {
     if (typeof documentOrText !== 'string') {
       // Clear previous diagnostics when cmd starts running
       this.diagnosticsCollection.set(documentOrText.uri, []);
+      this.groovyDiagnosticsCollection.set(documentOrText.uri, []);
     }
 
     if (this.session == null) {
@@ -582,6 +587,27 @@ export class DhcService extends DisposableBase implements IDhcService {
               [diagnostic]
             );
           }
+        }
+      } else if (
+        languageId === 'groovy' &&
+        typeof documentOrText !== 'string'
+      ) {
+        const errors = parseGroovyServerError(error);
+
+        for (const { type, value } of errors) {
+          // Flag the first token on the first line since Groovy import errors
+          // don't include a specific line number
+          const diagnostic: vscode.Diagnostic = {
+            code: type,
+            message: value == null ? error : `${value}\n${error}`,
+            severity: vscode.DiagnosticSeverity.Error,
+            range: new vscode.Range(0, 0, 0, 0),
+            source: 'deephaven',
+          };
+
+          this.groovyDiagnosticsCollection.set(documentOrText.uri, [
+            diagnostic,
+          ]);
         }
       }
     }

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -404,8 +404,8 @@ export class DhcService extends DisposableBase implements IDhcService {
    * Check if the remote file source plugin is installed.
    * @returns true if the plugin is installed, false otherwise
    */
-  hasRemoteFileSourcePlugin = (): boolean => {
-    return this.remoteFileSourcePluginSubscription != null;
+  hasPythonRemoteFileSourcePlugin = (): boolean => {
+    return this.pythonRemoteFileSourcePluginSubscription != null;
   };
 
   getConsoleTypes = async (): Promise<Set<ConsoleType>> => {

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -410,6 +410,14 @@ export class DhcService extends DisposableBase implements IDhcService {
   }
 
   /**
+   * Check if the Groovy remote file source plugin is installed.
+   * @returns true if the plugin is installed, false otherwise
+   */
+  hasGroovyRemoteFileSourcePlugin = (): boolean => {
+    return this.groovyRemoteFileSourcePluginSubscription != null;
+  };
+
+  /**
    * Check if the remote file source plugin is installed.
    * @returns true if the plugin is installed, false otherwise
    */

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -38,7 +38,7 @@ import {
 import {
   NoConsoleTypesError,
   parseGroovyServerError,
-  parseServerError,
+  parsePythonServerError,
 } from '../dh/errorUtils';
 import { hasErrorCode } from '../util/typeUtils';
 import { DisposableBase } from './DisposableBase';
@@ -561,7 +561,7 @@ export class DhcService extends DisposableBase implements IDhcService {
       this.outputChannel.show(true);
 
       if (languageId === 'python' && typeof documentOrText !== 'string') {
-        const errors = parseServerError(error);
+        const errors = parsePythonServerError(error);
 
         for (const { type, file, line, value } of errors) {
           if (line != null) {

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -139,7 +139,8 @@ export class DhcService extends DisposableBase implements IDhcService {
 
   private cn: DhcType.IdeConnection | null = null;
   private cnId: UniqueID | null = null;
-  private remoteFileSourcePluginSubscription: (() => void) | null = null;
+  private groovyRemoteFileSourcePluginSubscription: (() => void) | null = null;
+  private pythonRemoteFileSourcePluginSubscription: (() => void) | null = null;
   private session: DhcType.IdeSession | null = null;
 
   get isInitialized(): boolean {
@@ -282,15 +283,22 @@ export class DhcService extends DisposableBase implements IDhcService {
     }
 
     try {
-      const { cn, cnId, remoteFileSourcePlugin, session } =
-        await this.initSessionPromise;
+      const {
+        cn,
+        cnId,
+        groovyRemoteFileSourcePlugin,
+        pythonRemoteFileSourcePlugin,
+        session,
+      } = await this.initSessionPromise;
       this.cn = cn;
       this.cnId = cnId;
       this.session = session;
 
-      if (remoteFileSourcePlugin != null) {
-        await this._initRemoteFileSourcePlugin(session, remoteFileSourcePlugin);
-      }
+      await this._initRemoteFileSourcePlugins(
+        session,
+        groovyRemoteFileSourcePlugin,
+        pythonRemoteFileSourcePlugin
+      );
     } catch (err) {
       logger.error(err);
       const toastMessage = this.getToastErrorMessage(
@@ -330,25 +338,45 @@ export class DhcService extends DisposableBase implements IDhcService {
   };
 
   /**
-   * Initialize the remote file source plugin.
-   * @param session the ide session to associate with the plugin
-   * @param remoteFileSourcePlugin the remote file source plugin widget
+   * Initialize the remote file source plugins.
+   * @param session the ide session to associate with the plugins
+   * @param groovyRemoteFileSourcePlugin the Groovy remote file source plugin widget
+   * @param pythonRemoteFileSourcePlugin the Python remote file source plugin widget
    */
-  private _initRemoteFileSourcePlugin = async (
+  private _initRemoteFileSourcePlugins = async (
     session: DhcType.IdeSession,
-    remoteFileSourcePlugin: DhcType.Widget
+    groovyRemoteFileSourcePlugin: DhcType.remotefilesource.RemoteFileSourceService | null,
+    pythonRemoteFileSourcePlugin: DhcType.Widget | null
   ): Promise<void> => {
-    this.disposables.add(() => {
-      remoteFileSourcePlugin.close();
-    });
+    // Groovy plugin
+    if (groovyRemoteFileSourcePlugin != null) {
+      this.disposables.add(() => {
+        groovyRemoteFileSourcePlugin.close();
+      });
 
-    this.remoteFileSourcePluginSubscription =
-      await this.remoteFileSourceService.registerPlugin(
-        session,
-        remoteFileSourcePlugin
-      );
+      this.groovyRemoteFileSourcePluginSubscription =
+        await this.remoteFileSourceService.registerGroovyPlugin(
+          session,
+          groovyRemoteFileSourcePlugin
+        );
 
-    this.disposables.add(this.remoteFileSourcePluginSubscription);
+      this.disposables.add(this.groovyRemoteFileSourcePluginSubscription);
+    }
+
+    // Python plugin
+    if (pythonRemoteFileSourcePlugin != null) {
+      this.disposables.add(() => {
+        pythonRemoteFileSourcePlugin.close();
+      });
+
+      this.pythonRemoteFileSourcePluginSubscription =
+        await this.remoteFileSourceService.registerPythonPlugin(
+          session,
+          pythonRemoteFileSourcePlugin
+        );
+
+      this.disposables.add(this.pythonRemoteFileSourcePluginSubscription);
+    }
   };
 
   async getClient(): Promise<CoreAuthenticatedClient | null> {
@@ -467,8 +495,8 @@ export class DhcService extends DisposableBase implements IDhcService {
 
       this.isRunningCode = true;
 
-      if (this.remoteFileSourcePluginSubscription != null) {
-        await this.remoteFileSourceService.setServerExecutionContext(
+      if (this.pythonRemoteFileSourcePluginSubscription != null) {
+        await this.remoteFileSourceService.setPythonServerExecutionContext(
           this.cnId,
           this.session
         );

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -143,6 +143,10 @@ export class DhcService extends DisposableBase implements IDhcService {
   private pythonRemoteFileSourcePluginSubscription: (() => void) | null = null;
   private session: DhcType.IdeSession | null = null;
 
+  private groovyRemoteFileSourcePluginService: DhcType.remotefilesource.RemoteFileSourceService | null =
+    null;
+  private pythonRemoteFileSourcePlugin: DhcType.Widget | null = null;
+
   get isInitialized(): boolean {
     return this.initSessionPromise != null;
   }
@@ -340,24 +344,28 @@ export class DhcService extends DisposableBase implements IDhcService {
   /**
    * Initialize the remote file source plugins.
    * @param session the ide session to associate with the plugins
-   * @param groovyRemoteFileSourcePlugin the Groovy remote file source plugin widget
+   * @param groovyRemoteFileSourcePluginService the Groovy remote file source plugin service
    * @param pythonRemoteFileSourcePlugin the Python remote file source plugin widget
    */
   private _initRemoteFileSourcePlugins = async (
     session: DhcType.IdeSession,
-    groovyRemoteFileSourcePlugin: DhcType.remotefilesource.RemoteFileSourceService | null,
+    groovyRemoteFileSourcePluginService: DhcType.remotefilesource.RemoteFileSourceService | null,
     pythonRemoteFileSourcePlugin: DhcType.Widget | null
   ): Promise<void> => {
+    this.groovyRemoteFileSourcePluginService =
+      groovyRemoteFileSourcePluginService;
+    this.pythonRemoteFileSourcePlugin = pythonRemoteFileSourcePlugin;
+
     // Groovy plugin
-    if (groovyRemoteFileSourcePlugin != null) {
+    if (groovyRemoteFileSourcePluginService != null) {
       this.disposables.add(() => {
-        groovyRemoteFileSourcePlugin.close();
+        groovyRemoteFileSourcePluginService.close();
       });
 
       this.groovyRemoteFileSourcePluginSubscription =
         await this.remoteFileSourceService.registerGroovyPlugin(
           session,
-          groovyRemoteFileSourcePlugin
+          groovyRemoteFileSourcePluginService
         );
 
       this.disposables.add(this.groovyRemoteFileSourcePluginSubscription);
@@ -495,10 +503,16 @@ export class DhcService extends DisposableBase implements IDhcService {
 
       this.isRunningCode = true;
 
-      if (this.pythonRemoteFileSourcePluginSubscription != null) {
+      if (this.pythonRemoteFileSourcePlugin != null) {
         await this.remoteFileSourceService.setPythonServerExecutionContext(
           this.cnId,
           this.session
+        );
+      }
+
+      if (this.groovyRemoteFileSourcePluginService != null) {
+        await this.remoteFileSourceService.setGroovyServerExecutionContext(
+          this.groovyRemoteFileSourcePluginService
         );
       }
 

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -57,6 +57,7 @@ export class DhcService extends DisposableBase implements IDhcService {
    */
   static factory = (
     coreClientCache: URLMap<CoreAuthenticatedClient>,
+    groovyDiagnosticsCollection: vscode.DiagnosticCollection,
     diagnosticsCollection: vscode.DiagnosticCollection,
     remoteFileSourceService: RemoteFileSourceService,
     outputChannel: vscode.OutputChannel,
@@ -69,6 +70,7 @@ export class DhcService extends DisposableBase implements IDhcService {
         return new DhcService(
           serverUrl,
           coreClientCache,
+          groovyDiagnosticsCollection,
           diagnosticsCollection,
           remoteFileSourceService,
           outputChannel,
@@ -88,6 +90,7 @@ export class DhcService extends DisposableBase implements IDhcService {
   private constructor(
     serverUrl: URL,
     coreClientCache: URLMap<CoreAuthenticatedClient>,
+    groovyDiagnosticsCollection: vscode.DiagnosticCollection,
     diagnosticsCollection: vscode.DiagnosticCollection,
     remoteFileSourceService: RemoteFileSourceService,
     outputChannel: vscode.OutputChannel,
@@ -99,6 +102,7 @@ export class DhcService extends DisposableBase implements IDhcService {
     super();
 
     this.coreClientCache = coreClientCache;
+    this.groovyDiagnosticsCollection = groovyDiagnosticsCollection;
     this.diagnosticsCollection = diagnosticsCollection;
     this.remoteFileSourceService = remoteFileSourceService;
     this.outputChannel = outputChannel;
@@ -131,6 +135,7 @@ export class DhcService extends DisposableBase implements IDhcService {
   private readonly secretService: ISecretService;
   private readonly toaster: IToastService;
   private readonly panelService: IPanelService;
+  private readonly groovyDiagnosticsCollection: vscode.DiagnosticCollection;
   private readonly diagnosticsCollection: vscode.DiagnosticCollection;
   private clientPromise: Promise<CoreAuthenticatedClient | null> | null = null;
   private initSessionPromise: Promise<

--- a/src/services/FilteredWorkspace.spec.ts
+++ b/src/services/FilteredWorkspace.spec.ts
@@ -2,9 +2,9 @@
 import * as vscode from 'vscode';
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import {
+  DEFAULT_IGNORE_TOP_LEVEL_FOLDER_NAMES,
   FilteredWorkspace,
   PYTHON_FILE_PATTERN,
-  PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
 } from './FilteredWorkspace';
 import {
   getPythonTopLevelModuleFullname,
@@ -295,7 +295,7 @@ async function initWorkspace(wsMap: URIMap<URISet>): Promise<{
     PYTHON_FILE_PATTERN,
     'python',
     getPythonTopLevelModuleFullname,
-    PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES,
+    DEFAULT_IGNORE_TOP_LEVEL_FOLDER_NAMES,
     mockToaster
   );
 

--- a/src/services/FilteredWorkspace.spec.ts
+++ b/src/services/FilteredWorkspace.spec.ts
@@ -490,6 +490,51 @@ describe.each([true, false])(
         expect(onDidChangeFileDecorationsListener).toHaveBeenCalledTimes(1);
       }
     });
+
+    it('should unmark ancestors and re-promote remaining marked siblings as top-level', async () => {
+      const { workspace, expectResult } = await initWorkspace(mock2RootWs);
+
+      // Mark sub1 as top-level, which marks all its descendants
+      workspace.markFolder(mock.folder1.sub1, supressNotify);
+      vi.clearAllMocks();
+
+      vi.spyOn(workspace, 'unmarkConflictingTopLevelFolder');
+
+      // Unmark sub1_b (nested child) — triggers ancestor behavior on sub1
+      workspace.unmarkFolder(mock.folder1.sub1_b, supressNotify);
+
+      expectResult(
+        mock.folder1.root,
+        expected.folder1.sub1aMarked
+      );
+
+      // sub1 (the ancestor) should no longer be a top-level marked folder
+      const topLevelFolders = workspace.getTopLevelMarkedFolders();
+      expect(
+        topLevelFolders.some(f => f.uri.fsPath === mock.folder1.sub1.fsPath)
+      ).toBe(false);
+
+      // sub1_a (sibling of sub1_b) should be re-promoted to top-level
+      expect(topLevelFolders).toContainEqual(
+        topLevelMarkedFolderElement(mock.folder1.sub1_a)
+      );
+
+      // ancestor loop calls unmarkConflictingTopLevelFolder once for sub1_a,
+      // the only remaining marked folder child of the ancestor sub1
+      expect(workspace.unmarkConflictingTopLevelFolder).toHaveBeenCalledOnce();
+      expect(workspace.unmarkConflictingTopLevelFolder).toHaveBeenCalledWith(
+        mock.folder1.sub1_a,
+        true
+      );
+
+      if (supressNotify) {
+        expect(onDidUpdateListener).not.toHaveBeenCalled();
+        expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
+      } else {
+        expect(onDidUpdateListener).toHaveBeenCalledTimes(1);
+        expect(onDidChangeFileDecorationsListener).toHaveBeenCalledTimes(1);
+      }
+    });
   }
 );
 

--- a/src/services/FilteredWorkspace.spec.ts
+++ b/src/services/FilteredWorkspace.spec.ts
@@ -70,6 +70,9 @@ const folderElement = element.bind(null, 'folder');
 const wkspFolderElement = element.bind(null, 'workspaceRootFolder');
 const topLevelMarkedFolderElement = element.bind(null, 'topLevelMarkedFolder');
 
+const onDidUpdateListener = vi.fn();
+const onDidChangeFileDecorationsListener = vi.fn();
+
 function element(
   type: RemoteImportSourceTreeElement['type'],
   uri: vscode.Uri,
@@ -299,6 +302,9 @@ async function initWorkspace(wsMap: URIMap<URISet>): Promise<{
     mockToaster
   );
 
+  workspace.onDidUpdate(onDidUpdateListener);
+  workspace.onDidChangeFileDecorations(onDidChangeFileDecorationsListener);
+
   return {
     workspace,
     // Helper to check the current state of the workspace against expected nodes
@@ -379,74 +385,113 @@ describe('getTopLevelMarkedFolders', () => {
   );
 });
 
-describe('mark / unmark', () => {
-  it.each([
-    [[mock.folder1.sub1, mock.folder1.sub2], expected.folder1.allMarked],
-    [[mock.folder1.sub1], expected.folder1.sub1Marked],
-    [[mock.folder1.sub1_a], expected.folder1.sub1aMarked],
-  ])(
-    'should mark a folder and its children: %s',
-    async (markRoots, expected) => {
+describe.each([true, false])(
+  'mark / unmark - supressNotify%s',
+  supressNotify => {
+    it.each([
+      [[mock.folder1.sub1, mock.folder1.sub2], expected.folder1.allMarked],
+      [[mock.folder1.sub1], expected.folder1.sub1Marked],
+      [[mock.folder1.sub1_a], expected.folder1.sub1aMarked],
+    ])(
+      'should mark a folder and its children: %s',
+      async (markRoots, expected) => {
+        const { workspace, expectResult } = await initWorkspace(mock2RootWs);
+
+        vi.spyOn(workspace, 'unmarkConflictingTopLevelFolder');
+
+        markRoots.forEach(markRoot => {
+          workspace.markFolder(markRoot, supressNotify);
+          expect(
+            workspace.unmarkConflictingTopLevelFolder
+          ).toHaveBeenCalledWith(markRoot, true);
+        });
+
+        expectResult(mock.folder1.root, expected);
+
+        if (supressNotify) {
+          expect(onDidUpdateListener).not.toHaveBeenCalled();
+          expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
+        } else {
+          expect(onDidUpdateListener).toHaveBeenCalledTimes(markRoots.length);
+          expect(onDidChangeFileDecorationsListener).toHaveBeenCalledTimes(
+            markRoots.length
+          );
+        }
+      }
+    );
+
+    it('should replace folder with conflicting module name', async () => {
       const { workspace, expectResult } = await initWorkspace(mock2RootWs);
 
-      markRoots.forEach(markRoot => {
-        workspace.markFolder(markRoot);
-      });
+      const moduleA = mock.folder1.sub1_a;
+      const conflictingModuleA = mock.folder1.sub2_a;
 
-      expectResult(mock.folder1.root, expected);
-    }
-  );
+      workspace.markFolder(moduleA, supressNotify);
 
-  it('should replace folder with conflicting module name', async () => {
-    const { workspace, expectResult } = await initWorkspace(mock2RootWs);
+      expectResult(
+        mock.folder1.root,
+        expected.folder1.sub1aMarked,
+        'mark module a'
+      );
 
-    const moduleA = mock.folder1.sub1_a;
-    const conflictingModuleA = mock.folder1.sub2_a;
+      workspace.markFolder(moduleA, supressNotify);
+      expect(mockToaster.error).not.toHaveBeenCalled();
+      expectResult(
+        mock.folder1.root,
+        expected.folder1.sub1aMarked,
+        'mark same module a again'
+      );
 
-    workspace.markFolder(moduleA);
+      workspace.markFolder(conflictingModuleA, supressNotify);
+      expect(mockToaster.info).toHaveBeenCalledWith(
+        `Updated 'a' import source to 'sub2/a'.`
+      );
+      expectResult(
+        mock.folder1.root,
+        expected.folder1.sub2aMarked,
+        'unmark conflicting module a'
+      );
 
-    expectResult(
-      mock.folder1.root,
-      expected.folder1.sub1aMarked,
-      'mark module a'
-    );
+      if (supressNotify) {
+        expect(onDidUpdateListener).not.toHaveBeenCalled();
+        expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
+      } else {
+        expect(onDidUpdateListener).toHaveBeenCalledTimes(3);
+        expect(onDidChangeFileDecorationsListener).toHaveBeenCalledTimes(3);
+      }
+    });
+  }
+);
 
-    workspace.markFolder(moduleA);
-    expect(mockToaster.error).not.toHaveBeenCalled();
-    expectResult(
-      mock.folder1.root,
-      expected.folder1.sub1aMarked,
-      'mark same module a again'
-    );
+describe.each([true, false])(
+  'unmarkFolder - supressNotify%s',
+  supressNotify => {
+    it('should unmark a folder and its children', async () => {
+      const { workspace, expectResult } = await initWorkspace(mock2RootWs);
 
-    workspace.markFolder(conflictingModuleA);
-    expect(mockToaster.info).toHaveBeenCalledWith(
-      `Updated 'a' import source to 'sub2/a'.`
-    );
-    expectResult(
-      mock.folder1.root,
-      expected.folder1.sub2aMarked,
-      'unmark conflicting module a'
-    );
-  });
-});
+      workspace.markFolder(mock.folder1.sub1, supressNotify);
+      workspace.markFolder(mock.folder1.sub2, supressNotify);
+      vi.clearAllMocks();
 
-describe('unmarkFolder', () => {
-  it('should unmark a folder and its children', async () => {
-    const { workspace, expectResult } = await initWorkspace(mock2RootWs);
-    workspace.markFolder(mock.folder1.sub1);
-    workspace.markFolder(mock.folder1.sub2);
+      workspace.unmarkFolder(mock.folder1.sub2, supressNotify);
 
-    workspace.unmarkFolder(mock.folder1.sub2);
+      // Unmarking sub2 should result in only sub1 being marked
+      expectResult(
+        mock.folder1.root,
+        expected.folder1.sub1Marked,
+        'unmark folder1 sub2'
+      );
 
-    // Unmarking sub2 should result in only sub1 being marked
-    expectResult(
-      mock.folder1.root,
-      expected.folder1.sub1Marked,
-      'unmark folder1 sub2'
-    );
-  });
-});
+      if (supressNotify) {
+        expect(onDidUpdateListener).not.toHaveBeenCalled();
+        expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
+      } else {
+        expect(onDidUpdateListener).toHaveBeenCalledTimes(1);
+        expect(onDidChangeFileDecorationsListener).toHaveBeenCalledTimes(1);
+      }
+    });
+  }
+);
 
 describe('unmarkConflictingTopLevelFolder', () => {
   it('should unmark conflicting top-level marked folders', async () => {
@@ -462,7 +507,10 @@ describe('unmarkConflictingTopLevelFolder', () => {
       expected.folder1.sub1aMarked,
       'mark module a'
     );
+    onDidUpdateListener.mockClear();
+    onDidChangeFileDecorationsListener.mockClear();
 
+    // non-conflict scenario
     workspace.unmarkConflictingTopLevelFolder(moduleA);
     expect(mockToaster.error).not.toHaveBeenCalled();
     expectResult(
@@ -470,7 +518,10 @@ describe('unmarkConflictingTopLevelFolder', () => {
       expected.folder1.sub1aMarked,
       'unmark non-conclicting module a'
     );
+    expect(onDidUpdateListener).not.toHaveBeenCalled();
+    expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
 
+    // conflict scenario
     workspace.unmarkConflictingTopLevelFolder(conflictingModuleA);
     expect(mockToaster.info).toHaveBeenCalledWith(
       `Updated 'a' import source to 'sub2/a'.`
@@ -480,6 +531,8 @@ describe('unmarkConflictingTopLevelFolder', () => {
       expected.folder1.allUnmarked,
       'unmark conflicting module a'
     );
+    expect(onDidUpdateListener).toHaveBeenCalledTimes(1);
+    expect(onDidChangeFileDecorationsListener).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/services/FilteredWorkspace.spec.ts
+++ b/src/services/FilteredWorkspace.spec.ts
@@ -386,8 +386,8 @@ describe('getTopLevelMarkedFolders', () => {
 });
 
 describe.each([true, false])(
-  'mark / unmark - supressNotify%s',
-  supressNotify => {
+  'mark / unmark - suppressNotify%s',
+  suppressNotify => {
     it.each([
       [[mock.folder1.sub1, mock.folder1.sub2], expected.folder1.allMarked],
       [[mock.folder1.sub1], expected.folder1.sub1Marked],
@@ -400,7 +400,7 @@ describe.each([true, false])(
         vi.spyOn(workspace, 'unmarkConflictingTopLevelFolder');
 
         markRoots.forEach(markRoot => {
-          workspace.markFolder(markRoot, supressNotify);
+          workspace.markFolder(markRoot, suppressNotify);
           expect(
             workspace.unmarkConflictingTopLevelFolder
           ).toHaveBeenCalledWith(markRoot, true);
@@ -408,7 +408,7 @@ describe.each([true, false])(
 
         expectResult(mock.folder1.root, expected);
 
-        if (supressNotify) {
+        if (suppressNotify) {
           expect(onDidUpdateListener).not.toHaveBeenCalled();
           expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
         } else {
@@ -426,7 +426,7 @@ describe.each([true, false])(
       const moduleA = mock.folder1.sub1_a;
       const conflictingModuleA = mock.folder1.sub2_a;
 
-      workspace.markFolder(moduleA, supressNotify);
+      workspace.markFolder(moduleA, suppressNotify);
 
       expectResult(
         mock.folder1.root,
@@ -434,7 +434,7 @@ describe.each([true, false])(
         'mark module a'
       );
 
-      workspace.markFolder(moduleA, supressNotify);
+      workspace.markFolder(moduleA, suppressNotify);
       expect(mockToaster.error).not.toHaveBeenCalled();
       expectResult(
         mock.folder1.root,
@@ -442,7 +442,7 @@ describe.each([true, false])(
         'mark same module a again'
       );
 
-      workspace.markFolder(conflictingModuleA, supressNotify);
+      workspace.markFolder(conflictingModuleA, suppressNotify);
       expect(mockToaster.info).toHaveBeenCalledWith(
         `Updated 'a' import source to 'sub2/a'.`
       );
@@ -452,7 +452,7 @@ describe.each([true, false])(
         'unmark conflicting module a'
       );
 
-      if (supressNotify) {
+      if (suppressNotify) {
         expect(onDidUpdateListener).not.toHaveBeenCalled();
         expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
       } else {
@@ -464,16 +464,16 @@ describe.each([true, false])(
 );
 
 describe.each([true, false])(
-  'unmarkFolder - supressNotify%s',
-  supressNotify => {
+  'unmarkFolder - suppressNotify%s',
+  suppressNotify => {
     it('should unmark a folder and its children', async () => {
       const { workspace, expectResult } = await initWorkspace(mock2RootWs);
 
-      workspace.markFolder(mock.folder1.sub1, supressNotify);
-      workspace.markFolder(mock.folder1.sub2, supressNotify);
+      workspace.markFolder(mock.folder1.sub1, suppressNotify);
+      workspace.markFolder(mock.folder1.sub2, suppressNotify);
       vi.clearAllMocks();
 
-      workspace.unmarkFolder(mock.folder1.sub2, supressNotify);
+      workspace.unmarkFolder(mock.folder1.sub2, suppressNotify);
 
       // Unmarking sub2 should result in only sub1 being marked
       expectResult(
@@ -482,7 +482,7 @@ describe.each([true, false])(
         'unmark folder1 sub2'
       );
 
-      if (supressNotify) {
+      if (suppressNotify) {
         expect(onDidUpdateListener).not.toHaveBeenCalled();
         expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
       } else {
@@ -495,18 +495,15 @@ describe.each([true, false])(
       const { workspace, expectResult } = await initWorkspace(mock2RootWs);
 
       // Mark sub1 as top-level, which marks all its descendants
-      workspace.markFolder(mock.folder1.sub1, supressNotify);
+      workspace.markFolder(mock.folder1.sub1, suppressNotify);
       vi.clearAllMocks();
 
       vi.spyOn(workspace, 'unmarkConflictingTopLevelFolder');
 
       // Unmark sub1_b (nested child) — triggers ancestor behavior on sub1
-      workspace.unmarkFolder(mock.folder1.sub1_b, supressNotify);
+      workspace.unmarkFolder(mock.folder1.sub1_b, suppressNotify);
 
-      expectResult(
-        mock.folder1.root,
-        expected.folder1.sub1aMarked
-      );
+      expectResult(mock.folder1.root, expected.folder1.sub1aMarked);
 
       // sub1 (the ancestor) should no longer be a top-level marked folder
       const topLevelFolders = workspace.getTopLevelMarkedFolders();
@@ -527,7 +524,7 @@ describe.each([true, false])(
         true
       );
 
-      if (supressNotify) {
+      if (suppressNotify) {
         expect(onDidUpdateListener).not.toHaveBeenCalled();
         expect(onDidChangeFileDecorationsListener).not.toHaveBeenCalled();
       } else {

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -122,10 +122,10 @@ export class FilteredWorkspace<
    * Mark a folder and all its children. Will also update parent folders if the
    * changes cause a status change.
    * @param folderUri The folder URI to mark.
-   * @param supressNotify If true, will not notify listeners of changes.
+   * @param suppressNotify If true, will not notify listeners of changes.
    */
-  markFolder(folderUri: vscode.Uri, supressNotify = false): void {
-    // supress notify to avoid multiple notifications during marking
+  markFolder(folderUri: vscode.Uri, suppressNotify = false): void {
+    // suppress notify to avoid multiple notifications during marking
     this.unmarkConflictingTopLevelFolder(folderUri, true);
 
     for (const node of this.iterateNodeTree(folderUri)) {
@@ -146,7 +146,7 @@ export class FilteredWorkspace<
       }
     }
 
-    if (!supressNotify) {
+    if (!suppressNotify) {
       this._onDidChangeFileDecorations.fire(undefined);
       this._onDidUpdate.fire();
     }
@@ -157,12 +157,12 @@ export class FilteredWorkspace<
    * checks for any existing mappings for the same module name as the given
    * folder URI, and unmarks them.
    * @param folderUri
-   * @param supressNotify If true, will not notify listeners of changes.
+   * @param suppressNotify If true, will not notify listeners of changes.
    * @returns
    */
   unmarkConflictingTopLevelFolder(
     folderUri: vscode.Uri,
-    supressNotify = false
+    suppressNotify = false
   ): void {
     const moduleName = this._getTopLevelModuleName(folderUri);
     const existingTopLevelUri = this._topLevelMarkedUriMap.get(moduleName);
@@ -181,7 +181,7 @@ export class FilteredWorkspace<
       return;
     }
 
-    this.unmarkFolder(existingTopLevelUri, supressNotify);
+    this.unmarkFolder(existingTopLevelUri, suppressNotify);
 
     const relativePath = vscode.workspace.asRelativePath(folderUri, true);
 
@@ -193,9 +193,9 @@ export class FilteredWorkspace<
   /**
    * Unmark a folder, its children, and its ancestors.
    * @param folderUri The folder URI to unmark.
-   * @param supressNotify If true, will not notify listeners of changes.
+   * @param suppressNotify If true, will not notify listeners of changes.
    */
-  unmarkFolder(folderUri: vscode.Uri, supressNotify = false): void {
+  unmarkFolder(folderUri: vscode.Uri, suppressNotify = false): void {
     for (const node of this.iterateNodeTree(folderUri)) {
       if (node.type !== 'workspaceRootFolder') {
         node.isMarked = false;
@@ -215,7 +215,7 @@ export class FilteredWorkspace<
         }
 
         if (childNode.type === 'folder') {
-          // supress notify to avoid multiple notifications during unmarking
+          // suppress notify to avoid multiple notifications during unmarking
           this.unmarkConflictingTopLevelFolder(childNode.uri, true);
 
           this._topLevelMarkedUriMap.set(
@@ -229,7 +229,7 @@ export class FilteredWorkspace<
       }
     }
 
-    if (!supressNotify) {
+    if (!suppressNotify) {
       this._onDidChangeFileDecorations.fire(undefined);
       this._onDidUpdate.fire();
     }
@@ -271,9 +271,9 @@ export class FilteredWorkspace<
     for (const [, folderUri] of topLeveMarkedlUris) {
       for (const node of this.iterateNodeTree(folderUri)) {
         if (node.type === 'file') {
-          const relativePath = path.join(
-            path.basename(folderUri.fsPath),
-            path.relative(folderUri.fsPath, node.uri.fsPath)
+          const relativePath = path.posix.join(
+            path.posix.basename(folderUri.path),
+            path.posix.relative(folderUri.path, node.uri.path)
           );
           relativeFilePaths.add(relativePath as RelativeWsUriString);
         }
@@ -435,9 +435,9 @@ export class FilteredWorkspace<
 
   /**
    * Refresh caches based on current workspace state.
-   * @param supressNotify If true, will not notify listeners of changes.
+   * @param suppressNotify If true, will not notify listeners of changes.
    */
-  async refresh(supressNotify = false): Promise<void> {
+  async refresh(suppressNotify = false): Promise<void> {
     // Store a map of just the filtered files in the workspace
     this._wsFileUriMap = await getWorkspaceFileUriMap(
       this.filePattern,
@@ -501,7 +501,7 @@ export class FilteredWorkspace<
       }
     }
 
-    if (!supressNotify) {
+    if (!suppressNotify) {
       this._onDidChangeFileDecorations.fire(undefined);
       this._onDidUpdate.fire();
     }
@@ -525,7 +525,10 @@ export class FilteredWorkspace<
    */
   private _isUnderMarkedFolder(uri: vscode.Uri): boolean {
     for (const markedFolderUri of this._topLevelMarkedUriMap.values()) {
-      if (uri.fsPath.startsWith(markedFolderUri.fsPath)) {
+      if (
+        uri.fsPath === markedFolderUri.fsPath ||
+        uri.fsPath.startsWith(markedFolderUri.fsPath + path.sep)
+      ) {
         return true;
       }
     }

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -25,23 +25,24 @@ const logger = new Logger('FilteredWorkspace');
 export const GROOVY_FILE_PATTERN = '**/*.groovy' as const;
 export const PYTHON_FILE_PATTERN = '**/*.py' as const;
 
-export const GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES = new Set<FolderName>();
-
 // TODO: This should be configurable DH-20662
-export const PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES: Set<FolderName> =
+export const DEFAULT_IGNORE_TOP_LEVEL_FOLDER_NAMES: Set<FolderName> =
   new Set<FolderName>([
-    '.venv',
-    'venv',
-    'env',
-    '.env',
     '__pycache__',
+    '.env',
     '.git',
+    '.gradle',
+    '.ipynb_checkpoints',
     '.mypy_cache',
     '.pytest_cache',
     '.tox',
+    '.venv',
+    '*.egg-info',
     'build',
     'dist',
-    '*.egg-info',
+    'env',
+    'node_modules',
+    'venv',
   ] as Array<FolderName>);
 
 export type FilteredWorkspaceRootNode =

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -62,6 +62,7 @@ export class FilteredWorkspace<
 {
   constructor(
     readonly filePattern: FilePattern,
+    readonly languageId: 'groovy' | 'python',
     private readonly _getTopLevelModuleName: (
       folderUri: vscode.Uri
     ) => TModuleName,
@@ -244,6 +245,7 @@ export class FilteredWorkspace<
     return topLeveMarkedlUris.map(([name, uri]) => ({
       name,
       type: 'topLevelMarkedFolder',
+      languageId: this.languageId,
       isMarked: true,
       uri,
     }));
@@ -412,6 +414,7 @@ export class FilteredWorkspace<
       this._updateNodeMaps(null, {
         name: ws.name,
         type: 'workspaceRootFolder',
+        languageId: this.languageId,
         uri: wsUri,
       });
 
@@ -429,6 +432,7 @@ export class FilteredWorkspace<
           this._updateNodeMaps(parentUri, {
             uri,
             type: uri.fsPath === fileUri.fsPath ? 'file' : 'folder',
+            languageId: this.languageId,
             isMarked: false,
             name: token,
           });

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -77,6 +77,9 @@ export class FilteredWorkspace<
 
     const watcher = vscode.workspace.createFileSystemWatcher(filePattern);
     this.disposables.add(watcher.onDidCreate(() => this.refresh()));
+    this.disposables.add(
+      watcher.onDidChange(uri => this._handleFileContentChange(uri))
+    );
     this.disposables.add(watcher.onDidDelete(() => this.refresh()));
     this.disposables.add(watcher);
 
@@ -494,6 +497,31 @@ export class FilteredWorkspace<
       this._onDidChangeFileDecorations.fire(undefined);
       this._onDidUpdate.fire();
     }
+  }
+
+  /**
+   * Handle file content changes and fire update events if the file is under
+   * a marked folder.
+   * @param uri The URI of the file that changed.
+   */
+  private _handleFileContentChange(uri: vscode.Uri): void {
+    if (this._isUnderMarkedFolder(uri)) {
+      this._onDidUpdate.fire();
+    }
+  }
+
+  /**
+   * Check if a URI is under any marked folder.
+   * @param uri The URI to check.
+   * @returns true if the URI is under a marked folder, false otherwise.
+   */
+  private _isUnderMarkedFolder(uri: vscode.Uri): boolean {
+    for (const markedFolderUri of this._topLevelMarkedUriMap.values()) {
+      if (uri.fsPath.startsWith(markedFolderUri.fsPath)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import type {
   FilePattern,
   FolderName,
+  GroovyPackageName,
   PythonModuleFullname,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
@@ -9,7 +10,6 @@ import type {
   RemoteImportSourceTreeWkspRootFolderElement,
 } from '../types';
 import {
-  getTopLevelModuleFullname,
   getWorkspaceFileUriMap,
   Logger,
   URIMap,
@@ -54,12 +54,17 @@ export type FilteredWorkspaceNode =
  * Represents a filtered view of a VS Code workspace. Also supports "marking"
  * folders that can be used for an additional filter layer.
  */
-export class FilteredWorkspace
+export class FilteredWorkspace<
+    TModuleName extends PythonModuleFullname | GroovyPackageName,
+  >
   extends DisposableBase
   implements vscode.FileDecorationProvider
 {
   constructor(
     readonly filePattern: FilePattern,
+    private readonly _getTopLevelModuleName: (
+      folderUri: vscode.Uri
+    ) => TModuleName,
     private readonly _ignoreTopLevelFolderNames: Set<FolderName>,
     private readonly _toaster: Toaster
   ) {
@@ -89,10 +94,7 @@ export class FilteredWorkspace
   private readonly _parentUriMap = new URIMap<vscode.Uri | null>();
   private readonly _nodeMap = new URIMap<FilteredWorkspaceNode>();
   private readonly _rootNodeMap = new URIMap<FilteredWorkspaceRootNode>();
-  private readonly _topLevelMarkedUriMap = new Map<
-    PythonModuleFullname,
-    vscode.Uri
-  >();
+  private readonly _topLevelMarkedUriMap = new Map<TModuleName, vscode.Uri>();
   private _wsFileUriMap = new URIMap<URISet>();
 
   /**
@@ -100,7 +102,7 @@ export class FilteredWorkspace
    * @param folderUri The folder URI to delete.
    */
   deleteExactTopLevelMarkedUri(folderUri: vscode.Uri): void {
-    const moduleName = getTopLevelModuleFullname(folderUri);
+    const moduleName = this._getTopLevelModuleName(folderUri);
 
     if (
       this._topLevelMarkedUriMap.get(moduleName)?.fsPath === folderUri.fsPath
@@ -126,7 +128,7 @@ export class FilteredWorkspace
 
       // If this node is the parent folder being marked, add it to the map
       if (node.uri.fsPath === folderUri.fsPath) {
-        const moduleName = getTopLevelModuleFullname(node.uri);
+        const moduleName = this._getTopLevelModuleName(node.uri);
         this._topLevelMarkedUriMap.set(moduleName, folderUri);
       } else {
         // Since we've marked the parent folder as top-level, remove top-level
@@ -147,7 +149,7 @@ export class FilteredWorkspace
    * @returns
    */
   unmarkConflictingTopLevelFolder(folderUri: vscode.Uri): void {
-    const moduleName = getTopLevelModuleFullname(folderUri);
+    const moduleName = this._getTopLevelModuleName(folderUri);
     const existingTopLevelUri = this._topLevelMarkedUriMap.get(moduleName);
     const noConflict =
       existingTopLevelUri == null ||
@@ -196,7 +198,7 @@ export class FilteredWorkspace
           this.unmarkConflictingTopLevelFolder(childNode.uri);
 
           this._topLevelMarkedUriMap.set(
-            getTopLevelModuleFullname(childNode.uri),
+            this._getTopLevelModuleName(childNode.uri),
             childNode.uri
           );
         }

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -1,9 +1,11 @@
 import * as vscode from 'vscode';
+import path from 'node:path';
 import type {
   FilePattern,
   FolderName,
   GroovyPackageName,
   PythonModuleFullname,
+  RelativeWsUriString,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
   RemoteImportSourceTreeTopLevelMarkedFolderElement,
@@ -116,9 +118,11 @@ export class FilteredWorkspace<
    * Mark a folder and all its children. Will also update parent folders if the
    * changes cause a status change.
    * @param folderUri The folder URI to mark.
+   * @param supressNotify If true, will not notify listeners of changes.
    */
-  markFolder(folderUri: vscode.Uri): void {
-    this.unmarkConflictingTopLevelFolder(folderUri);
+  markFolder(folderUri: vscode.Uri, supressNotify = false): void {
+    // supress notify to avoid multiple notifications during marking
+    this.unmarkConflictingTopLevelFolder(folderUri, true);
 
     for (const node of this.iterateNodeTree(folderUri)) {
       if (node.type === 'workspaceRootFolder') {
@@ -138,8 +142,10 @@ export class FilteredWorkspace<
       }
     }
 
-    this._onDidChangeFileDecorations.fire(undefined);
-    this._onDidUpdate.fire();
+    if (!supressNotify) {
+      this._onDidChangeFileDecorations.fire(undefined);
+      this._onDidUpdate.fire();
+    }
   }
 
   /**
@@ -147,9 +153,13 @@ export class FilteredWorkspace<
    * checks for any existing mappings for the same module name as the given
    * folder URI, and unmarks them.
    * @param folderUri
+   * @param supressNotify If true, will not notify listeners of changes.
    * @returns
    */
-  unmarkConflictingTopLevelFolder(folderUri: vscode.Uri): void {
+  unmarkConflictingTopLevelFolder(
+    folderUri: vscode.Uri,
+    supressNotify = false
+  ): void {
     const moduleName = this._getTopLevelModuleName(folderUri);
     const existingTopLevelUri = this._topLevelMarkedUriMap.get(moduleName);
     const noConflict =
@@ -167,7 +177,7 @@ export class FilteredWorkspace<
       return;
     }
 
-    this.unmarkFolder(existingTopLevelUri);
+    this.unmarkFolder(existingTopLevelUri, supressNotify);
 
     const relativePath = vscode.workspace.asRelativePath(folderUri, true);
 
@@ -179,8 +189,9 @@ export class FilteredWorkspace<
   /**
    * Unmark a folder, its children, and its ancestors.
    * @param folderUri The folder URI to unmark.
+   * @param supressNotify If true, will not notify listeners of changes.
    */
-  unmarkFolder(folderUri: vscode.Uri): void {
+  unmarkFolder(folderUri: vscode.Uri, supressNotify = false): void {
     for (const node of this.iterateNodeTree(folderUri)) {
       if (node.type !== 'workspaceRootFolder') {
         node.isMarked = false;
@@ -196,7 +207,8 @@ export class FilteredWorkspace<
       // remaining marked children to re-add as top-level folders
       for (const childNode of this.getChildNodes(node.uri)) {
         if (childNode.isMarked) {
-          this.unmarkConflictingTopLevelFolder(childNode.uri);
+          // supress notify to avoid multiple notifications during unmarking
+          this.unmarkConflictingTopLevelFolder(childNode.uri, true);
 
           this._topLevelMarkedUriMap.set(
             this._getTopLevelModuleName(childNode.uri),
@@ -206,8 +218,10 @@ export class FilteredWorkspace<
       }
     }
 
-    this._onDidChangeFileDecorations.fire(undefined);
-    this._onDidUpdate.fire();
+    if (!supressNotify) {
+      this._onDidChangeFileDecorations.fire(undefined);
+      this._onDidUpdate.fire();
+    }
   }
 
   /**
@@ -233,6 +247,29 @@ export class FilteredWorkspace<
     }
 
     return [...childMap.values()];
+  }
+
+  /**
+   * Get relative file paths under marked folders.
+   * @returns The set of relative file paths.
+   */
+  getMarkedRelativeFilePaths(): Set<RelativeWsUriString> {
+    const relativeFilePaths = new Set<RelativeWsUriString>();
+
+    const topLeveMarkedlUris = [...this._topLevelMarkedUriMap.entries()];
+    for (const [, folderUri] of topLeveMarkedlUris) {
+      for (const node of this.iterateNodeTree(folderUri)) {
+        if (node.type === 'file') {
+          const relativePath = path.join(
+            path.basename(folderUri.fsPath),
+            path.relative(folderUri.fsPath, node.uri.fsPath)
+          );
+          relativeFilePaths.add(relativePath as RelativeWsUriString);
+        }
+      }
+    }
+
+    return relativeFilePaths;
   }
 
   /**
@@ -387,8 +424,9 @@ export class FilteredWorkspace<
 
   /**
    * Refresh caches based on current workspace state.
+   * @param supressNotify If true, will not notify listeners of changes.
    */
-  async refresh(): Promise<void> {
+  async refresh(supressNotify = false): Promise<void> {
     // Store a map of just the filtered files in the workspace
     this._wsFileUriMap = await getWorkspaceFileUriMap(
       this.filePattern,
@@ -445,14 +483,17 @@ export class FilteredWorkspace<
     // Re-apply top level marked folders if they still exist after refresh
     for (const uri of this._topLevelMarkedUriMap.values()) {
       if (this._nodeMap.has(uri)) {
-        this.markFolder(uri);
+        // surpress notify to avoid multiple notifications during refresh
+        this.markFolder(uri, true);
       } else {
         this.deleteExactTopLevelMarkedUri(uri);
       }
     }
 
-    this._onDidChangeFileDecorations.fire(undefined);
-    this._onDidUpdate.fire();
+    if (!supressNotify) {
+      this._onDidChangeFileDecorations.fire(undefined);
+      this._onDidUpdate.fire();
+    }
   }
 
   /**

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import type {
   FilePattern,
   FolderName,
-  ModuleFullname,
+  PythonModuleFullname,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
   RemoteImportSourceTreeTopLevelMarkedFolderElement,
@@ -20,10 +20,13 @@ import { DisposableBase } from './DisposableBase';
 
 const logger = new Logger('FilteredWorkspace');
 
+export const GROOVY_FILE_PATTERN = '**/*.groovy' as const;
 export const PYTHON_FILE_PATTERN = '**/*.py' as const;
 
+export const GROOVY_IGNORE_TOP_LEVEL_FOLDER_NAMES = new Set<FolderName>();
+
 // TODO: This should be configurable DH-20662
-const PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES: Set<FolderName> =
+export const PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES: Set<FolderName> =
   new Set<FolderName>([
     '.venv',
     'venv',
@@ -57,6 +60,7 @@ export class FilteredWorkspace
 {
   constructor(
     readonly filePattern: FilePattern,
+    private readonly _ignoreTopLevelFolderNames: Set<FolderName>,
     private readonly _toaster: Toaster
   ) {
     super();
@@ -81,15 +85,12 @@ export class FilteredWorkspace
   private _onDidUpdate = new vscode.EventEmitter<void>();
   readonly onDidUpdate = this._onDidUpdate.event;
 
-  private readonly _ignoreTopLevelFolderNames =
-    PYTHON_IGNORE_TOP_LEVEL_FOLDER_NAMES;
-
   private readonly _childNodeMap = new URIMap<URIMap<FilteredWorkspaceNode>>();
   private readonly _parentUriMap = new URIMap<vscode.Uri | null>();
   private readonly _nodeMap = new URIMap<FilteredWorkspaceNode>();
   private readonly _rootNodeMap = new URIMap<FilteredWorkspaceRootNode>();
   private readonly _topLevelMarkedUriMap = new Map<
-    ModuleFullname,
+    PythonModuleFullname,
     vscode.Uri
   >();
   private _wsFileUriMap = new URIMap<URISet>();

--- a/src/services/FilteredWorkspace.ts
+++ b/src/services/FilteredWorkspace.ts
@@ -210,7 +210,11 @@ export class FilteredWorkspace<
       // Since we've unmarked the parent as a top-level folder, we look for any
       // remaining marked children to re-add as top-level folders
       for (const childNode of this.getChildNodes(node.uri)) {
-        if (childNode.isMarked) {
+        if (!childNode.isMarked) {
+          continue;
+        }
+
+        if (childNode.type === 'folder') {
           // supress notify to avoid multiple notifications during unmarking
           this.unmarkConflictingTopLevelFolder(childNode.uri, true);
 
@@ -218,6 +222,9 @@ export class FilteredWorkspace<
             this._getTopLevelModuleName(childNode.uri),
             childNode.uri
           );
+        } else {
+          // Files cannot be top-level entries; unmark since their parent is now unmarked
+          childNode.isMarked = false;
         }
       }
     }

--- a/src/services/RemoteFileSourceService.ts
+++ b/src/services/RemoteFileSourceService.ts
@@ -158,16 +158,6 @@ export class RemoteFileSourceService extends DisposableBase {
     return null;
   }
 
-  getGroovyTopLevelPackageNames(): Set<GroovyPackageName> {
-    const set = new Set<GroovyPackageName>();
-
-    this._groovyWorkspace.getTopLevelMarkedFolders().forEach(({ uri }) => {
-      set.add(getGroovyTopLevelPackageName(uri));
-    });
-
-    return set;
-  }
-
   /**
    * Get the top level Python module names available to the remote file source.
    */
@@ -258,7 +248,7 @@ export class RemoteFileSourceService extends DisposableBase {
     pluginService: DhcType.remotefilesource.RemoteFileSourceService
   ): Promise<void> {
     await pluginService.setExecutionContext([
-      ...this.getGroovyTopLevelPackageNames(),
+      ...this._groovyWorkspace.getMarkedRelativeFilePaths(),
     ]);
   }
 

--- a/src/services/RemoteFileSourceService.ts
+++ b/src/services/RemoteFileSourceService.ts
@@ -30,7 +30,7 @@ export class RemoteFileSourceService extends DisposableBase {
 
     this.disposables.add(
       this._groovyWorkspace.onDidUpdate(() => {
-        this._onDidUpdateGroovyModuleMeta.fire();
+        this._isGroovyWorkspaceDirty = true;
       })
     );
 
@@ -41,9 +41,7 @@ export class RemoteFileSourceService extends DisposableBase {
     );
   }
 
-  private _onDidUpdateGroovyModuleMeta = new vscode.EventEmitter<void>();
-  readonly onDidUpdateGroovyModuleMeta =
-    this._onDidUpdateGroovyModuleMeta.event;
+  private _isGroovyWorkspaceDirty = false;
 
   private _onDidUpdatePythonModuleMeta = new vscode.EventEmitter<void>();
   readonly onDidUpdatePythonModuleMeta =
@@ -183,22 +181,10 @@ export class RemoteFileSourceService extends DisposableBase {
         getGroovyResourceData
       );
 
-    const setServerExecutionContext = this.setGroovyServerExecutionContext.bind(
-      this,
-      pluginService
-    );
-
-    // Set initial top-level module names and subscribe to update on meta changes
-    await setServerExecutionContext();
-    const metaSubscription = this.onDidUpdateGroovyModuleMeta(
-      setServerExecutionContext
-    );
-
     this.disposables.add(messageSubscription);
 
     return () => {
       messageSubscription();
-      metaSubscription.dispose();
     };
   }
 
@@ -247,7 +233,10 @@ export class RemoteFileSourceService extends DisposableBase {
   async setGroovyServerExecutionContext(
     pluginService: DhcType.remotefilesource.RemoteFileSourceService
   ): Promise<void> {
-    await pluginService.setExecutionContext([
+    const isDirty = this._isGroovyWorkspaceDirty;
+    this._isGroovyWorkspaceDirty = false;
+
+    await pluginService.setExecutionContext(isDirty, [
       ...this._groovyWorkspace.getMarkedRelativeFilePaths(),
     ]);
   }

--- a/src/services/RemoteFileSourceService.ts
+++ b/src/services/RemoteFileSourceService.ts
@@ -236,9 +236,18 @@ export class RemoteFileSourceService extends DisposableBase {
     const isDirty = this._isGroovyWorkspaceDirty;
     this._isGroovyWorkspaceDirty = false;
 
-    await pluginService.setExecutionContext(isDirty, [
+    const resourcePaths = [
       ...this._groovyWorkspace.getMarkedRelativeFilePaths(),
-    ]);
+    ];
+
+    logger.debug(
+      'Setting Groovy server execution context. isDirty:',
+      isDirty,
+      'resourcePaths:',
+      resourcePaths
+    );
+
+    await pluginService.setExecutionContext(isDirty, resourcePaths);
   }
 
   /**

--- a/src/types/remoteFileSourceTypes.ts
+++ b/src/types/remoteFileSourceTypes.ts
@@ -4,7 +4,8 @@ export type Include<T> = { value: T; include?: boolean };
 
 export type FilePattern = `**/*.${string}`;
 export type FolderName = Brand<'FolderName', string>;
-export type ModuleFullname = Brand<'ModuleFullname', string>;
+export type GroovyResourceName = Brand<'GroovyResourceName', string>;
+export type PythonModuleFullname = Brand<'ModuleFullname', string>;
 export type RelativeWsUriString = Brand<'RelativeWsUriString', string>;
 
 interface JsonRpcRequestBase {
@@ -15,7 +16,7 @@ interface JsonRpcRequestBase {
 export interface JsonRpcFetchModuleRequest extends JsonRpcRequestBase {
   method: 'fetch_module';
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  params: { module_name: ModuleFullname };
+  params: { module_name: PythonModuleFullname };
 }
 
 export interface JsonRpcSetConnectionIdRequest extends JsonRpcRequestBase {
@@ -45,14 +46,14 @@ export interface JsonRpcError {
 export type JsonRpcResponse = JsonRpcSuccess | JsonRpcError;
 
 export interface PythonRegularPackageSpecData {
-  name: ModuleFullname;
+  name: PythonModuleFullname;
   isPackage: true;
   origin: string;
   subModuleSearchLocations: string[];
 }
 
 export interface PythonNamespacePackageSpecData {
-  name: ModuleFullname;
+  name: PythonModuleFullname;
   isPackage: true;
   subModuleSearchLocations: string[];
 
@@ -61,7 +62,7 @@ export interface PythonNamespacePackageSpecData {
 }
 
 export interface PythonRegularModuleSpecData {
-  name: ModuleFullname;
+  name: PythonModuleFullname;
   isPackage: false;
   origin: string;
 
@@ -75,7 +76,7 @@ export type PythonModuleSpecData =
   | PythonRegularModuleSpecData;
 
 export interface PythonModuleSpecDataResult {
-  name: ModuleFullname;
+  name: PythonModuleFullname;
   origin?: string;
   /* eslint-disable @typescript-eslint/naming-convention */
   is_package: boolean;

--- a/src/types/remoteFileSourceTypes.ts
+++ b/src/types/remoteFileSourceTypes.ts
@@ -71,6 +71,11 @@ export interface PythonRegularModuleSpecData {
   subModuleSearchLocations?: never;
 }
 
+export interface GroovyResourceData {
+  name: GroovyResourceName;
+  origin: string;
+}
+
 export type PythonModuleSpecData =
   | PythonRegularPackageSpecData
   | PythonNamespacePackageSpecData

--- a/src/types/remoteFileSourceTypes.ts
+++ b/src/types/remoteFileSourceTypes.ts
@@ -4,6 +4,7 @@ export type Include<T> = { value: T; include?: boolean };
 
 export type FilePattern = `**/*.${string}`;
 export type FolderName = Brand<'FolderName', string>;
+export type GroovyPackageName = Brand<'GroovyPackageName', string>;
 export type GroovyResourceName = Brand<'GroovyResourceName', string>;
 export type PythonModuleFullname = Brand<'ModuleFullname', string>;
 export type RelativeWsUriString = Brand<'RelativeWsUriString', string>;

--- a/src/types/remoteFileSourceTypes.ts
+++ b/src/types/remoteFileSourceTypes.ts
@@ -6,7 +6,7 @@ export type FilePattern = `**/*.${string}`;
 export type FolderName = Brand<'FolderName', string>;
 export type GroovyPackageName = Brand<'GroovyPackageName', string>;
 export type GroovyResourceName = Brand<'GroovyResourceName', string>;
-export type PythonModuleFullname = Brand<'ModuleFullname', string>;
+export type PythonModuleFullname = Brand<'PythonModuleFullname', string>;
 export type RelativeWsUriString = Brand<'RelativeWsUriString', string>;
 
 interface JsonRpcRequestBase {

--- a/src/types/remoteImportSourceTreeTypes.ts
+++ b/src/types/remoteImportSourceTreeTypes.ts
@@ -5,6 +5,12 @@ export interface RemoteImportSourceTreeRootElement {
   type: 'root';
 }
 
+export interface RemoteImportSourceTreeLanguageRootElement {
+  name: string;
+  type: 'languageRoot';
+  languageId: string;
+}
+
 export interface RemoteImportSourceTreeWkspRootFolderElement {
   name: string;
   type: 'workspaceRootFolder';
@@ -38,6 +44,7 @@ export interface RemoteImportSourceTreeFolderElement {
 
 export type RemoteImportSourceTreeElement =
   | RemoteImportSourceTreeRootElement
+  | RemoteImportSourceTreeLanguageRootElement
   | RemoteImportSourceTreeWkspRootFolderElement
   | RemoteImportSourceTreeTopLevelMarkedFolderElement
   | RemoteImportSourceTreeFileElement

--- a/src/types/remoteImportSourceTreeTypes.ts
+++ b/src/types/remoteImportSourceTreeTypes.ts
@@ -8,12 +8,14 @@ export interface RemoteImportSourceTreeRootElement {
 export interface RemoteImportSourceTreeWkspRootFolderElement {
   name: string;
   type: 'workspaceRootFolder';
+  languageId: string;
   uri: vscode.Uri;
 }
 
 export interface RemoteImportSourceTreeTopLevelMarkedFolderElement {
   name: string;
   type: 'topLevelMarkedFolder';
+  languageId: string;
   isMarked: true;
   uri: vscode.Uri;
 }
@@ -21,6 +23,7 @@ export interface RemoteImportSourceTreeTopLevelMarkedFolderElement {
 export interface RemoteImportSourceTreeFileElement {
   name: string;
   type: 'file';
+  languageId: string;
   isMarked: boolean;
   uri: vscode.Uri;
 }
@@ -28,14 +31,15 @@ export interface RemoteImportSourceTreeFileElement {
 export interface RemoteImportSourceTreeFolderElement {
   name: string;
   type: 'folder';
+  languageId: string;
   isMarked: boolean;
   uri: vscode.Uri;
 }
 
 export type RemoteImportSourceTreeElement =
   | RemoteImportSourceTreeRootElement
-  | RemoteImportSourceTreeTopLevelMarkedFolderElement
   | RemoteImportSourceTreeWkspRootFolderElement
+  | RemoteImportSourceTreeTopLevelMarkedFolderElement
   | RemoteImportSourceTreeFileElement
   | RemoteImportSourceTreeFolderElement;
 

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -61,6 +61,7 @@ export interface IDhcService extends IDisposable, ConnectionState {
   readonly onDidDisconnect: vscode.Event<URL>;
   readonly onDidChangeRunningCodeStatus: vscode.Event<boolean>;
 
+  hasGroovyRemoteFileSourcePlugin(): boolean;
   hasPythonRemoteFileSourcePlugin(): boolean;
   initSession(): Promise<boolean>;
   getClient(): Promise<CoreAuthenticatedClient | null>;

--- a/src/types/serviceTypes.d.ts
+++ b/src/types/serviceTypes.d.ts
@@ -61,6 +61,7 @@ export interface IDhcService extends IDisposable, ConnectionState {
   readonly onDidDisconnect: vscode.Event<URL>;
   readonly onDidChangeRunningCodeStatus: vscode.Event<boolean>;
 
+  hasPythonRemoteFileSourcePlugin(): boolean;
   initSession(): Promise<boolean>;
   getClient(): Promise<CoreAuthenticatedClient | null>;
   getConnection(): Promise<DhcType.IdeConnection | null>;

--- a/src/util/__snapshots__/remoteFileSourceUtils.spec.ts.snap
+++ b/src/util/__snapshots__/remoteFileSourceUtils.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`getFileTreeItem > should return a TreeItem for a file element 1`] = `
 exports[`getFolderTreeItem > should return a TreeItem for a folder element. isMarked:false 1`] = `
 {
   "collapsibleState": 1,
-  "contextValue": "canAddRemoteFileSource",
+  "contextValue": "canAddRemoteFileSource:python",
   "iconPath": ThemeIcon {
     "color": undefined,
     "id": "folder",
@@ -43,7 +43,7 @@ exports[`getFolderTreeItem > should return a TreeItem for a folder element. isMa
 exports[`getFolderTreeItem > should return a TreeItem for a folder element. isMarked:true 1`] = `
 {
   "collapsibleState": 1,
-  "contextValue": "canRemoveRemoteFileSource",
+  "contextValue": "canRemoveRemoteFileSource:python",
   "iconPath": ThemeIcon {
     "color": undefined,
     "id": "folder",
@@ -60,7 +60,7 @@ exports[`getFolderTreeItem > should return a TreeItem for a folder element. isMa
 exports[`getTopLevelMarkedFolderTreeItem > should return a TreeItem for a top-level marked folder element 1`] = `
 {
   "collapsibleState": 0,
-  "contextValue": "canRemoveRemoteFileSource",
+  "contextValue": "canRemoveRemoteFileSource:python",
   "description": undefined,
   "iconPath": ThemeIcon {
     "color": undefined,

--- a/src/util/__snapshots__/remoteFileSourceUtils.spec.ts.snap
+++ b/src/util/__snapshots__/remoteFileSourceUtils.spec.ts.snap
@@ -57,6 +57,38 @@ exports[`getFolderTreeItem > should return a TreeItem for a folder element. isMa
 }
 `;
 
+exports[`getLanguageRootTreeItem > should return a collapsed TreeItem for a language root element: groovy 1`] = `
+{
+  "collapsibleState": 1,
+  "contextValue": "languageRoot",
+  "iconPath": ThemeIcon {
+    "color": undefined,
+    "id": "coffee",
+  },
+  "label": "groovy root",
+}
+`;
+
+exports[`getLanguageRootTreeItem > should return a collapsed TreeItem for a language root element: python 1`] = `
+{
+  "collapsibleState": 1,
+  "contextValue": "languageRoot",
+  "iconPath": ThemeIcon {
+    "color": undefined,
+    "id": "dh-python",
+  },
+  "label": "python root",
+}
+`;
+
+exports[`getRootTreeItem > should return an expanded TreeItem for a root element 1`] = `
+{
+  "collapsibleState": 2,
+  "contextValue": "root",
+  "label": "root",
+}
+`;
+
 exports[`getTopLevelMarkedFolderTreeItem > should return a TreeItem for a top-level marked folder element 1`] = `
 {
   "collapsibleState": 0,
@@ -72,5 +104,30 @@ exports[`getTopLevelMarkedFolderTreeItem > should return a TreeItem for a top-le
     "path": "/mock/top/level/marked/folder/",
     "scheme": "file",
   },
+}
+`;
+
+exports[`getTopLevelMarkedFolderTreeItem > should return a non-collapsible TreeItem for a top-level marked folder element 1`] = `
+{
+  "collapsibleState": 0,
+  "contextValue": "canRemoveRemoteFileSource:python",
+  "description": undefined,
+  "iconPath": ThemeIcon {
+    "color": undefined,
+    "id": "dh-python",
+  },
+  "label": "",
+  "resourceUri": Uri {
+    "fsPath": "/mock/top/level/marked/folder/",
+    "path": "/mock/top/level/marked/folder/",
+    "scheme": "file",
+  },
+}
+`;
+
+exports[`getWorkspaceFolderRootTreeItem > should return a collapsed TreeItem for a workspace folder root element 1`] = `
+{
+  "collapsibleState": 1,
+  "label": "Workspace1",
 }
 `;

--- a/src/util/__snapshots__/remoteFileSourceUtils.spec.ts.snap
+++ b/src/util/__snapshots__/remoteFileSourceUtils.spec.ts.snap
@@ -89,24 +89,6 @@ exports[`getRootTreeItem > should return an expanded TreeItem for a root element
 }
 `;
 
-exports[`getTopLevelMarkedFolderTreeItem > should return a TreeItem for a top-level marked folder element 1`] = `
-{
-  "collapsibleState": 0,
-  "contextValue": "canRemoveRemoteFileSource:python",
-  "description": undefined,
-  "iconPath": ThemeIcon {
-    "color": undefined,
-    "id": "dh-python",
-  },
-  "label": "",
-  "resourceUri": Uri {
-    "fsPath": "/mock/top/level/marked/folder/",
-    "path": "/mock/top/level/marked/folder/",
-    "scheme": "file",
-  },
-}
-`;
-
 exports[`getTopLevelMarkedFolderTreeItem > should return a non-collapsible TreeItem for a top-level marked folder element 1`] = `
 {
   "collapsibleState": 0,

--- a/src/util/remoteFileSourceMsgUtils.spec.ts
+++ b/src/util/remoteFileSourceMsgUtils.spec.ts
@@ -4,10 +4,10 @@ import {
   moduleSpecErrorResponse,
   setConnectionIdRequest,
 } from './remoteFileSourceMsgUtils';
-import type { ModuleFullname, UniqueID } from '../types';
+import type { PythonModuleFullname, UniqueID } from '../types';
 
 const mockMsgId = 'mock.msgId';
-const mockModuleName = 'mock.module' as ModuleFullname;
+const mockModuleName = 'mock.module' as PythonModuleFullname;
 
 describe('moduleSpecResponse', () => {
   it('should return correct JSON-RPC success response', () => {

--- a/src/util/remoteFileSourceMsgUtils.ts
+++ b/src/util/remoteFileSourceMsgUtils.ts
@@ -2,7 +2,7 @@ import type {
   JsonRpcError,
   JsonRpcSetConnectionIdRequest,
   JsonRpcSuccess,
-  ModuleFullname,
+  PythonModuleFullname,
   PythonModuleSpecData,
   PythonModuleSpecDataResult,
   UniqueID,
@@ -43,7 +43,7 @@ export function moduleSpecResponse(
  */
 export function moduleSpecErrorResponse(
   id: string,
-  moduleName: ModuleFullname
+  moduleName: PythonModuleFullname
 ): JsonRpcError {
   return {
     jsonrpc: '2.0',

--- a/src/util/remoteFileSourceUtils.spec.ts
+++ b/src/util/remoteFileSourceUtils.spec.ts
@@ -15,7 +15,7 @@ import type {
   JsonRpcFetchModuleRequest,
   JsonRpcRequest,
   JsonRpcResponse,
-  ModuleFullname,
+  PythonModuleFullname,
   PythonModuleSpecData,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
@@ -155,9 +155,11 @@ describe('hasPythonPluginVariable', () => {
 
 describe('registerRemoteFileSourcePluginMessageListener', () => {
   const getPythonModuleSpecData =
-    vi.fn<(moduleFullname: ModuleFullname) => PythonModuleSpecData | null>();
+    vi.fn<
+      (moduleFullname: PythonModuleFullname) => PythonModuleSpecData | null
+    >();
 
-  const mockModuleName = 'a.b.c' as ModuleFullname;
+  const mockModuleName = 'a.b.c' as PythonModuleFullname;
 
   const mockFile = {
     exists: {
@@ -178,7 +180,7 @@ describe('registerRemoteFileSourcePluginMessageListener', () => {
       id: '1',
       method: 'fetch_module',
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      params: { module_name: moduleName as ModuleFullname },
+      params: { module_name: moduleName as PythonModuleFullname },
     }),
     fetchModuleRes: ({
       source,

--- a/src/util/remoteFileSourceUtils.spec.ts
+++ b/src/util/remoteFileSourceUtils.spec.ts
@@ -6,9 +6,9 @@ import {
   getFolderTreeItem,
   getSetExecutionContextScript,
   getTopLevelMarkedFolderTreeItem,
-  getTopLevelModuleFullname,
+  getPythonTopLevelModuleFullname,
   hasPythonPluginVariable,
-  registerRemoteFileSourcePluginMessageListener,
+  registerPythonRemoteFileSourcePluginMessageListener,
   sendWidgetMessageAsync,
 } from './remoteFileSourceUtils';
 import type {
@@ -69,6 +69,7 @@ describe('getFolderTreeItem', () => {
         name: 'mockFolder',
         isMarked,
         uri: vscode.Uri.parse('file:///mock/folder/path/'),
+        languageId: 'python',
       } as RemoteImportSourceTreeFolderElement;
 
       expect(getFolderTreeItem(element)).toMatchSnapshot();
@@ -97,6 +98,7 @@ describe('getTopLevelMarkedFolderTreeItem', () => {
   it('should return a TreeItem for a top-level marked folder element', () => {
     const element = {
       uri: vscode.Uri.parse('file:///mock/top/level/marked/folder/'),
+      languageId: 'python',
     } as RemoteImportSourceTreeTopLevelMarkedFolderElement;
 
     expect(getTopLevelMarkedFolderTreeItem(element)).toMatchSnapshot();
@@ -110,7 +112,7 @@ describe('getTopLevelModuleFullname', () => {
   ])(
     'should return the top-level module fullname for a given folder URI: %s',
     (uriPath, expectedModuleName) => {
-      const result = getTopLevelModuleFullname(vscode.Uri.parse(uriPath));
+      const result = getPythonTopLevelModuleFullname(vscode.Uri.parse(uriPath));
       expect(result).toBe(expectedModuleName);
     }
   );
@@ -214,7 +216,7 @@ describe('registerRemoteFileSourcePluginMessageListener', () => {
       mockIncomingMsg(mockMsg.fetchModuleReq(mockModuleName));
       getPythonModuleSpecData.mockReturnValueOnce(spec);
 
-      registerRemoteFileSourcePluginMessageListener(
+      registerPythonRemoteFileSourcePluginMessageListener(
         mockPlugin,
         getPythonModuleSpecData
       );

--- a/src/util/remoteFileSourceUtils.spec.ts
+++ b/src/util/remoteFileSourceUtils.spec.ts
@@ -4,8 +4,12 @@ import type { dh as DhcType } from '@deephaven/jsapi-types';
 import {
   getFileTreeItem,
   getFolderTreeItem,
+  getGroovyTopLevelPackageName,
+  getLanguageRootTreeItem,
+  getRootTreeItem,
   getSetExecutionContextScript,
   getTopLevelMarkedFolderTreeItem,
+  getWorkspaceFolderRootTreeItem,
   getPythonTopLevelModuleFullname,
   hasPythonPluginVariable,
   registerPythonRemoteFileSourcePluginMessageListener,
@@ -19,7 +23,10 @@ import type {
   PythonModuleSpecData,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
+  RemoteImportSourceTreeLanguageRootElement,
+  RemoteImportSourceTreeRootElement,
   RemoteImportSourceTreeTopLevelMarkedFolderElement,
+  RemoteImportSourceTreeWkspRootFolderElement,
   UniqueID,
 } from '../types';
 import { getLastEventListener } from '../testUtils';
@@ -95,13 +102,62 @@ describe('getSetExecutionContextScript', () => {
 });
 
 describe('getTopLevelMarkedFolderTreeItem', () => {
-  it('should return a TreeItem for a top-level marked folder element', () => {
+  it('should return a non-collapsible TreeItem for a top-level marked folder element', () => {
     const element = {
       uri: vscode.Uri.parse('file:///mock/top/level/marked/folder/'),
       languageId: 'python',
     } as RemoteImportSourceTreeTopLevelMarkedFolderElement;
 
     expect(getTopLevelMarkedFolderTreeItem(element)).toMatchSnapshot();
+  });
+});
+
+describe('getGroovyTopLevelPackageName', () => {
+  it.each([
+    ['file:///mock/trailing-slash/', 'trailing-slash'],
+    ['file:///mock/package', 'package'],
+  ])(
+    'should return the top-level package name for a given folder URI: %s',
+    (uriPath, expectedPackageName) => {
+      const result = getGroovyTopLevelPackageName(vscode.Uri.parse(uriPath));
+      expect(result).toBe(expectedPackageName);
+    }
+  );
+});
+
+describe('getLanguageRootTreeItem', () => {
+  it.each(['python', 'groovy'] as const)(
+    'should return a collapsed TreeItem for a language root element: %s',
+    languageId => {
+      const element: RemoteImportSourceTreeLanguageRootElement = {
+        name: `${languageId} root`,
+        type: 'languageRoot',
+        languageId,
+      };
+      expect(getLanguageRootTreeItem(element)).toMatchSnapshot();
+    }
+  );
+});
+
+describe('getRootTreeItem', () => {
+  it('should return an expanded TreeItem for a root element', () => {
+    const element: RemoteImportSourceTreeRootElement = {
+      name: 'root',
+      type: 'root',
+    };
+    expect(getRootTreeItem(element)).toMatchSnapshot();
+  });
+});
+
+describe('getWorkspaceFolderRootTreeItem', () => {
+  it('should return a collapsed TreeItem for a workspace folder root element', () => {
+    const element: RemoteImportSourceTreeWkspRootFolderElement = {
+      name: 'Workspace1',
+      type: 'workspaceRootFolder',
+      languageId: 'python',
+      uri: vscode.Uri.parse('file:///path/to/ws1'),
+    };
+    expect(getWorkspaceFolderRootTreeItem(element)).toMatchSnapshot();
   });
 });
 

--- a/src/util/remoteFileSourceUtils.ts
+++ b/src/util/remoteFileSourceUtils.ts
@@ -14,7 +14,10 @@ import type {
   PythonModuleSpecData,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
+  RemoteImportSourceTreeLanguageRootElement,
+  RemoteImportSourceTreeRootElement,
   RemoteImportSourceTreeTopLevelMarkedFolderElement,
+  RemoteImportSourceTreeWkspRootFolderElement,
   UniqueID,
 } from '../types';
 import { withResolvers } from './promiseUtils';
@@ -173,6 +176,44 @@ export function getFolderTreeItem({
 }
 
 /**
+ * Get `TreeItem` for a language root element in the remote import source tree.
+ * @param element The language root element.
+ * @returns TreeItem for the language root
+ */
+export function getLanguageRootTreeItem({
+  name,
+  languageId,
+}: RemoteImportSourceTreeLanguageRootElement): vscode.TreeItem {
+  return {
+    label: name,
+    contextValue: 'languageRoot',
+    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+    iconPath:
+      languageId === 'python'
+        ? new vscode.ThemeIcon(ICON_ID.python)
+        : languageId === 'groovy'
+          ? new vscode.ThemeIcon(ICON_ID.groovy)
+          : undefined,
+  };
+}
+
+/**
+ * Get `TreeItem` for a root element in the remote import source tree.
+ * @param element The root element.
+ * @returns TreeItem for the root
+ */
+export function getRootTreeItem({
+  name,
+  type,
+}: RemoteImportSourceTreeRootElement): vscode.TreeItem {
+  return {
+    label: name,
+    contextValue: type,
+    collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+  };
+}
+
+/**
  * Get `TreeItem` for a top-level marked folder element in the remote import
  * source tree.
  * @param element The top-level marked folder element.
@@ -192,6 +233,21 @@ export function getTopLevelMarkedFolderTreeItem({
         ? new vscode.ThemeIcon(ICON_ID.groovy)
         : new vscode.ThemeIcon(ICON_ID.python),
     collapsibleState: vscode.TreeItemCollapsibleState.None,
+  };
+}
+
+/**
+ * Get `TreeItem` for a workspace folder root element in the remote import
+ * source tree.
+ * @param element The workspace folder root element.
+ * @returns TreeItem for the workspace folder root
+ */
+export function getWorkspaceFolderRootTreeItem({
+  name,
+}: RemoteImportSourceTreeWkspRootFolderElement): vscode.TreeItem {
+  return {
+    label: name,
+    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
   };
 }
 

--- a/src/util/remoteFileSourceUtils.ts
+++ b/src/util/remoteFileSourceUtils.ts
@@ -4,6 +4,7 @@ import { URIMap } from './maps';
 import type {
   FilePattern,
   FolderName,
+  GroovyPackageName,
   Include,
   JsonRpcRequest,
   JsonRpcResponse,
@@ -185,12 +186,27 @@ export function getTopLevelMarkedFolderTreeItem({
 }
 
 /**
+ * Get the top-level Groovy package name for a given folder URI. It will be the
+ * last segment of the folder path.
+ * @param folderUri The folder URI.
+ * @returns The top-level package name.
+ */
+export function getGroovyTopLevelPackageName(
+  folderUri: vscode.Uri
+): GroovyPackageName {
+  return folderUri.path
+    .replace(/\/$/, '')
+    .split('/')
+    .at(-1) as GroovyPackageName;
+}
+
+/**
  * Get the top-level Python module name for a given folder URI. It will be the
  * last segment of the folder path.
  * @param folderUri The folder URI.
  * @returns The top-level module name.
  */
-export function getTopLevelModuleFullname(
+export function getPythonTopLevelModuleFullname(
   folderUri: vscode.Uri
 ): PythonModuleFullname {
   return folderUri.path
@@ -265,13 +281,30 @@ export function hasPythonPluginVariable(
 }
 
 /**
+ * Register a message listener on the Groovy remote file source plugin to
+ * handle requests.
+ * @param pluginService The remote file source plugin service.
+ * @returns a function to unregister the listener
+ */
+export function registerGroovyRemoteFileSourcePluginMessageListener(
+  pluginService: DhcType.remotefilesource.RemoteFileSourceService
+): () => void {
+  return pluginService.addEventListener<DhcType.remotefilesource.ResourceRequestEvent>(
+    'requestsource',
+    async ({ detail }) => {
+      console.log('[TESTING] requestSource event:', detail.resourceName);
+    }
+  );
+}
+
+/**
  * Register a message listener on the remote file source plugin to handle requests.
  * @param plugin the remote file source plugin widget
  * @param getPythonModuleSpecData a function that returns the module spec data
  * for a given module fullname
  * @returns a function to unregister the listener
  */
-export function registerRemoteFileSourcePluginMessageListener(
+export function registerPythonRemoteFileSourcePluginMessageListener(
   plugin: DhcType.Widget,
   getPythonModuleSpecData: (
     moduleFullname: PythonModuleFullname

--- a/src/util/remoteFileSourceUtils.ts
+++ b/src/util/remoteFileSourceUtils.ts
@@ -7,7 +7,7 @@ import type {
   Include,
   JsonRpcRequest,
   JsonRpcResponse,
-  ModuleFullname,
+  PythonModuleFullname,
   PythonModuleSpecData,
   RemoteImportSourceTreeFileElement,
   RemoteImportSourceTreeFolderElement,
@@ -26,12 +26,14 @@ import { Logger } from './Logger';
 const logger = new Logger('remoteFileSourceUtils');
 
 export type PythonModuleWorkspaceMap = URIMap<
-  Map<ModuleFullname, Include<vscode.Uri>>
+  Map<PythonModuleFullname, Include<vscode.Uri>>
 >;
 
 export interface PythonModuleMeta {
   moduleMap: PythonModuleWorkspaceMap;
-  topLevelModuleNames: URIMap<Map<ModuleFullname, Include<ModuleFullname>>>;
+  topLevelModuleNames: URIMap<
+    Map<PythonModuleFullname, Include<PythonModuleFullname>>
+  >;
 }
 
 /**
@@ -190,8 +192,11 @@ export function getTopLevelMarkedFolderTreeItem({
  */
 export function getTopLevelModuleFullname(
   folderUri: vscode.Uri
-): ModuleFullname {
-  return folderUri.path.replace(/\/$/, '').split('/').at(-1) as ModuleFullname;
+): PythonModuleFullname {
+  return folderUri.path
+    .replace(/\/$/, '')
+    .split('/')
+    .at(-1) as PythonModuleFullname;
 }
 
 /**
@@ -269,7 +274,7 @@ export function hasPythonPluginVariable(
 export function registerRemoteFileSourcePluginMessageListener(
   plugin: DhcType.Widget,
   getPythonModuleSpecData: (
-    moduleFullname: ModuleFullname
+    moduleFullname: PythonModuleFullname
   ) => PythonModuleSpecData | null
 ): () => void {
   return plugin.addEventListener<DhcType.Widget>(

--- a/src/util/remoteFileSourceUtils.ts
+++ b/src/util/remoteFileSourceUtils.ts
@@ -70,6 +70,8 @@ export const DH_PYTHON_REMOTE_SOURCE_PLUGIN_INIT_SCRIPT = [
   '        print("Python remote file source plugin not installed")',
 ].join('\n');
 
+// Alias for `dh.remotefilesource.RemoteFileSourceService.EVENT_REQUEST_SOURCE` to avoid having to pass in a
+// `dh` instance to util functions that only need the event name.
 export const DH_REQUEST_SOURCE_EVENT = 'requestsource' as const;
 
 // Alias for `dh.Widget.EVENT_MESSAGE` to avoid having to pass in a `dh` instance
@@ -350,6 +352,7 @@ export function hasPythonPluginVariable(
  * Register a message listener on the Groovy remote file source plugin to
  * handle requests.
  * @param pluginService The remote file source plugin service.
+ * @param getGroovyResourceData Function to retrieve resource data for a given resource name.
  * @returns a function to unregister the listener
  */
 export function registerGroovyRemoteFileSourcePluginMessageListener(
@@ -361,28 +364,32 @@ export function registerGroovyRemoteFileSourcePluginMessageListener(
   return pluginService.addEventListener<DhcType.remotefilesource.ResourceRequestEvent>(
     DH_REQUEST_SOURCE_EVENT,
     async ({ detail }) => {
-      logger.info(
-        'Received resource request from server:',
-        detail.resourceName
-      );
-
-      const resourceData = getGroovyResourceData(
-        detail.resourceName as GroovyResourceName
-      );
-
       let source: string | undefined;
-      if (resourceData?.origin != null) {
-        const textDoc = await vscode.workspace.openTextDocument(
-          resourceData.origin
+      try {
+        logger.info(
+          'Received resource request from server:',
+          detail.resourceName
         );
-        source = textDoc.getText();
-      }
 
-      if (source == null) {
-        logger.error('Resource source not found:', detail.resourceName);
-      }
+        const resourceData = getGroovyResourceData(
+          detail.resourceName as GroovyResourceName
+        );
 
-      detail.respond(source);
+        if (resourceData?.origin != null) {
+          const textDoc = await vscode.workspace.openTextDocument(
+            resourceData.origin
+          );
+          source = textDoc.getText();
+        }
+
+        if (source == null) {
+          logger.error('Resource source not found:', detail.resourceName);
+        }
+      } catch (err) {
+        logger.error('Error handling resource request:', err);
+      } finally {
+        detail.respond(source);
+      }
     }
   );
 }


### PR DESCRIPTION
DH-20578: Adds Groovy support for remote file source features in VS Code extension. The supporting plugin work has not fully landed yet mostly waiting on tests, but I don't think that should block this PR:

**Related Pending PRs**
Changes for these are deployed to `bmingles-remote-file-source2` BHS
- https://github.com/deephaven/deephaven-core/pull/7451
- https://github.com/deephaven-ent/iris/pull/3878
- TBD: PR to integrate Core changes into gplus

## Testing
- Test on a grizzly or gplus server without the plugin installed. Verify that we can still run python and groovy scripts without remote file sourcing. This is just a regression test.
- `bmingles-remote-file-source2` has Groovy and Python remote plugins installed, so full feature set can be tested there

### Setup
- Start `bmingles-remote-file-source2` vm if not already running
- Clone this test repo `git@github.com:bmingles/deephaven-controller-script-test`
- Checkout the `local` git branch (the `main` branch is configured as a controller source on `bmingles-remote-file-source2`).

### Local override tests
- Connect to `bmingles-remote-file-source2` server in VS Code
- Open and run `src/main/groovy/docs-sample.groovy` against the BHS
- Should see STDOUT entries in OUTPUT -> Deephaven panel with `"Server"` prefix e.g.
   ```
   12:16:14.829 STDOUT Server: Notebook Level Var
   12:16:14.830 STDOUT Server: Notebook Level Var
   12:16:14.830 STDOUT Server: Top Level Var
   12:16:14.830 STDOUT Server: Top Level Var
   ...
   ```
- Cells in the `testTable` should also include the `"Server"` prefix
- Add `src/main/groovy/test` folder as a Groovy remote file source
- Run the script again. Should see `"Local"` prefix e.g.
   ```
   12:21:12.336 STDOUT Local: Notebook Level Var
   12:21:12.336 STDOUT Local: Notebook Level Var
   12:21:12.337 STDOUT Local: Top Level Var
   12:21:12.337 STDOUT Local: Top Level Var
   ...
   ```
- Cells in the `testTable` should also include the `"Local"` prefix
- Remove the `src/main/groovy/test` as a remote file source
- Run the script again. STDOUT and table cells should all go back to the `"Server"` prefixes

### Tree Selection Behavior
There was a bug fixed in this PR that impacts how partial unmarking works in the Remote file source tree view.
- Navigate to Deephaven activity bar tab (left sidebar)
- Expand Groovy workspace tree until you get to `src/main/groovy/nested/ws1`
- Add `ws1` folder as remote source with the `+` button
- Should see ws1 and all of its children turn green
- Hover over `ws1/sub1` subfolder and click the `-` sign to remove it
- Result should be that `ws1/sub2` is now the marked folder. `ws1/sub1` and `ws1/file1.groovy` should both be unmarked