### PR TITLE
fix: DH-21980: Fixed a race condition bug caused by MS python extension

### DIFF
--- a/src/controllers/PipServerController.ts
+++ b/src/controllers/PipServerController.ts
@@ -274,6 +274,14 @@ export class PipServerController implements IDisposable {
         /* eslint-enable @typescript-eslint/naming-convention */
       },
       isTransient: true,
+      // The MS Python extension injects a venv activation command into new
+      // terminals. There is a race condition such that it doesn't always inject
+      // early enough and can interrupt other processes. In this case it kills
+      // the pip server process and breaks the managed servers feature. Hiding
+      // the terminal prevents the Python extension from injecting the command.
+      // Since server output is sent to Output -> Deephaven panel, the terminal
+      // doesn't need to be visible.
+      hideFromUser: true,
     });
 
     this._serverUrlTerminalMap.set(port, terminal);


### PR DESCRIPTION
DH-21980:
The MS Python extension can inject a command to activate venv whenever a new terminal is opened. There is a race condition in that there is no guarantee the command will run before other commands are started in the terminal session. If a pip managed server is started before the command is injected, the injection will kill the server. I have observed this mostly in single folder workspaces.

Here's an example of the injected cmd killing the server:

<img width="1259" height="463" alt="image" src="https://github.com/user-attachments/assets/4ffdd596-5866-4d04-82a8-4c048ef99d06" />

This fix simply hides the terminal so that the injection never happens for pip managed servers.

## Testing
- Open a folder in VS Code and activate a Python venv
- Install deephaven-server pip package
- Start a managed server from VS Code extension
- It should start and stay connected
