### PR TITLE
fix: DH-22840: DHC connection race

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ See [vscode-extension-tester](https://github.com/redhat-developer/vscode-extensi
 To run end-to-end tests:
 
 ```sh
-npm run test:e2e
+npm run test:e2e -- --core
 ```
 
 To run using `VS Code` debugger:
@@ -61,6 +61,7 @@ For release testing:
 1. Checkout the appropriate pre-release tag for the pending release.
 1. Run `npm install`
 1. It is recommended to run against a few different server configurations:
+
    - Server configured with both basic and SAML configs
    - Server with basic only config
    - Envoy server

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -84,6 +84,15 @@ fi
 
 export DH_SERVER_URL="${SERVER_URL}"
 
+# Locally, default test resources to a short path outside the repo. VS Code/Electron
+# creates an IPC socket under <TEST_RESOURCES>/settings, and macOS caps Unix socket
+# paths at 104 bytes; a long repo/worktree path overflows it and the VS Code instance
+# exits immediately ("Chrome instance exited"). Skipped in CI (where $CI is set) so
+# screenshots keep landing in e2e-testing/.resources for the artifact upload.
+if [[ -z "$CI" ]]; then
+  export TEST_RESOURCES="${TEST_RESOURCES:-$HOME/.dh-e2e-resources}"
+fi
+
 # Run e2e tests
 echo "Running E2E tests..."
 node e2e-testing/out/runner.mjs --setup

--- a/scripts/generate-test-settings.mjs
+++ b/scripts/generate-test-settings.mjs
@@ -92,16 +92,21 @@ if (coreServers.length === 0 && enterpriseServers.length === 0) {
 }
 
 // Create settings object
+/* eslint-disable @typescript-eslint/naming-convention */
 const settings = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   'deephaven.coreServers': coreServers,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   'deephaven.enterpriseServers': enterpriseServers,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   'extensions.ignoreRecommendations': true,
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   'git.openRepositoryInParentFolders': 'never',
+  // Suppress the onboarding overlay (.onboarding-a-overlay, "Welcome to Visual
+  // Studio Code") that newer VS Code shows on first run. ExTester wipes the
+  // user-data-dir each run, so every run looks like a first run and the overlay
+  // reappears, intercepting clicks and blocking the quick-input widget.
+  // VS Code's tryShowOnboarding() only calls show() when this setting is truthy
+  // (see workbench.desktop.main.js), so false short-circuits it entirely.
+  'workbench.welcomePage.experimentalOnboarding': false,
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 // Output path
 const outputPath = `${__dirname}/../e2e-testing/test-ws/.vscode/settings.json`;

--- a/src/services/DhcService.spec.ts
+++ b/src/services/DhcService.spec.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DhcService } from './DhcService';
 import { ConfigService } from './ConfigService';
 import type { RemoteFileSourceService } from './RemoteFileSourceService';
-import type { UniqueID } from '../types';
+import type { PublicOf, UniqueID } from '../types';
 
 vi.mock('vscode');
 
@@ -16,8 +16,23 @@ vi.mock('./ConfigService', () => {
   return { ConfigService: mockConfigService };
 });
 
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createMockCn(): DhcType.IdeConnection {
+  return {
+    getConsoleTypes: vi.fn().mockResolvedValue(['python']),
+  } as unknown as DhcType.IdeConnection;
+}
+
+type DhcServicePublicCn = PublicOf<DhcService> & {
+  cn: DhcType.IdeConnection | null;
+};
+
 /** Build a minimal DhcService instance that has a session already set up. */
 function createTestDhcService({
+  cn = createMockCn(),
   pythonRemoteFileSourcePlugin,
   setControllerImportPrefixes = vi.fn(),
   setPythonServerExecutionContext = vi.fn().mockResolvedValue(undefined),
@@ -26,18 +41,15 @@ function createTestDhcService({
     changes: { created: [], updated: [], removed: [] },
   }),
 }: {
+  cn?: DhcType.IdeConnection | null;
   pythonRemoteFileSourcePlugin?: DhcType.Widget | null;
   setControllerImportPrefixes?: ReturnType<typeof vi.fn>;
   setPythonServerExecutionContext?: ReturnType<typeof vi.fn>;
   sessionRunCode?: ReturnType<typeof vi.fn>;
-} = {}): DhcService {
+} = {}): DhcServicePublicCn {
   const mockSession = {
     runCode: sessionRunCode,
   } as unknown as DhcType.IdeSession;
-
-  const mockCn = {
-    getConsoleTypes: vi.fn().mockResolvedValue(['python']),
-  } as unknown as DhcType.IdeConnection;
 
   const mockRemoteFileSourceService = {
     setControllerImportPrefixes,
@@ -51,7 +63,7 @@ function createTestDhcService({
 
   const service = Object.assign(Object.create(DhcService.prototype), {
     session: mockSession,
-    cn: mockCn,
+    cn,
     cnId: 'test-cn-id' as UniqueID,
     pythonRemoteFileSourcePlugin:
       pythonRemoteFileSourcePlugin !== undefined
@@ -82,12 +94,8 @@ function mockTextDoc(codeText: string): vscode.TextDocument {
   } as unknown as vscode.TextDocument;
 }
 
-describe('DhcService.runCode – importPrefixes setting', () => {
+describe('runCode – importPrefixes setting', () => {
   const mockSetControllerImportPrefixes = vi.fn();
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
 
   it.each([
     {
@@ -115,7 +123,8 @@ describe('DhcService.runCode – importPrefixes setting', () => {
       expected: null,
     },
     {
-      label: 'calls with empty set for full file runs even when no prefixes found',
+      label:
+        'calls with empty set for full file runs even when no prefixes found',
       configPrefixes: undefined,
       input: mockTextDoc('x = 1'),
       expected: new Set(),
@@ -123,7 +132,8 @@ describe('DhcService.runCode – importPrefixes setting', () => {
     {
       label: 'setting takes precedence over meta_import in code',
       configPrefixes: ['forced'],
-      input: 'deephaven_enterprise.controller_import.meta_import("otherPrefix")\n',
+      input:
+        'deephaven_enterprise.controller_import.meta_import("otherPrefix")\n',
       expected: new Set(['forced']),
     },
     {
@@ -148,5 +158,37 @@ describe('DhcService.runCode – importPrefixes setting', () => {
     } else {
       expect(mockSetControllerImportPrefixes).toHaveBeenCalledWith(expected);
     }
+  });
+});
+
+describe('getConnection', () => {
+  it('initializes the session when no connection exists yet', async () => {
+    const service = createTestDhcService({ cn: null });
+
+    const mockCn = createMockCn();
+
+    // `initSession` establishes the connection as a side effect.
+    const initSession = vi
+      .spyOn(service, 'initSession')
+      .mockImplementation(async () => {
+        service.cn = mockCn;
+        return true;
+      });
+
+    const result = await service.getConnection();
+
+    expect(initSession).toHaveBeenCalledOnce();
+    expect(result).toBe(mockCn);
+  });
+
+  it('returns the existing connection without re-initializing', async () => {
+    const service = createTestDhcService();
+
+    const initSession = vi.spyOn(service, 'initSession');
+
+    const result = await service.getConnection();
+
+    expect(initSession).not.toHaveBeenCalled();
+    expect(result).toBe(service.cn);
   });
 });

--- a/src/services/DhcService.ts
+++ b/src/services/DhcService.ts
@@ -461,6 +461,10 @@ export class DhcService extends DisposableBase implements IDhcService {
   }
 
   async getConnection(): Promise<DhcType.IdeConnection | null> {
+    if (this.cn == null) {
+      await this.initSession();
+    }
+
     return this.cn;
   }
 

--- a/src/services/ServerManager.spec.ts
+++ b/src/services/ServerManager.spec.ts
@@ -1,0 +1,186 @@
+import * as vscode from 'vscode';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ServerManager } from './ServerManager';
+import { URLMap, withResolvers } from '../util';
+import type {
+  ConnectionState,
+  IAsyncCacheService,
+  IConfigService,
+  IDhcServiceFactory,
+  IDheService,
+  ISecretService,
+  IToastService,
+  PublicOf,
+  ServerState,
+  ServerType,
+} from '../types';
+
+// See __mocks__/vscode.ts for the mock implementation
+vi.mock('vscode');
+
+// Avoid real server status polling triggered by the constructor's
+// `loadServerConfig` call.
+vi.mock('../dh/dhc', () => ({
+  isDhcServerRunning: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../dh/dhe', () => ({
+  getWorkerCredentials: vi.fn(),
+  isDheServerRunning: vi.fn().mockResolvedValue(false),
+}));
+
+/**
+ * Internal shape of `ServerManager` used to seed state and stub the actual
+ * connection logic so we can exercise the `connectToServer` race-condition
+ * handling in isolation.
+ */
+type TestServerManager = PublicOf<ServerManager> & {
+  _serverMap: URLMap<ServerState>;
+  _connectionMap: URLMap<ConnectionState>;
+  _pendingConnectionMap: URLMap<Promise<ConnectionState | null>>;
+  _doConnectToServer: ReturnType<typeof vi.fn>;
+};
+
+/** Build a `ServerManager` with minimal mocked dependencies. */
+function createServerManager(): TestServerManager {
+  const configService = {
+    getCoreServers: vi.fn().mockReturnValue([]),
+    getEnterpriseServers: vi.fn().mockReturnValue([]),
+  } as unknown as IConfigService;
+
+  const dhcServiceFactory = {
+    create: vi.fn(),
+  } as unknown as IDhcServiceFactory;
+
+  const dheServiceCache = {
+    has: vi.fn().mockReturnValue(false),
+    get: vi.fn(),
+  } as unknown as IAsyncCacheService<URL, IDheService>;
+
+  const manager = new ServerManager(
+    configService,
+    new URLMap(),
+    dhcServiceFactory,
+    new URLMap(),
+    dheServiceCache,
+    { appendLine: vi.fn() } as unknown as vscode.OutputChannel,
+    {} as ISecretService,
+    { info: vi.fn(), error: vi.fn() } as IToastService
+  ) as unknown as TestServerManager;
+
+  return manager;
+}
+
+function mockConnectionState(url: URL): ConnectionState {
+  return { isConnected: true, serverUrl: url };
+}
+
+function mockServerState({
+  url,
+  type = 'DHC',
+  connectionCount = 0,
+}: {
+  url: URL;
+  type?: ServerType;
+  connectionCount?: number;
+}): ServerState {
+  return {
+    type,
+    url,
+    isConnected: connectionCount > 0,
+    isRunning: true,
+    connectionCount,
+  };
+}
+
+const serverUrl = new URL('http://localhost:10000/');
+const dhcServer0 = mockServerState({
+  url: serverUrl,
+  type: 'DHC',
+});
+const dhcServer1 = mockServerState({
+  url: serverUrl,
+  type: 'DHC',
+  connectionCount: 1,
+});
+const dheServer0 = mockServerState({
+  url: serverUrl,
+  type: 'DHE',
+});
+const cn1 = mockConnectionState(serverUrl);
+const cn2 = mockConnectionState(serverUrl);
+
+describe('ServerManager.connectToServer', () => {
+  let manager: TestServerManager;
+
+  let promise: Promise<ConnectionState | null>;
+  let resolve: (value: ConnectionState | null) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = createServerManager();
+
+    ({ promise, resolve } = withResolvers<ConnectionState | null>());
+
+    manager._doConnectToServer = vi.fn().mockReturnValue(promise);
+  });
+
+  it('throws when the server is not found', async () => {
+    await expect(manager.connectToServer(serverUrl)).rejects.toThrow(
+      `Server with URL '${serverUrl}' not found.`
+    );
+  });
+
+  it('returns the existing connection for an already-connected DHC server', async () => {
+    manager._serverMap.set(dhcServer1.url, dhcServer1);
+    manager._connectionMap.set(serverUrl, cn1);
+
+    const result = await manager.connectToServer(serverUrl);
+
+    expect(result).toBe(cn1);
+    expect(manager._doConnectToServer).not.toHaveBeenCalled();
+  });
+
+  it('only connects once when called concurrently for the same DHC server', async () => {
+    manager._serverMap.set(dhcServer0.url, dhcServer0);
+
+    const first = manager.connectToServer(serverUrl);
+    const second = manager.connectToServer(serverUrl);
+
+    // The in-progress connection is reused rather than starting a new one.
+    expect(manager._doConnectToServer).toHaveBeenCalledTimes(1);
+
+    resolve(cn1);
+
+    expect(await first).toBe(cn1);
+    expect(await second).toBe(cn1);
+  });
+
+  it('clears the pending connection once it resolves so later calls reconnect', async () => {
+    manager._serverMap.set(dhcServer0.url, dhcServer0);
+
+    manager._doConnectToServer.mockResolvedValue(cn1);
+    const first = manager.connectToServer(serverUrl);
+    expect(manager._pendingConnectionMap.has(serverUrl)).toBe(true);
+    expect(await first).toBe(cn1);
+
+    expect(manager._pendingConnectionMap.has(serverUrl)).toBe(false);
+
+    // A subsequent connect attempt is not blocked by the resolved pending entry.
+    manager._doConnectToServer.mockResolvedValue(cn2);
+    const second = manager.connectToServer(serverUrl);
+    expect(await second).toBe(cn2);
+
+    expect(manager._doConnectToServer).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not track pending connections for DHE servers', async () => {
+    manager._serverMap.set(dheServer0.url, dheServer0);
+
+    void manager.connectToServer(serverUrl);
+    void manager.connectToServer(serverUrl);
+
+    // DHE supports multiple connections, so concurrent calls each start one.
+    expect(manager._doConnectToServer).toHaveBeenCalledTimes(2);
+    expect(manager._pendingConnectionMap.has(serverUrl)).toBe(false);
+  });
+});

--- a/src/services/ServerManager.ts
+++ b/src/services/ServerManager.ts
@@ -52,6 +52,7 @@ export class ServerManager implements IServerManager {
   ) {
     this._configService = configService;
     this._connectionMap = new URLMap<ConnectionState>();
+    this._pendingConnectionMap = new URLMap<Promise<ConnectionState | null>>();
     this._coreClientCache = coreClientCache;
     this._dhcServiceFactory = dhcServiceFactory;
     this._dheClientCache = dheClientCache;
@@ -70,6 +71,9 @@ export class ServerManager implements IServerManager {
 
   private readonly _configService: IConfigService;
   private readonly _connectionMap: URLMap<ConnectionState>;
+  private readonly _pendingConnectionMap: URLMap<
+    Promise<ConnectionState | null>
+  >;
   private readonly _coreClientCache: URLMap<CoreAuthenticatedClient>;
   private readonly _dhcServiceFactory: IDhcServiceFactory;
   private readonly _dheClientCache: URLMap<DheAuthenticatedClientWrapper>;
@@ -115,6 +119,7 @@ export class ServerManager implements IServerManager {
 
     await Promise.all([
       this._connectionMap.dispose(),
+      this._pendingConnectionMap.dispose(),
       this._serverMap.dispose(),
       this._uriConnectionsMap.dispose(),
       this._workerURLToServerURLMap.dispose(),
@@ -200,17 +205,51 @@ export class ServerManager implements IServerManager {
     const serverState = this._serverMap.get(serverUrl);
 
     if (serverState == null) {
-      return null;
+      throw new Error(`Server with URL '${serverUrl}' not found.`);
     }
 
-    // DHE supports multiple connections, but DHC does not.
-    if (
-      !this._dheServiceCache.has(serverUrl) &&
-      serverState.connectionCount > 0
-    ) {
-      logger.info('Already connected to server:', serverUrl);
-      return null;
+    // We only support 1 connection for DHC servers in the extension
+    if (serverState.type === 'DHC' && serverState.connectionCount > 0) {
+      logger.info('Already connected to server:', serverUrl.href);
+      return this._connectionMap.getOrThrow(serverUrl);
     }
+
+    if (this._pendingConnectionMap.has(serverUrl)) {
+      logger.debug('Connection already in progress:', serverUrl.href);
+      return this._pendingConnectionMap.getOrThrow(serverUrl);
+    }
+
+    const connectionPromise = this._doConnectToServer(
+      serverState,
+      workerConsoleType,
+      operateAsAnotherUser
+    );
+
+    // We only support 1 connection for DHC servers in the extension, but the
+    // count doesn't get updated until the connection is established, so we need
+    // to mark pending connections to prevent multiple simultaneous connection
+    // attempts to the same DHC server.
+    if (serverState.type === 'DHC') {
+      this._pendingConnectionMap.set(
+        serverUrl,
+        connectionPromise.then(result => {
+          this._pendingConnectionMap.delete(serverUrl);
+          return result;
+        })
+      );
+    }
+
+    return connectionPromise;
+  };
+
+  private _doConnectToServer = async (
+    serverState: ServerState,
+    workerConsoleType?: ConsoleType,
+    operateAsAnotherUser: boolean = false
+  ): Promise<ConnectionState | null> => {
+    let serverUrl = serverState.url;
+
+    logger.debug('Connecting to server:', serverUrl.href);
 
     let tagId: UniqueID | undefined;
 

--- a/src/types/commonTypes.d.ts
+++ b/src/types/commonTypes.d.ts
@@ -263,3 +263,7 @@ export interface SerializedPoint {
 }
 
 export type SerializedRange = [start: SerializedPoint, end: SerializedPoint];
+
+export type PublicOf<T> = {
+  [K in keyof T]: T[K];
+};


### PR DESCRIPTION
DH-22840: Fixed a race condition where clicking a community server node multiple times could result in connection count > 1

### Testing
- Configure a community server
- While disconnected from the server, click the server node multiple times quickly. Should only see (1) connection and `Output → Deephaven Debug` panel should show a message like `[ServerManager] INFO: Already connected to server: http://localhost:10000/`